### PR TITLE
chore: add codev forge + VS Code extension config

### DIFF
--- a/.codev/config.json
+++ b/.codev/config.json
@@ -18,5 +18,9 @@
         "skip": true
       }
     }
+  },
+  "forge": {
+    "provider": "linear",
+    "linear-team": "ENG"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ af-config.json
 
 # Claude Code (machine-local settings)
 .claude/
+
+# Codev VS Code extension settings (shared)
+!.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,5 @@ af-config.json
 .claude/
 
 # Codev VS Code extension settings (shared)
+!.vscode/
 !.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "codev.autoStartTower": true,
+  "codev.autoConnect": true,
+  "codev.autoOpenBuilderTerminal": "auto",
+  "codev.terminalPosition": "panel"
+}


### PR DESCRIPTION
## Summary
- Adds `forge.provider: "linear"` + `forge.linear-team: "ENG"` to `.codev/config.json`
- Adds codev VS Code extension settings to `.vscode/settings.json`
- Updates `.gitignore` to allow `.vscode/settings.json` (if previously ignored)

Part of the MachineWisdom VS Code-first workflow migration.

## Test plan
- [ ] `porch status` still works (forge config is forward-compatible; Linear provider ships separately)
- [ ] VS Code opens workspace without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)