### PR TITLE
chore: release v0.5.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fava-trails"
-version = "0.5.5"
+version = "0.5.6"
 description = "FAVA Trails 🫛👣 — Federated Agents Versioned Audit Trail. VCS-backed memory for AI agents via MCP."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "fava-trails"
-version = "0.5.4"
+version = "0.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "any-llm-sdk" },


### PR DESCRIPTION
## Summary
- Bump version to 0.5.6 to release the OpenRouter `service_tier` validation fix from PR #44
- Patch release — no API changes

## What's in this release
- **Fix**: `service_tier` Pydantic validation error when OpenRouter returns non-OpenAI values (e.g., `"standard"`). Trust gate `propose_truth` calls were failing consistently. (#44)

## Test plan
- [x] `uv run pytest` passes locally
- [ ] Release workflow publishes to PyPI on tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)