### PR TITLE
chore: add codev worktree config

### DIFF
--- a/.codev/config.json
+++ b/.codev/config.json
@@ -22,5 +22,17 @@
   "forge": {
     "provider": "linear",
     "linear-team": "ENG"
+  },
+  "worktree": {
+    "symlinks": [
+      ".env.local",
+      ".env.development",
+      ".env.development.local",
+      "apps/*/.env",
+      "apps/*/.env.local",
+      "packages/*/.env",
+      "packages/*/.env.local"
+    ],
+    "postSpawn": []
   }
 }


### PR DESCRIPTION
## Summary
- Add env-symlink-only `worktree` config to `.codev/config.json`.
- Leave `postSpawn` empty and omit `devCommand` so repo-specific install/dev commands are not guessed.

## Validation
- `jq empty .codev/config.json`
- Verified `worktree.symlinks` matches the MachineWisdom default list, `worktree.postSpawn` is empty, and no `worktree.devCommand` is set.