### PR TITLE
feat: generate minimal FAVA reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ venv/
 .coverage
 htmlcov/
 
+# Agent review artifacts
+.wise-agents/
+
 # IDE
 .vscode/
 .idea/
@@ -26,6 +29,9 @@ Thumbs.db
 # Environment
 .env
 .secrets
+
+# Node package manager artifacts from generated readers
+package-lock.json
 
 # Codev (transient state — protocols and resources are committed)
 .agent-farm/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to FAVA Trails are documented here.
 
+## Unreleased
+
+### Added
+- `fava-trails rich-view generate --scope <path> --out <dir>`: generates a minimal plain-Astro static reader from FAVA trail thought records (ULID routes, derived titles, snapshot metadata). Implements #52.
+
 ## [0.5.7] — 2026-06-30
 
 ### Fixed

--- a/src/fava_trails/cli.py
+++ b/src/fava_trails/cli.py
@@ -781,6 +781,32 @@ def cmd_get(args: argparse.Namespace) -> int:
     return 1
 
 
+# ─── Rich Views reader generation ─────────────────────────────────────────────
+
+
+def cmd_rich_view_generate(args: argparse.Namespace) -> int:
+    """Generate a minimal plain-Astro reader from FAVA source records."""
+    try:
+        trails_dir = Path(args.trails_dir).expanduser().resolve() if args.trails_dir else get_trails_dir()
+        output_dir = Path(args.out).expanduser().resolve()
+        from .rich_views import generate_reader
+
+        result = generate_reader(
+            trails_dir=trails_dir,
+            scope=args.scope,
+            output_dir=output_dir,
+        )
+    except (OSError, ValueError, yaml.YAMLError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Generated FAVA reader for {result.scope} at {result.output_dir}")
+    print(f"  Thoughts: {result.thought_count}")
+    print(f"  Generated at: {result.generated_at.isoformat()}")
+    print("  Build: cd <output-dir> && npm install && npm run build")
+    return 0
+
+
 # ─── Protocol setup commands ──────────────────────────────────────────────────
 
 
@@ -1287,6 +1313,25 @@ def build_parser() -> argparse.ArgumentParser:
         help="Include YAML frontmatter in output",
     )
     p_get.set_defaults(func=cmd_get)
+
+    # rich-view
+    p_rich_view = subparsers.add_parser("rich-view", help="Generate minimal FAVA Rich Views readers")
+    rich_view_sub = p_rich_view.add_subparsers(dest="rich_view_command", metavar="<subcommand>")
+
+    p_rich_view_generate = rich_view_sub.add_parser(
+        "generate",
+        help="Generate a minimal plain-Astro FAVA reader from source records",
+    )
+    p_rich_view_generate.add_argument("--scope", required=True, help="Input FAVA scope path")
+    p_rich_view_generate.add_argument("--out", required=True, help="Output directory for the generated reader")
+    p_rich_view_generate.add_argument(
+        "--trails-dir",
+        default=None,
+        help="Directory containing FAVA trails (default: configured data repo trails directory)",
+    )
+    p_rich_view_generate.set_defaults(func=cmd_rich_view_generate)
+
+    p_rich_view.set_defaults(func=lambda args: (p_rich_view.print_help(), 0)[1])
 
     # integrate
     p_integrate = subparsers.add_parser("integrate", help="Set up integrations with external tools")

--- a/src/fava_trails/rich_views.py
+++ b/src/fava_trails/rich_views.py
@@ -15,6 +15,7 @@ from .config import sanitize_scope_path
 from .models import ThoughtRecord
 
 _HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$", re.MULTILINE)
+_SAFE_THOUGHT_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 _WHITESPACE_RE = re.compile(r"\s+")
 
 
@@ -86,6 +87,7 @@ def _load_reader_thoughts(trails_dir: Path, scope: str) -> list[ReaderThought]:
         raw_frontmatter = _read_raw_frontmatter(raw_text)
         record = ThoughtRecord.from_markdown(raw_text)
         thought_id = record.thought_id
+        _validate_reader_thought_id(thought_id, path)
         if thought_id in seen:
             raise ValueError(f"Duplicate thought_id {thought_id} in {path} and {seen[thought_id]}")
         seen[thought_id] = path
@@ -113,6 +115,11 @@ def _load_reader_thoughts(trails_dir: Path, scope: str) -> list[ReaderThought]:
         )
 
     return sorted(thoughts, key=lambda thought: thought.thought_id)
+
+
+def _validate_reader_thought_id(thought_id: str, source_path: Path) -> None:
+    if not _SAFE_THOUGHT_ID_RE.fullmatch(thought_id):
+        raise ValueError(f"Unsafe thought_id {thought_id!r} in {source_path}")
 
 
 def _read_raw_frontmatter(text: str) -> dict[str, Any]:

--- a/src/fava_trails/rich_views.py
+++ b/src/fava_trails/rich_views.py
@@ -1,0 +1,483 @@
+"""Minimal FAVA Rich Views reader generation."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .config import sanitize_scope_path
+from .models import ThoughtRecord
+
+_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$", re.MULTILINE)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+@dataclass(frozen=True)
+class ReaderThought:
+    """View model for a generated FAVA reader thought page."""
+
+    thought_id: str
+    title: str
+    content: str
+    namespace: str
+    source_path: str
+    source_type: str
+    validation_status: str
+    agent_id: str
+    confidence: float
+    tags: tuple[str, ...]
+    route: str
+
+
+@dataclass(frozen=True)
+class GenerationResult:
+    """Summary returned after reader generation."""
+
+    scope: str
+    output_dir: Path
+    generated_at: datetime
+    thought_count: int
+    routes: tuple[str, ...]
+
+
+def generate_reader(
+    *,
+    trails_dir: Path | str,
+    scope: str,
+    output_dir: Path | str,
+    generated_at: datetime | None = None,
+) -> GenerationResult:
+    """Generate a minimal plain-Astro reader from FAVA source thought records."""
+
+    safe_scope = sanitize_scope_path(scope)
+    source_root = Path(trails_dir)
+    destination = Path(output_dir)
+    timestamp = generated_at or datetime.now(UTC)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=UTC)
+
+    thoughts = _load_reader_thoughts(source_root, safe_scope)
+    _write_reader(destination, safe_scope, timestamp, thoughts)
+
+    return GenerationResult(
+        scope=safe_scope,
+        output_dir=destination,
+        generated_at=timestamp,
+        thought_count=len(thoughts),
+        routes=tuple(thought.route for thought in thoughts),
+    )
+
+
+def _load_reader_thoughts(trails_dir: Path, scope: str) -> list[ReaderThought]:
+    thoughts_dir = trails_dir / scope / "thoughts"
+    if not thoughts_dir.is_dir():
+        raise ValueError(f"No FAVA thoughts found for scope {scope!r} at {thoughts_dir}")
+
+    seen: dict[str, Path] = {}
+    thoughts: list[ReaderThought] = []
+    for path in sorted(p for p in thoughts_dir.rglob("*.md") if p.name != ".gitkeep"):
+        raw_text = path.read_text(encoding="utf-8")
+        raw_frontmatter = _read_raw_frontmatter(raw_text)
+        record = ThoughtRecord.from_markdown(raw_text)
+        thought_id = record.thought_id
+        if thought_id in seen:
+            raise ValueError(f"Duplicate thought_id {thought_id} in {path} and {seen[thought_id]}")
+        seen[thought_id] = path
+
+        try:
+            namespace = str(path.parent.relative_to(thoughts_dir))
+        except ValueError:
+            namespace = path.parent.name
+        source_path = str(path.relative_to(trails_dir))
+        fm = record.frontmatter
+        thoughts.append(
+            ReaderThought(
+                thought_id=thought_id,
+                title=_derive_title(raw_frontmatter, record.content),
+                content=record.content,
+                namespace=namespace,
+                source_path=source_path,
+                source_type=fm.source_type.value,
+                validation_status=fm.validation_status.value,
+                agent_id=fm.agent_id,
+                confidence=fm.confidence,
+                tags=tuple(fm.metadata.tags),
+                route=f"/thoughts/{thought_id}/",
+            )
+        )
+
+    return sorted(thoughts, key=lambda thought: thought.thought_id)
+
+
+def _read_raw_frontmatter(text: str) -> dict[str, Any]:
+    if not text.startswith("---"):
+        return {}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    data = yaml.safe_load(parts[1]) or {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def _derive_title(frontmatter: dict[str, Any], content: str) -> str:
+    explicit_title = frontmatter.get("title")
+    if isinstance(explicit_title, str) and explicit_title.strip():
+        return _normalize_title(explicit_title)
+
+    heading = _HEADING_RE.search(content)
+    if heading:
+        return _normalize_title(heading.group(1))
+
+    for line in content.splitlines():
+        candidate = _normalize_title(line)
+        if candidate:
+            return _truncate_title(candidate)
+
+    return "Untitled thought"
+
+
+def _normalize_title(value: str) -> str:
+    return _WHITESPACE_RE.sub(" ", value.strip().strip("#").strip())
+
+
+def _truncate_title(value: str, max_length: int = 80) -> str:
+    if len(value) <= max_length:
+        return value
+    return value[: max_length - 1].rstrip() + "..."
+
+
+def _write_reader(output_dir: Path, scope: str, generated_at: datetime, thoughts: list[ReaderThought]) -> None:
+    generated_at_iso = generated_at.isoformat()
+    (output_dir / "src/pages/thoughts").mkdir(parents=True, exist_ok=True)
+    (output_dir / "src/data").mkdir(parents=True, exist_ok=True)
+    (output_dir / "src/layouts").mkdir(parents=True, exist_ok=True)
+
+    _write_package_json(output_dir)
+    _write_astro_config(output_dir)
+    _write_readme(output_dir, scope, generated_at_iso)
+    _write_generated_metadata(output_dir, scope, generated_at_iso, thoughts)
+    _write_index(output_dir, scope, generated_at_iso, thoughts)
+    _write_layout(output_dir)
+    for thought in thoughts:
+        _write_thought_page(output_dir, scope, generated_at_iso, thought)
+
+
+def _write_package_json(output_dir: Path) -> None:
+    package = {
+        "name": "fava-reader",
+        "private": True,
+        "type": "module",
+        "scripts": {
+            "dev": "astro dev",
+            "build": "astro build",
+            "preview": "astro preview",
+        },
+        "devDependencies": {
+            "astro": "latest",
+        },
+    }
+    (output_dir / "package.json").write_text(json.dumps(package, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_astro_config(output_dir: Path) -> None:
+    (output_dir / "astro.config.mjs").write_text(
+        "import { defineConfig } from 'astro/config';\n\n"
+        "export default defineConfig({\n"
+        "  output: 'static',\n"
+        "});\n",
+        encoding="utf-8",
+    )
+
+
+def _write_readme(output_dir: Path, scope: str, generated_at: str) -> None:
+    (output_dir / "README.md").write_text(
+        f"""# FAVA Reader
+
+This is a static snapshot generated from FAVA source records.
+It is not a live view. Regenerate it when the trail changes.
+
+- Input scope: {scope}
+- Generated at: {generated_at}
+
+## Build
+
+```bash
+npm install
+npm run build
+npm run preview
+```
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_generated_metadata(output_dir: Path, scope: str, generated_at: str, thoughts: list[ReaderThought]) -> None:
+    metadata = {
+        "inputScope": scope,
+        "generatedAt": generated_at,
+        "generator": "fava-trails rich-view generate",
+        "snapshotNotice": "Static snapshot; not a live view.",
+        "thoughtCount": len(thoughts),
+        "routes": [thought.route for thought in thoughts],
+    }
+    (output_dir / "src/data/generated.json").write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_index(output_dir: Path, scope: str, generated_at: str, thoughts: list[ReaderThought]) -> None:
+    thought_data = [
+        {
+            "thoughtId": thought.thought_id,
+            "title": thought.title,
+            "route": thought.route,
+            "namespace": thought.namespace,
+            "sourceType": thought.source_type,
+            "validationStatus": thought.validation_status,
+            "sourcePath": thought.source_path,
+        }
+        for thought in thoughts
+    ]
+    (output_dir / "src/pages/index.astro").write_text(
+        f"""---
+const thoughts = {json.dumps(thought_data, indent=2)};
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>FAVA Reader - {scope}</title>
+    <style>
+      :root {{
+        color: #161616;
+        background: #f7f7f4;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }}
+      body {{
+        margin: 0;
+      }}
+      main {{
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 32px 20px 48px;
+      }}
+      header {{
+        border-bottom: 1px solid #d8d8d0;
+        margin-bottom: 24px;
+        padding-bottom: 16px;
+      }}
+      h1 {{
+        font-size: 1.9rem;
+        margin: 0 0 12px;
+      }}
+      .meta {{
+        color: #555;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 18px;
+        font-size: 0.92rem;
+        margin: 0;
+      }}
+      .notice {{
+        background: #fff8d8;
+        border: 1px solid #e1ce75;
+        border-radius: 6px;
+        margin: 18px 0 0;
+        padding: 10px 12px;
+      }}
+      ul {{
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }}
+      li {{
+        background: #fff;
+        border: 1px solid #ddd;
+        border-radius: 6px;
+        margin-bottom: 10px;
+        padding: 14px 16px;
+      }}
+      a {{
+        color: #135d54;
+        font-weight: 650;
+      }}
+      code {{
+        font-size: 0.82rem;
+      }}
+      .row-meta {{
+        color: #666;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 14px;
+        margin-top: 8px;
+      }}
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>FAVA Reader</h1>
+        <p class="meta">
+          <span>Input scope: {scope}</span>
+          <span>Generated at: {generated_at}</span>
+          <span>{len(thoughts)} thoughts</span>
+        </p>
+        <p class="notice">Static snapshot generated from FAVA source records; this is not a live view.</p>
+      </header>
+      <ul>
+        {{thoughts.map((thought) => (
+          <li>
+            <a href={{thought.route}}>{{thought.title}}</a>
+            <div class="row-meta">
+              <code>{{thought.thoughtId}}</code>
+              <span>{{thought.namespace}}</span>
+              <span>{{thought.sourceType}}</span>
+              <span>{{thought.validationStatus}}</span>
+              <span>{{thought.sourcePath}}</span>
+            </div>
+          </li>
+        ))}}
+      </ul>
+    </main>
+  </body>
+</html>
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_layout(output_dir: Path) -> None:
+    (output_dir / "src/layouts/ThoughtLayout.astro").write_text(
+        """---
+const { frontmatter } = Astro.props;
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{frontmatter.title}</title>
+    <style>
+      :root {
+        color: #161616;
+        background: #f7f7f4;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      body {
+        margin: 0;
+      }
+      main {
+        max-width: 880px;
+        margin: 0 auto;
+        padding: 32px 20px 56px;
+      }
+      a {
+        color: #135d54;
+      }
+      header {
+        border-bottom: 1px solid #d8d8d0;
+        margin-bottom: 24px;
+        padding-bottom: 16px;
+      }
+      h1 {
+        font-size: 1.8rem;
+        margin: 0 0 12px;
+      }
+      dl {
+        display: grid;
+        gap: 8px 14px;
+        grid-template-columns: max-content 1fr;
+      }
+      dt {
+        color: #555;
+        font-weight: 650;
+      }
+      dd {
+        margin: 0;
+      }
+      code {
+        font-size: 0.85rem;
+      }
+      .notice {
+        background: #fff8d8;
+        border: 1px solid #e1ce75;
+        border-radius: 6px;
+        margin: 16px 0 0;
+        padding: 10px 12px;
+      }
+      article {
+        background: #fff;
+        border: 1px solid #ddd;
+        border-radius: 6px;
+        padding: 22px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p><a href="/">Back to reader index</a></p>
+      <header>
+        <h1>{frontmatter.title}</h1>
+        <dl>
+          <dt>Thought ID</dt>
+          <dd><code>{frontmatter.thoughtId}</code></dd>
+          <dt>Input scope</dt>
+          <dd>{frontmatter.inputScope}</dd>
+          <dt>Generated at</dt>
+          <dd>{frontmatter.generatedAt}</dd>
+          <dt>Namespace</dt>
+          <dd>{frontmatter.namespace}</dd>
+          <dt>Source type</dt>
+          <dd>{frontmatter.sourceType}</dd>
+          <dt>Validation</dt>
+          <dd>{frontmatter.validationStatus}</dd>
+          <dt>Source path</dt>
+          <dd><code>{frontmatter.sourcePath}</code></dd>
+        </dl>
+        <p class="notice">Static snapshot generated from FAVA source records; this is not a live view.</p>
+      </header>
+      <article>
+        <slot />
+      </article>
+    </main>
+  </body>
+</html>
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_thought_page(output_dir: Path, scope: str, generated_at: str, thought: ReaderThought) -> None:
+    frontmatter = [
+        "---",
+        'layout: "../../layouts/ThoughtLayout.astro"',
+        f"title: {_yaml_string(thought.title)}",
+        f"thoughtId: {_yaml_string(thought.thought_id)}",
+        f"inputScope: {_yaml_string(scope)}",
+        f"generatedAt: {_yaml_string(generated_at)}",
+        f"namespace: {_yaml_string(thought.namespace)}",
+        f"sourceType: {_yaml_string(thought.source_type)}",
+        f"validationStatus: {_yaml_string(thought.validation_status)}",
+        f"agentId: {_yaml_string(thought.agent_id)}",
+        f"confidence: {thought.confidence}",
+        f"sourcePath: {_yaml_string(thought.source_path)}",
+    ]
+    if thought.tags:
+        frontmatter.append("tags:")
+        frontmatter.extend(f"  - {_yaml_string(tag)}" for tag in thought.tags)
+    else:
+        frontmatter.append("tags: []")
+    frontmatter.append("---")
+    page = "\n".join(frontmatter) + "\n" + thought.content.rstrip() + "\n"
+    (output_dir / "src/pages/thoughts" / f"{thought.thought_id}.md").write_text(page, encoding="utf-8")
+
+
+def _yaml_string(value: str) -> str:
+    return json.dumps(value)

--- a/src/fava_trails/rich_views.py
+++ b/src/fava_trails/rich_views.py
@@ -110,7 +110,7 @@ def _load_reader_thoughts(trails_dir: Path, scope: str) -> list[ReaderThought]:
                 agent_id=fm.agent_id,
                 confidence=fm.confidence,
                 tags=tuple(fm.metadata.tags),
-                route=f"/thoughts/{thought_id}/",
+                route=f"/id/{thought_id}/",
             )
         )
 
@@ -163,7 +163,8 @@ def _truncate_title(value: str, max_length: int = 80) -> str:
 
 def _write_reader(output_dir: Path, scope: str, generated_at: datetime, thoughts: list[ReaderThought]) -> None:
     generated_at_iso = generated_at.isoformat()
-    (output_dir / "src/pages/thoughts").mkdir(parents=True, exist_ok=True)
+
+    (output_dir / "src/pages/id").mkdir(parents=True, exist_ok=True)
     (output_dir / "src/data").mkdir(parents=True, exist_ok=True)
     (output_dir / "src/layouts").mkdir(parents=True, exist_ok=True)
 
@@ -483,7 +484,7 @@ def _write_thought_page(output_dir: Path, scope: str, generated_at: str, thought
         frontmatter.append("tags: []")
     frontmatter.append("---")
     page = "\n".join(frontmatter) + "\n" + thought.content.rstrip() + "\n"
-    (output_dir / "src/pages/thoughts" / f"{thought.thought_id}.md").write_text(page, encoding="utf-8")
+    (output_dir / "src/pages/id" / f"{thought.thought_id}.md").write_text(page, encoding="utf-8")
 
 
 def _yaml_string(value: str) -> str:

--- a/src/fava_trails/rich_views.py
+++ b/src/fava_trails/rich_views.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -17,6 +18,8 @@ from .models import ThoughtRecord
 _HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$", re.MULTILINE)
 _SAFE_THOUGHT_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 _WHITESPACE_RE = re.compile(r"\s+")
+_GENERATED_READER_MARKER = "fava-trails rich-view generate"
+_GENERATED_READER_ARTIFACTS = ("src", "package.json", "astro.config.mjs", "README.md")
 
 
 @dataclass(frozen=True)
@@ -164,6 +167,8 @@ def _truncate_title(value: str, max_length: int = 80) -> str:
 def _write_reader(output_dir: Path, scope: str, generated_at: datetime, thoughts: list[ReaderThought]) -> None:
     generated_at_iso = generated_at.isoformat()
 
+    _prepare_reader_output_dir(output_dir)
+
     (output_dir / "src/pages/id").mkdir(parents=True, exist_ok=True)
     (output_dir / "src/data").mkdir(parents=True, exist_ok=True)
     (output_dir / "src/layouts").mkdir(parents=True, exist_ok=True)
@@ -178,6 +183,39 @@ def _write_reader(output_dir: Path, scope: str, generated_at: datetime, thoughts
         _write_thought_page(output_dir, scope, generated_at_iso, thought)
 
 
+def _prepare_reader_output_dir(output_dir: Path) -> None:
+    if not output_dir.exists():
+        return
+    if not output_dir.is_dir():
+        raise ValueError(f"Output path exists and is not a directory: {output_dir}")
+    if not any(output_dir.iterdir()):
+        return
+    if not _is_generated_reader_output_dir(output_dir):
+        raise ValueError(
+            f"refusing to overwrite non-reader output directory {output_dir}; "
+            "choose an empty directory or a previous fava-trails reader output"
+        )
+
+    # Clean prior generated artifacts so re-runs don't leave stale pages from previous generations.
+    for name in _GENERATED_READER_ARTIFACTS:
+        p = output_dir / name
+        if p.is_dir():
+            shutil.rmtree(p)
+        elif p.exists():
+            p.unlink(missing_ok=True)
+
+
+def _is_generated_reader_output_dir(output_dir: Path) -> bool:
+    marker_path = output_dir / "src/data/generated.json"
+    if not marker_path.is_file():
+        return False
+    try:
+        metadata = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return isinstance(metadata, dict) and metadata.get("generator") == _GENERATED_READER_MARKER
+
+
 def _write_package_json(output_dir: Path) -> None:
     package = {
         "name": "fava-reader",
@@ -189,7 +227,7 @@ def _write_package_json(output_dir: Path) -> None:
             "preview": "astro preview",
         },
         "devDependencies": {
-            "astro": "latest",
+            "astro": "^7.0.0",
         },
     }
     (output_dir / "package.json").write_text(json.dumps(package, indent=2) + "\n", encoding="utf-8")

--- a/tests/test_rich_views.py
+++ b/tests/test_rich_views.py
@@ -23,10 +23,11 @@ def _write_thought(
     thought_id: str,
     body: str,
     *,
+    filename: str | None = None,
     title: str | None = None,
     source_type: str = "observation",
 ) -> Path:
-    path = trails_dir / scope / "thoughts" / namespace / f"{thought_id}.md"
+    path = trails_dir / scope / "thoughts" / namespace / f"{filename or thought_id}.md"
     path.parent.mkdir(parents=True, exist_ok=True)
     title_line = f'title: "{title}"\n' if title else ""
     path.write_text(
@@ -134,6 +135,38 @@ def test_generate_reader_rejects_duplicate_thought_ids(tmp_path):
             output_dir=tmp_path / "reader",
             generated_at=datetime(2026, 7, 1, 12, 0, tzinfo=UTC),
         )
+
+
+def test_generate_reader_rejects_path_traversal_thought_id_without_writing_outside_output(tmp_path):
+    trails_dir = tmp_path / "data-repo" / "trails"
+    output_dir = tmp_path / "reader"
+    outside_dir = tmp_path / "tmp"
+    outside_dir.mkdir()
+    outside_path = outside_dir / "pwned.md"
+    scope = "mw/eng/demo"
+    unsafe_id = "../../../../tmp/pwned"
+    source_path = _write_thought(
+        trails_dir,
+        scope,
+        "decisions",
+        unsafe_id,
+        "# Poisoned",
+        filename="01KTEST000000000000000004",
+    )
+
+    with pytest.raises(ValueError) as exc:
+        generate_reader(
+            trails_dir=trails_dir,
+            scope=scope,
+            output_dir=output_dir,
+            generated_at=datetime(2026, 7, 1, 12, 0, tzinfo=UTC),
+        )
+
+    message = str(exc.value)
+    assert "Unsafe thought_id" in message
+    assert unsafe_id in message
+    assert str(source_path) in message
+    assert not outside_path.exists()
 
 
 def test_cli_rich_view_generate_command_builds_reader_from_fixture_records(tmp_path):

--- a/tests/test_rich_views.py
+++ b/tests/test_rich_views.py
@@ -178,6 +178,65 @@ def test_generate_reader_rejects_path_traversal_thought_id_without_writing_outsi
     assert not outside_path.exists()
 
 
+def test_generate_reader_rejects_non_empty_non_reader_output_without_clobbering(tmp_path):
+    trails_dir = tmp_path / "data-repo" / "trails"
+    output_dir = tmp_path / "existing-project"
+    scope = "mw/eng/demo"
+    source_id = "01KTEST000000000000000004"
+    _write_thought(trails_dir, scope, "decisions", source_id, "# Safe source")
+
+    existing_src = output_dir / "src"
+    existing_src.mkdir(parents=True)
+    existing_app = existing_src / "app.py"
+    existing_app.write_text("print('keep me')\n", encoding="utf-8")
+    existing_readme = output_dir / "README.md"
+    existing_readme.write_text("# Existing project\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="refusing to overwrite non-reader output directory"):
+        generate_reader(
+            trails_dir=trails_dir,
+            scope=scope,
+            output_dir=output_dir,
+            generated_at=datetime(2026, 7, 1, 12, 0, tzinfo=UTC),
+        )
+
+    assert existing_app.read_text(encoding="utf-8") == "print('keep me')\n"
+    assert existing_readme.read_text(encoding="utf-8") == "# Existing project\n"
+    assert not (output_dir / "src/pages/id" / f"{source_id}.md").exists()
+
+
+def test_generate_reader_rerun_cleans_stale_generated_pages(tmp_path):
+    trails_dir = tmp_path / "data-repo" / "trails"
+    output_dir = tmp_path / "reader"
+    scope = "mw/eng/demo"
+    first_id = "01KTEST000000000000000004"
+    stale_id = "01KTEST000000000000000005"
+    generated_at = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+
+    _write_thought(trails_dir, scope, "decisions", first_id, "# Current thought")
+    stale_source = _write_thought(trails_dir, scope, "observations", stale_id, "# Stale thought")
+
+    generate_reader(
+        trails_dir=trails_dir,
+        scope=scope,
+        output_dir=output_dir,
+        generated_at=generated_at,
+    )
+    assert (output_dir / "src/pages/id" / f"{stale_id}.md").is_file()
+
+    stale_source.unlink()
+    result = generate_reader(
+        trails_dir=trails_dir,
+        scope=scope,
+        output_dir=output_dir,
+        generated_at=generated_at,
+    )
+
+    assert result.thought_count == 1
+    assert (output_dir / "src/pages/id" / f"{first_id}.md").is_file()
+    assert not (output_dir / "src/pages/id" / f"{stale_id}.md").exists()
+
+
 def test_cli_rich_view_generate_command_builds_reader_from_fixture_records(tmp_path):
     trails_dir = tmp_path / "data-repo" / "trails"
     output_dir = tmp_path / "reader"

--- a/tests/test_rich_views.py
+++ b/tests/test_rich_views.py
@@ -1,0 +1,173 @@
+"""Tests for generating a minimal FAVA Rich Views reader."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from fava_trails.rich_views import generate_reader
+
+EXPLICIT_TITLE_ID = "01KTEST000000000000000001"
+HEADING_TITLE_ID = "01KTEST000000000000000002"
+FALLBACK_TITLE_ID = "01KTEST000000000000000003"
+
+
+def _write_thought(
+    trails_dir: Path,
+    scope: str,
+    namespace: str,
+    thought_id: str,
+    body: str,
+    *,
+    title: str | None = None,
+    source_type: str = "observation",
+) -> Path:
+    path = trails_dir / scope / "thoughts" / namespace / f"{thought_id}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    title_line = f'title: "{title}"\n' if title else ""
+    path.write_text(
+        f"""---
+schema_version: 1
+thought_id: "{thought_id}"
+{title_line}agent_id: test-agent
+source_type: {source_type}
+confidence: 0.85
+validation_status: approved
+created_at: "2026-07-01T09:30:00Z"
+metadata:
+  project: rich-views
+  tags:
+    - fixture
+---
+{body}
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_generate_reader_writes_plain_astro_reader_from_fixture_records(tmp_path):
+    trails_dir = tmp_path / "data-repo" / "trails"
+    output_dir = tmp_path / "reader"
+    scope = "mw/eng/demo"
+    generated_at = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+
+    _write_thought(
+        trails_dir,
+        scope,
+        "decisions",
+        EXPLICIT_TITLE_ID,
+        "Body with an explicit frontmatter title.",
+        title="Explicit operator title",
+        source_type="decision",
+    )
+    _write_thought(
+        trails_dir,
+        scope,
+        "observations",
+        HEADING_TITLE_ID,
+        "# Heading-derived title\n\nBody content under the heading.",
+    )
+    _write_thought(
+        trails_dir,
+        scope,
+        "drafts",
+        FALLBACK_TITLE_ID,
+        "Fallback title comes from the first words of the body when no heading exists.",
+    )
+
+    result = generate_reader(
+        trails_dir=trails_dir,
+        scope=scope,
+        output_dir=output_dir,
+        generated_at=generated_at,
+    )
+
+    assert result.thought_count == 3
+    assert result.scope == scope
+
+    package_json = (output_dir / "package.json").read_text(encoding="utf-8")
+    assert '"astro"' in package_json
+    assert "starlight" not in package_json.lower()
+    assert "quartz" not in package_json.lower()
+    assert (output_dir / "astro.config.mjs").is_file()
+
+    metadata = (output_dir / "src/data/generated.json").read_text(encoding="utf-8")
+    assert '"inputScope": "mw/eng/demo"' in metadata
+    assert '"generatedAt": "2026-07-01T12:00:00+00:00"' in metadata
+
+    index = (output_dir / "src/pages/index.astro").read_text(encoding="utf-8")
+    assert "Static snapshot" in index
+    assert "not a live view" in index
+    assert "Input scope: mw/eng/demo" in index
+    assert "Generated at: 2026-07-01T12:00:00+00:00" in index
+    assert "Explicit operator title" in index
+    assert "Heading-derived title" in index
+    assert "Fallback title comes from the first words" in index
+    assert f"/thoughts/{EXPLICIT_TITLE_ID}/" in index
+    assert f"/thoughts/{HEADING_TITLE_ID}/" in index
+    assert f"/thoughts/{FALLBACK_TITLE_ID}/" in index
+
+    detail_page = output_dir / "src/pages/thoughts" / f"{EXPLICIT_TITLE_ID}.md"
+    detail_text = detail_page.read_text(encoding="utf-8")
+    assert f'thoughtId: "{EXPLICIT_TITLE_ID}"' in detail_text
+    assert 'inputScope: "mw/eng/demo"' in detail_text
+    assert 'generatedAt: "2026-07-01T12:00:00+00:00"' in detail_text
+    assert "Body with an explicit frontmatter title." in detail_text
+
+
+def test_generate_reader_rejects_duplicate_thought_ids(tmp_path):
+    trails_dir = tmp_path / "data-repo" / "trails"
+    scope = "mw/eng/demo"
+    duplicate_id = "01KTEST0000000000000000DUP"
+    _write_thought(trails_dir, scope, "decisions", duplicate_id, "# First copy")
+    _write_thought(trails_dir, scope, "observations", duplicate_id, "# Second copy")
+
+    with pytest.raises(ValueError, match=f"Duplicate thought_id {duplicate_id}"):
+        generate_reader(
+            trails_dir=trails_dir,
+            scope=scope,
+            output_dir=tmp_path / "reader",
+            generated_at=datetime(2026, 7, 1, 12, 0, tzinfo=UTC),
+        )
+
+
+def test_cli_rich_view_generate_command_builds_reader_from_fixture_records(tmp_path):
+    trails_dir = tmp_path / "data-repo" / "trails"
+    output_dir = tmp_path / "reader"
+    scope = "mw/eng/demo"
+    _write_thought(
+        trails_dir,
+        scope,
+        "decisions",
+        EXPLICIT_TITLE_ID,
+        "# CLI fixture\n\nGenerated from the CLI.",
+        source_type="decision",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "fava_trails.cli",
+            "rich-view",
+            "generate",
+            "--trails-dir",
+            str(trails_dir),
+            "--scope",
+            scope,
+            "--out",
+            str(output_dir),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Generated FAVA reader" in result.stdout
+    assert (output_dir / "src/pages/index.astro").is_file()
+    assert (output_dir / "src/pages/thoughts" / f"{EXPLICIT_TITLE_ID}.md").is_file()

--- a/tests/test_rich_views.py
+++ b/tests/test_rich_views.py
@@ -100,6 +100,11 @@ def test_generate_reader_writes_plain_astro_reader_from_fixture_records(tmp_path
     metadata = (output_dir / "src/data/generated.json").read_text(encoding="utf-8")
     assert '"inputScope": "mw/eng/demo"' in metadata
     assert '"generatedAt": "2026-07-01T12:00:00+00:00"' in metadata
+    assert f"/id/{EXPLICIT_TITLE_ID}/" in metadata
+    assert f"/id/{HEADING_TITLE_ID}/" in metadata
+    assert f"/id/{FALLBACK_TITLE_ID}/" in metadata
+    assert f"/thoughts/{EXPLICIT_TITLE_ID}/" not in metadata
+    assert f'"/{EXPLICIT_TITLE_ID}/"' not in metadata
 
     index = (output_dir / "src/pages/index.astro").read_text(encoding="utf-8")
     assert "Static snapshot" in index
@@ -109,11 +114,15 @@ def test_generate_reader_writes_plain_astro_reader_from_fixture_records(tmp_path
     assert "Explicit operator title" in index
     assert "Heading-derived title" in index
     assert "Fallback title comes from the first words" in index
-    assert f"/thoughts/{EXPLICIT_TITLE_ID}/" in index
-    assert f"/thoughts/{HEADING_TITLE_ID}/" in index
-    assert f"/thoughts/{FALLBACK_TITLE_ID}/" in index
+    assert f"/id/{EXPLICIT_TITLE_ID}/" in index
+    assert f"/id/{HEADING_TITLE_ID}/" in index
+    assert f"/id/{FALLBACK_TITLE_ID}/" in index
+    assert f"/thoughts/{EXPLICIT_TITLE_ID}/" not in index
+    assert f'"/{EXPLICIT_TITLE_ID}/"' not in index
 
-    detail_page = output_dir / "src/pages/thoughts" / f"{EXPLICIT_TITLE_ID}.md"
+    assert not (output_dir / "src/pages/thoughts" / f"{EXPLICIT_TITLE_ID}.md").exists()
+
+    detail_page = output_dir / "src/pages/id" / f"{EXPLICIT_TITLE_ID}.md"
     detail_text = detail_page.read_text(encoding="utf-8")
     assert f'thoughtId: "{EXPLICIT_TITLE_ID}"' in detail_text
     assert 'inputScope: "mw/eng/demo"' in detail_text
@@ -203,4 +212,5 @@ def test_cli_rich_view_generate_command_builds_reader_from_fixture_records(tmp_p
     assert result.returncode == 0, result.stderr
     assert "Generated FAVA reader" in result.stdout
     assert (output_dir / "src/pages/index.astro").is_file()
-    assert (output_dir / "src/pages/thoughts" / f"{EXPLICIT_TITLE_ID}.md").is_file()
+    assert (output_dir / "src/pages/id" / f"{EXPLICIT_TITLE_ID}.md").is_file()
+    assert not (output_dir / "src/pages/thoughts" / f"{EXPLICIT_TITLE_ID}.md").exists()


### PR DESCRIPTION
## Summary
- Adds `fava-trails rich-view generate` to produce a minimal plain Astro reader from source FAVA thought records.
- Generates ULID-backed thought routes, derived display titles, and snapshot metadata with input scope and generation time.
- Verifies fixture generation, duplicate ULID rejection, and CLI command behavior.

## References
- Parent PRD: #51
- Implements: #52

## Test Plan
- `env UV_CACHE_DIR=/private/tmp/fava-trails-uv-cache uv sync --frozen`
- `env UV_CACHE_DIR=/private/tmp/fava-trails-uv-cache uv run ruff check`
- `env UV_CACHE_DIR=/private/tmp/fava-trails-uv-cache uv run pytest tests/test_rich_views.py -v`
- `env UV_CACHE_DIR=/private/tmp/fava-trails-uv-cache uv run pytest tests/test_cli.py::test_cli_help tests/test_rich_views.py -v`
- `env UV_CACHE_DIR=/private/tmp/fava-trails-uv-cache uv run pytest -v`
- `env UV_CACHE_DIR=/private/tmp/fava-trails-uv-cache uv run python -m fava_trails.cli rich-view generate --help`