### PR TITLE
fix: relax service_tier validation for OpenRouter responses

### DIFF
--- a/src/fava_trails/llm/client.py
+++ b/src/fava_trails/llm/client.py
@@ -15,6 +15,16 @@ from .registry import get_registry
 # Enable unified exception hierarchy across all providers
 os.environ.setdefault("ANY_LLM_UNIFIED_EXCEPTIONS", "1")
 
+# Relax service_tier validation. OpenRouter may return values outside the
+# OpenAI SDK Literal set, e.g. "standard", and any-llm revalidates the response
+# against this model before returning it.
+from any_llm.types.completion import ChatCompletion as _ChatCompletion
+
+_service_tier = _ChatCompletion.model_fields.get("service_tier")
+if _service_tier is not None:
+    _service_tier.annotation = str | None
+    _ChatCompletion.model_rebuild(force=True)
+
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from any_llm.exceptions import AuthenticationError, RateLimitError
+from any_llm.types.completion import ChatCompletion
 
 from fava_trails.llm.client import LLMClient, LLMError, LLMResponse
 
@@ -165,3 +166,23 @@ async def test_api_key_passed_to_acompletion(client):
     call_kwargs = mock_acompletion.call_args.kwargs
     assert call_kwargs["api_key"] == "or-key"
     assert call_kwargs["provider"] == "openrouter"
+
+
+def test_chatcompletion_accepts_nonstandard_service_tier():
+    """Importing fava_trails.llm.client patches ChatCompletion to accept any service_tier string."""
+    data = {
+        "id": "gen-test",
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+            }
+        ],
+        "created": 1000000,
+        "model": "google/gemini-2.5-flash",
+        "object": "chat.completion",
+        "service_tier": "standard",
+    }
+    obj = ChatCompletion.model_validate(data)
+    assert obj.service_tier == "standard"


### PR DESCRIPTION
## Summary

- Monkey-patch `ChatCompletion.service_tier` to accept `str | None` at module load, fixing a Pydantic `ValidationError` when OpenRouter returns `service_tier: "standard"` (outside the OpenAI SDK's strict Literal set)
- `any-llm-sdk` inherits the strict type and revalidates responses in `_convert_chat_completion`, so fava-trails cannot recover the already-paid response from a wrapper
- Adds a regression test that validates `ChatCompletion` accepts non-standard `service_tier` values after the patch

## Context

Trust gate `propose_truth` consistently errors on thoughts (e.g. `01KQVCSTJ6CKM8H2YEZFFBTW70`) with:
```
Failed to parse reviewer response after retry: 1 validation error for ChatCompletion
service_tier
  Input should be 'auto', 'default', 'flex', 'scale' or 'priority'
  [input_value='standard', input_type=str]
```

## Test plan

- [x] `test_chatcompletion_accepts_nonstandard_service_tier` — verifies the patch works
- [x] Full suite: 619 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)