### PR TITLE
fix: guard fava trail sync against dirty data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,8 @@ Discard current reasoning line. Abandons the current JJ change.
 ### `sync`
 
 Sync with shared truth. Fetches from remote and rebases. Aborts automatically on conflict.
+Also blocks (status `blocked`) before fetching if the data repo has a dirty working copy or
+tracked paths that collide by case — repair or commit the offending paths, then retry.
 
 ### `conflicts`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to FAVA Trails are documented here.
 
+## [0.5.7] — 2026-06-30
+
+### Fixed
+- **Sync guarded against dirty data**: `sync` now blocks (instead of silently proceeding) when the data repo has a dirty working copy or tracked paths that collide by case. `commit_files` fails fast on unexpected dirty paths and executable-bit churn on data files, and operation-created paths (e.g. config files, drafts being removed on promotion) are now correctly included in their commits.
+
+---
+
 ## [0.4.9] — 2026-02-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fava-trails"
-version = "0.5.6"
+version = "0.5.7"
 description = "FAVA Trails 🫛👣 — Federated Agents Versioned Audit Trail. VCS-backed memory for AI agents via MCP."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/fava_trails/tools/navigation.py
+++ b/src/fava_trails/tools/navigation.py
@@ -237,6 +237,24 @@ async def handle_rollback(trail, arguments: dict) -> dict[str, Any]:
 async def handle_sync(trail, arguments: dict) -> dict[str, Any]:
     """Sync with shared truth. Aborts on conflict."""
     result = await trail.sync()
+    if getattr(result, "has_case_collisions", False):
+        return {
+            "status": "blocked",
+            "message": (
+                f"Sync blocked: {result.summary} "
+                "Repair or remove the colliding tracked paths before retrying."
+            ),
+            "case_collisions": result.case_collisions,
+        }
+    if getattr(result, "has_dirty_working_copy", False):
+        return {
+            "status": "blocked",
+            "message": (
+                f"Sync blocked: dirty working copy. {result.summary} "
+                "The sync tool fetches/rebases; it does not commit existing local files."
+            ),
+            "dirty_paths": result.dirty_paths,
+        }
     if result.has_conflicts:
         return {
             "status": "conflict",
@@ -245,6 +263,11 @@ async def handle_sync(trail, arguments: dict) -> dict[str, Any]:
                 {"file": c.file_path, "description": c.description}
                 for c in result.conflict_details
             ],
+        }
+    if not result.success:
+        return {
+            "status": "error",
+            "message": f"Sync failed: {result.summary}",
         }
     return {
         "status": "ok",

--- a/src/fava_trails/trail.py
+++ b/src/fava_trails/trail.py
@@ -186,9 +186,11 @@ class TrailManager:
             save_trail_config(self.trail_name, self.config)
 
             # Initial commit with directory structure
+            commit_paths = [self.trail_path / ".fava-trails.yaml"]
+            commit_paths.extend(self.trail_path.rglob(".gitkeep"))
             await self.vcs.commit_files(
                 "Initialize trail with namespace directories",
-                [str(p) for p in self.trail_path.rglob(".gitkeep")],
+                [str(p) for p in commit_paths],
             )
 
             return result
@@ -643,7 +645,7 @@ class TrailManager:
 
             await self.vcs.commit_files(
                 f"Promote {thought_id[:8]} from drafts/ to {target_ns}/ [{record.frontmatter.source_type.value}]",
-                [str(target_path)],
+                [str(target_path), str(drafts_path)],
             )
 
         # after_propose hook — runs inline so feedback reaches the caller

--- a/src/fava_trails/vcs/base.py
+++ b/src/fava_trails/vcs/base.py
@@ -54,6 +54,10 @@ class RebaseResult:
 
     success: bool
     has_conflicts: bool = False
+    has_dirty_working_copy: bool = False
+    dirty_paths: list[str] = field(default_factory=list)
+    has_case_collisions: bool = False
+    case_collisions: list[list[str]] = field(default_factory=list)
     pre_rebase_op_id: str = ""
     conflict_details: list[VcsConflict] = field(default_factory=list)
     summary: str = ""
@@ -88,7 +92,12 @@ class VcsBackend(ABC):
         ...
 
     @abstractmethod
-    async def commit_files(self, message: str, paths: list[str]) -> VcsChange:
+    async def commit_files(
+        self,
+        message: str,
+        paths: list[str],
+        allowed_prefixes: list[str] | None = None,
+    ) -> VcsChange:
         """Commit specific files with a message. Asserts no cross-trail pollution."""
         ...
 

--- a/src/fava_trails/vcs/jj_backend.py
+++ b/src/fava_trails/vcs/jj_backend.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import shutil
 from pathlib import Path
 
@@ -87,6 +88,26 @@ class JjBackend(VcsBackend):
             )
         return stdout, stderr
 
+    async def _run_git(self, *args: str, check: bool = True) -> tuple[str, str]:
+        """Run a git command at repo_root. Internal helper for colocated safety checks."""
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            *args,
+            cwd=self.repo_root,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_bytes, stderr_bytes = await proc.communicate()
+        stdout = stdout_bytes.decode("utf-8", errors="replace").strip()
+        stderr = stderr_bytes.decode("utf-8", errors="replace").strip()
+        if check and proc.returncode != 0:
+            raise JjError(
+                f"git {args[0]} failed (rc={proc.returncode}): {stderr or stdout}",
+                returncode=proc.returncode,
+                stderr=stderr,
+            )
+        return stdout, stderr
+
     # --- Semantic translation helpers ---
 
     @staticmethod
@@ -134,6 +155,70 @@ class JjBackend(VcsBackend):
         except ValueError:
             # trail_path not under repo_root — return as-is (shouldn't happen)
             return str(self.trail_path)
+
+    def _repo_rel_path(self, path: str | Path) -> str:
+        """Normalize an absolute or relative path to a repo-relative POSIX path."""
+        p = Path(path)
+        if p.is_absolute():
+            try:
+                return p.relative_to(self.repo_root).as_posix()
+            except ValueError:
+                return p.as_posix()
+        return p.as_posix()
+
+    async def _dirty_paths(self) -> list[str]:
+        """Return current JJ dirty paths as repo-relative paths."""
+        stdout, _ = await self._run("diff", "--name-only", check=False)
+        return sorted({line.strip() for line in stdout.splitlines() if line.strip()})
+
+    async def _tracked_case_collisions(self) -> list[list[str]]:
+        """Find tracked paths that differ only by case."""
+        stdout, _ = await self._run_git("ls-files", "-z")
+        buckets: dict[str, list[str]] = {}
+        for path in stdout.split("\0"):
+            if not path:
+                continue
+            buckets.setdefault(path.lower(), []).append(path)
+        return [sorted(paths) for paths in buckets.values() if len(paths) > 1]
+
+    async def _assert_no_case_collisions(self) -> None:
+        collisions = await self._tracked_case_collisions()
+        if collisions:
+            preview = "; ".join(" <-> ".join(paths[:3]) for paths in collisions[:5])
+            raise RuntimeError(
+                "Tracked path case collision detected. "
+                "Resolve paths that differ only by case before writing: "
+                f"{preview}"
+            )
+
+    @staticmethod
+    def _is_protected_data_file(path: str) -> bool:
+        return path.endswith(".md") or path.endswith(".yaml") or path.endswith(".gitkeep")
+
+    async def _executable_bit_changes(self, paths: list[str]) -> list[str]:
+        """Return protected data files whose dirty diff changes executable mode."""
+        if not paths:
+            return []
+
+        stdout, _ = await self._run("diff", "--git", *paths, check=False)
+        bad: list[str] = []
+        current_path: str | None = None
+        mode_change_in_block = False
+        for line in stdout.splitlines():
+            if line.startswith("diff --git "):
+                if current_path and mode_change_in_block and self._is_protected_data_file(current_path):
+                    bad.append(current_path)
+                current_path = None
+                mode_change_in_block = False
+                match = re.match(r"diff --git a/(.*?) b/(.*)", line)
+                if match:
+                    current_path = match.group(2)
+                continue
+            if line.startswith("old mode ") or line.startswith("new mode "):
+                mode_change_in_block = True
+        if current_path and mode_change_in_block and self._is_protected_data_file(current_path):
+            bad.append(current_path)
+        return bad
 
     # Log template: change_id, commit_id, description, author email, timestamp, empty flag
     LOG_TEMPLATE = (
@@ -199,6 +284,7 @@ class JjBackend(VcsBackend):
         return f"Trail directory created at {self.trail_path}"
 
     async def new_change(self, description: str = "") -> VcsChange:
+        await self._assert_no_case_collisions()
         effective = description.strip() or "(new change)"
         args = ["new", "-m", effective]
         stdout, _ = await self._run(*args)
@@ -223,9 +309,10 @@ class JjBackend(VcsBackend):
         fall under the expected trail prefix (or allowed_prefixes for cross-scope ops).
         Then describes and creates new change.
         """
-        # Get dirty files in the working copy
-        stdout, _ = await self._run("diff", "--name-only", check=False)
-        dirty_paths = [line.strip() for line in stdout.splitlines() if line.strip()]
+        await self._assert_no_case_collisions()
+
+        dirty_paths = await self._dirty_paths()
+        expected_paths = {self._repo_rel_path(path) for path in paths}
 
         # Cross-trail assertion: all dirty files must be under allowed prefixes
         if dirty_paths:
@@ -236,6 +323,21 @@ class JjBackend(VcsBackend):
                         f"Cross-trail pollution detected: '{dp}' is outside allowed prefixes {prefixes}. "
                         "Aborting commit to prevent data corruption."
                     )
+
+            unexpected_paths = sorted(set(dirty_paths) - expected_paths)
+            if unexpected_paths:
+                raise RuntimeError(
+                    "Unexpected dirty paths detected: "
+                    f"{unexpected_paths}. Expected only {sorted(expected_paths)}. "
+                    "Aborting commit to prevent unrelated local state from hitchhiking."
+                )
+
+            executable_changes = await self._executable_bit_changes(dirty_paths)
+            if executable_changes:
+                raise RuntimeError(
+                    "Executable bit change detected in data files: "
+                    f"{executable_changes}. Aborting commit to prevent unsafe mode churn."
+                )
 
         # Proceed with commit — always describe to prevent phantom empty commits
         # that block jj git push (JJ refuses to push undescribed commits)
@@ -465,6 +567,29 @@ class JjBackend(VcsBackend):
         return None
 
     async def fetch_and_rebase(self) -> RebaseResult:
+        case_collisions = await self._tracked_case_collisions()
+        if case_collisions:
+            return RebaseResult(
+                success=False,
+                has_case_collisions=True,
+                case_collisions=case_collisions,
+                summary=(
+                    "Tracked paths differ only by case. Resolve case collisions before syncing."
+                ),
+            )
+
+        dirty_paths = await self._dirty_paths()
+        if dirty_paths:
+            return RebaseResult(
+                success=False,
+                has_dirty_working_copy=True,
+                dirty_paths=dirty_paths,
+                summary=(
+                    "Local working copy has uncommitted changes. "
+                    "Commit, recover, or discard them before syncing."
+                ),
+            )
+
         # Record pre-rebase op for rollback
         ops = await self.op_log(limit=1)
         pre_op = ops[0].op_id if ops else ""

--- a/tests/test_jj_backend.py
+++ b/tests/test_jj_backend.py
@@ -203,6 +203,74 @@ async def test_commit_files_cross_trail_pollution_assertion(jj_backend):
 
 
 @pytest.mark.asyncio
+async def test_commit_files_refuses_unexpected_dirty_file_inside_trail(jj_backend):
+    """commit_files should only commit the operation's declared paths."""
+    expected = jj_backend.trail_path / "expected.md"
+    unexpected = jj_backend.trail_path / "unexpected.md"
+    expected.write_text("# Expected")
+    unexpected.write_text("# Unexpected ambient dirt")
+
+    with pytest.raises(RuntimeError, match="Unexpected dirty paths"):
+        await jj_backend.commit_files("should fail", [str(expected)])
+
+
+@pytest.mark.asyncio
+async def test_commit_files_rejects_executable_bit_change_for_data_files(jj_backend):
+    """Mode-only executable changes to Markdown/YAML/gitkeep files are unsafe."""
+    test_file = jj_backend.trail_path / "mode-test.md"
+    test_file.write_text("# Mode test")
+    await jj_backend.commit_files("add mode test", [str(test_file)])
+
+    test_file.chmod(0o755)
+
+    with pytest.raises(RuntimeError, match="Executable bit change"):
+        await jj_backend.commit_files("should fail", [str(test_file)])
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_rebase_blocks_dirty_working_copy(jj_backend):
+    """sync should not report success while local files are uncommitted."""
+    dirty = jj_backend.trail_path / "dirty.md"
+    dirty.write_text("# Dirty local state")
+
+    result = await jj_backend.fetch_and_rebase()
+
+    assert result.success is False
+    assert result.has_dirty_working_copy is True
+    assert "trails/test-jj/dirty.md" in result.dirty_paths
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_rebase_blocks_case_colliding_tracked_paths(jj_backend):
+    """sync should block when tracked paths differ only by case."""
+    blob = subprocess.run(
+        ["git", "hash-object", "-w", "--stdin"],
+        cwd=str(jj_backend.repo_root),
+        input=b"",
+        check=True,
+        capture_output=True,
+    ).stdout.decode().strip()
+    subprocess.run(
+        ["git", "update-index", "--add", "--cacheinfo", f"100644,{blob},trails/CaseScope/thoughts/drafts/.gitkeep"],
+        cwd=str(jj_backend.repo_root),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "update-index", "--add", "--cacheinfo", f"100644,{blob},trails/casescope/thoughts/drafts/.gitkeep"],
+        cwd=str(jj_backend.repo_root),
+        check=True,
+        capture_output=True,
+    )
+
+    result = await jj_backend.fetch_and_rebase()
+
+    assert result.success is False
+    assert result.has_case_collisions is True
+    assert result.case_collisions
+
+
+@pytest.mark.asyncio
 async def test_gc(jj_backend):
     """GC should complete without error."""
     result = await jj_backend.gc()

--- a/tests/test_navigation_tools.py
+++ b/tests/test_navigation_tools.py
@@ -1,0 +1,60 @@
+"""Tests for navigation/lifecycle tool handlers."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from fava_trails.tools.navigation import handle_sync
+
+
+class _SyncTrail:
+    def __init__(self, result):
+        self._result = result
+
+    async def sync(self):
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_handle_sync_blocks_dirty_working_copy():
+    """sync should tell agents local files remain dirty instead of saying ok."""
+    result = SimpleNamespace(
+        success=False,
+        has_conflicts=False,
+        has_dirty_working_copy=True,
+        dirty_paths=["trails/mwai/eng/WisdomLoop/thoughts/drafts/dirty.md"],
+        has_case_collisions=False,
+        case_collisions=[],
+        summary="Local working copy has uncommitted changes",
+    )
+
+    payload = await handle_sync(_SyncTrail(result), {})
+
+    assert payload["status"] == "blocked"
+    assert "dirty" in payload["message"].lower()
+    assert payload["dirty_paths"] == result.dirty_paths
+
+
+@pytest.mark.asyncio
+async def test_handle_sync_blocks_case_collisions():
+    """sync should surface tracked path case collisions as a repair blocker."""
+    result = SimpleNamespace(
+        success=False,
+        has_conflicts=False,
+        has_dirty_working_copy=False,
+        dirty_paths=[],
+        has_case_collisions=True,
+        case_collisions=[
+            [
+                "trails/mwai/eng/WisdomLoop/.fava-trails.yaml",
+                "trails/mwai/eng/wisdomloop/.fava-trails.yaml",
+            ]
+        ],
+        summary="Tracked paths differ only by case",
+    )
+
+    payload = await handle_sync(_SyncTrail(result), {})
+
+    assert payload["status"] == "blocked"
+    assert "case" in payload["message"].lower()
+    assert payload["case_collisions"] == result.case_collisions

--- a/uv.lock
+++ b/uv.lock
@@ -477,7 +477,7 @@ wheels = [
 
 [[package]]
 name = "fava-trails"
-version = "0.5.6"
+version = "0.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "any-llm-sdk" },


### PR DESCRIPTION
## Summary
- block sync when the data repo has dirty local files or tracked case-colliding paths
- make writes fail fast on case collisions, unrelated dirty paths, and executable-bit churn for data files
- preserve operation-created paths in init/promote commits and add regression coverage for navigation sync responses

## Data repo repair
- pushed fava-trails-data commit 72f0b586882483ca54e3951d7c1245982dd91a44 migrating mwai/eng/wisdomloop into mwai/eng/WisdomLoop
- removed the lowercase tracked tree after writing superseding copies and a migration summary

## Test Plan
- uv sync --frozen
- uv run pytest -v