### PR TITLE
feat: serve local rich-view reader (#53, PRD #51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to FAVA Trails are documented here.
 
 ### Added
 - `fava-trails rich-view generate --scope <path> --out <dir>`: generates a minimal plain-Astro static reader from FAVA trail thought records (ULID routes, derived titles, snapshot metadata). Implements #52.
+- `fava-trails rich-view serve`: generates or reuses the local FAVA reader and serves it on a loopback-only Astro dev server, defaulting to all discovered scopes while preserving `/id/<UID>/` routes. Implements #53.
 
 ## [0.5.7] — 2026-06-30
 

--- a/src/fava_trails/cli.py
+++ b/src/fava_trails/cli.py
@@ -8,6 +8,7 @@ import os
 import platform
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import tarfile
@@ -829,10 +830,6 @@ def cmd_rich_view_serve(args: argparse.Namespace) -> int:
                 output_dir=output_dir,
             )
 
-        if not is_generated_reader_output_dir(output_dir):
-            print(f"Error: {output_dir} is not a generated FAVA reader.", file=sys.stderr)
-            return 1
-
         _ensure_reader_node_modules(output_dir, skip_install=args.no_install)
         url = _reader_server_url(args.host, args.port)
         command = [
@@ -846,7 +843,7 @@ def cmd_rich_view_serve(args: argparse.Namespace) -> int:
             str(args.port),
             "--strictPort",
         ]
-        process = subprocess.Popen(command, cwd=str(output_dir))
+        process = _start_reader_process(command, output_dir)
         try:
             _wait_for_reader_server(url, process)
         except Exception:
@@ -859,7 +856,7 @@ def cmd_rich_view_serve(args: argparse.Namespace) -> int:
         print(f"  Reader: {output_dir}")
         print(f"  Scopes: {scopes}")
         print("  Press Ctrl-C to stop.")
-        _run_reader_process(process, serve_duration=getattr(args, "serve_duration", None))
+        _run_reader_process(process)
     except KeyboardInterrupt:
         print("\nStopped local FAVA reader.")
         return 0
@@ -898,6 +895,17 @@ def _ensure_reader_node_modules(output_dir: Path, *, skip_install: bool) -> None
         raise subprocess.SubprocessError("npm install failed for generated FAVA reader")
 
 
+def _start_reader_process(command: list[str], output_dir: Path) -> subprocess.Popen:
+    return subprocess.Popen(command, cwd=str(output_dir), **_reader_process_popen_kwargs())
+
+
+def _reader_process_popen_kwargs() -> dict[str, object]:
+    if os.name == "nt":
+        creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        return {"creationflags": creationflags} if creationflags else {}
+    return {"start_new_session": True}
+
+
 def _wait_for_reader_server(url: str, process: subprocess.Popen, *, timeout: float = 20.0) -> None:
     deadline = time.monotonic() + timeout
     last_error: Exception | None = None
@@ -913,25 +921,93 @@ def _wait_for_reader_server(url: str, process: subprocess.Popen, *, timeout: flo
     raise TimeoutError(f"Timed out waiting for local FAVA reader at {url}: {last_error}")
 
 
-def _run_reader_process(process: subprocess.Popen, *, serve_duration: float | None = None) -> None:
+def _run_reader_process(process: subprocess.Popen) -> None:
     try:
-        if serve_duration is None:
-            process.wait()
-        else:
-            time.sleep(serve_duration)
+        process.wait()
     finally:
         _stop_reader_process(process)
 
 
-def _stop_reader_process(process: subprocess.Popen) -> None:
+def _stop_reader_process(process: subprocess.Popen, *, timeout: float = 5.0) -> None:
+    if os.name == "nt":
+        _stop_windows_process_tree(process, timeout=timeout)
+        return
+
+    pid = getattr(process, "pid", None)
+    if isinstance(pid, int) and _signal_posix_process_group(pid, signal.SIGTERM):
+        _wait_for_reader_parent(process, timeout=timeout)
+        if not _wait_for_posix_process_group_exit(pid, timeout=timeout):
+            _signal_posix_process_group(pid, signal.SIGKILL)
+            _wait_for_reader_parent(process, timeout=timeout)
+            _wait_for_posix_process_group_exit(pid, timeout=timeout)
+        return
+
+    _stop_process_parent_only(process, timeout=timeout)
+
+
+def _stop_windows_process_tree(process: subprocess.Popen, *, timeout: float) -> None:
+    pid = getattr(process, "pid", None)
+    if isinstance(pid, int):
+        result = subprocess.run(
+            ["taskkill", "/PID", str(pid), "/T", "/F"],
+            check=False,
+            capture_output=True,
+        )
+        if result.returncode == 0:
+            _wait_for_reader_parent(process, timeout=timeout)
+            return
+
+    _stop_process_parent_only(process, timeout=timeout)
+
+
+def _stop_process_parent_only(process: subprocess.Popen, *, timeout: float) -> None:
     if process.poll() is not None:
         return
     process.terminate()
     try:
-        process.wait(timeout=5)
+        process.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         process.kill()
-        process.wait(timeout=5)
+        process.wait(timeout=timeout)
+
+
+def _wait_for_reader_parent(process: subprocess.Popen, *, timeout: float) -> bool:
+    if process.poll() is not None:
+        return True
+    try:
+        process.wait(timeout=timeout)
+        return True
+    except subprocess.TimeoutExpired:
+        return False
+
+
+def _signal_posix_process_group(pgid: int, sig: int) -> bool:
+    try:
+        os.killpg(pgid, sig)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return False
+    return True
+
+
+def _wait_for_posix_process_group_exit(pgid: int, *, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _posix_process_group_exists(pgid):
+            return True
+        time.sleep(0.05)
+    return not _posix_process_group_exists(pgid)
+
+
+def _posix_process_group_exists(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
 
 
 # ─── Protocol setup commands ──────────────────────────────────────────────────
@@ -1352,6 +1428,33 @@ def cmd_integrate_codev(args: argparse.Namespace) -> int:
 # ─── Argument parser ──────────────────────────────────────────────────────────
 
 
+def _add_rich_view_scope_arg(parser: argparse.ArgumentParser, *, required: bool, repeated: bool) -> None:
+    if repeated:
+        parser.add_argument(
+            "--scope",
+            action="append",
+            default=None,
+            help="Input FAVA scope path; may be repeated. Defaults to all discovered scopes.",
+        )
+        return
+    parser.add_argument("--scope", required=required, help="Input FAVA scope path")
+
+
+def _add_rich_view_out_arg(parser: argparse.ArgumentParser, *, required: bool) -> None:
+    help_text = "Output directory for the generated reader"
+    if not required:
+        help_text += " (default: user cache directory)"
+    parser.add_argument("--out", required=required, default=None, help=help_text)
+
+
+def _add_rich_view_trails_dir_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--trails-dir",
+        default=None,
+        help="Directory containing FAVA trails (default: configured data repo trails directory)",
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     try:
         from importlib.metadata import version
@@ -1449,35 +1552,18 @@ def build_parser() -> argparse.ArgumentParser:
         "generate",
         help="Generate a minimal plain-Astro FAVA reader from source records",
     )
-    p_rich_view_generate.add_argument("--scope", required=True, help="Input FAVA scope path")
-    p_rich_view_generate.add_argument("--out", required=True, help="Output directory for the generated reader")
-    p_rich_view_generate.add_argument(
-        "--trails-dir",
-        default=None,
-        help="Directory containing FAVA trails (default: configured data repo trails directory)",
-    )
+    _add_rich_view_scope_arg(p_rich_view_generate, required=True, repeated=False)
+    _add_rich_view_out_arg(p_rich_view_generate, required=True)
+    _add_rich_view_trails_dir_arg(p_rich_view_generate)
     p_rich_view_generate.set_defaults(func=cmd_rich_view_generate)
 
     p_rich_view_serve = rich_view_sub.add_parser(
         "serve",
         help="Serve the generated FAVA reader locally on a loopback-only Astro dev server",
     )
-    p_rich_view_serve.add_argument(
-        "--scope",
-        action="append",
-        default=None,
-        help="Input FAVA scope path; may be repeated. Defaults to all discovered scopes.",
-    )
-    p_rich_view_serve.add_argument(
-        "--out",
-        default=None,
-        help="Output directory for the generated reader (default: user cache directory)",
-    )
-    p_rich_view_serve.add_argument(
-        "--trails-dir",
-        default=None,
-        help="Directory containing FAVA trails (default: configured data repo trails directory)",
-    )
+    _add_rich_view_scope_arg(p_rich_view_serve, required=False, repeated=True)
+    _add_rich_view_out_arg(p_rich_view_serve, required=False)
+    _add_rich_view_trails_dir_arg(p_rich_view_serve)
     p_rich_view_serve.add_argument(
         "--host",
         default="127.0.0.1",

--- a/src/fava_trails/cli.py
+++ b/src/fava_trails/cli.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import time
 import urllib.error
 import urllib.request
 from importlib import resources as importlib_resources
@@ -807,6 +808,132 @@ def cmd_rich_view_generate(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_rich_view_serve(args: argparse.Namespace) -> int:
+    """Generate or locate a reader and serve it through a loopback-only Astro dev server."""
+    try:
+        _validate_loopback_host(args.host)
+        trails_dir = Path(args.trails_dir).expanduser().resolve() if args.trails_dir else get_trails_dir()
+        output_dir = _resolve_reader_output_dir(args.out)
+
+        from .rich_views import generate_reader_for_scopes, is_generated_reader_output_dir
+
+        if args.no_generate:
+            if not is_generated_reader_output_dir(output_dir):
+                print(f"Error: {output_dir} is not a generated FAVA reader.", file=sys.stderr)
+                return 1
+            result = None
+        else:
+            result = generate_reader_for_scopes(
+                trails_dir=trails_dir,
+                scopes=args.scope,
+                output_dir=output_dir,
+            )
+
+        if not is_generated_reader_output_dir(output_dir):
+            print(f"Error: {output_dir} is not a generated FAVA reader.", file=sys.stderr)
+            return 1
+
+        _ensure_reader_node_modules(output_dir, skip_install=args.no_install)
+        url = _reader_server_url(args.host, args.port)
+        command = [
+            "npm",
+            "run",
+            "dev",
+            "--",
+            "--host",
+            args.host,
+            "--port",
+            str(args.port),
+            "--strictPort",
+        ]
+        process = subprocess.Popen(command, cwd=str(output_dir))
+        try:
+            _wait_for_reader_server(url, process)
+        except Exception:
+            _stop_reader_process(process)
+            raise
+
+        scopes = ", ".join(result.scopes) if result is not None else "existing generated reader"
+        print("Serving local private FAVA data.")
+        print(f"  URL: {url}")
+        print(f"  Reader: {output_dir}")
+        print(f"  Scopes: {scopes}")
+        print("  Press Ctrl-C to stop.")
+        _run_reader_process(process, serve_duration=getattr(args, "serve_duration", None))
+    except KeyboardInterrupt:
+        print("\nStopped local FAVA reader.")
+        return 0
+    except (OSError, ValueError, subprocess.SubprocessError, yaml.YAMLError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+def _resolve_reader_output_dir(value: str | None) -> Path:
+    if value:
+        return Path(value).expanduser().resolve()
+    cache_home = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return cache_home / "fava-trails" / "rich-view-reader"
+
+
+def _validate_loopback_host(host: str) -> None:
+    if host not in {"127.0.0.1", "localhost", "::1"}:
+        raise ValueError("rich-view serve must bind to a loopback host: 127.0.0.1, localhost, or ::1")
+
+
+def _reader_server_url(host: str, port: int) -> str:
+    if host == "::1":
+        return f"http://[::1]:{port}/"
+    return f"http://{host}:{port}/"
+
+
+def _ensure_reader_node_modules(output_dir: Path, *, skip_install: bool) -> None:
+    if (output_dir / "node_modules").is_dir():
+        return
+    if skip_install:
+        raise ValueError(f"{output_dir}/node_modules is missing; rerun without --no-install")
+    result = subprocess.run(["npm", "install"], cwd=str(output_dir), check=False)
+    if result.returncode != 0:
+        raise subprocess.SubprocessError("npm install failed for generated FAVA reader")
+
+
+def _wait_for_reader_server(url: str, process: subprocess.Popen, *, timeout: float = 20.0) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise subprocess.SubprocessError("Astro dev server exited before becoming ready")
+        try:
+            with urllib.request.urlopen(url, timeout=0.5):
+                return
+        except (OSError, urllib.error.URLError) as e:
+            last_error = e
+            time.sleep(0.1)
+    raise TimeoutError(f"Timed out waiting for local FAVA reader at {url}: {last_error}")
+
+
+def _run_reader_process(process: subprocess.Popen, *, serve_duration: float | None = None) -> None:
+    try:
+        if serve_duration is None:
+            process.wait()
+        else:
+            time.sleep(serve_duration)
+    finally:
+        _stop_reader_process(process)
+
+
+def _stop_reader_process(process: subprocess.Popen) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
 # ─── Protocol setup commands ──────────────────────────────────────────────────
 
 
@@ -1330,6 +1457,49 @@ def build_parser() -> argparse.ArgumentParser:
         help="Directory containing FAVA trails (default: configured data repo trails directory)",
     )
     p_rich_view_generate.set_defaults(func=cmd_rich_view_generate)
+
+    p_rich_view_serve = rich_view_sub.add_parser(
+        "serve",
+        help="Serve the generated FAVA reader locally on a loopback-only Astro dev server",
+    )
+    p_rich_view_serve.add_argument(
+        "--scope",
+        action="append",
+        default=None,
+        help="Input FAVA scope path; may be repeated. Defaults to all discovered scopes.",
+    )
+    p_rich_view_serve.add_argument(
+        "--out",
+        default=None,
+        help="Output directory for the generated reader (default: user cache directory)",
+    )
+    p_rich_view_serve.add_argument(
+        "--trails-dir",
+        default=None,
+        help="Directory containing FAVA trails (default: configured data repo trails directory)",
+    )
+    p_rich_view_serve.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Loopback host to bind (default: 127.0.0.1)",
+    )
+    p_rich_view_serve.add_argument(
+        "--port",
+        type=int,
+        default=4321,
+        help="Local port for the Astro dev server (default: 4321)",
+    )
+    p_rich_view_serve.add_argument(
+        "--no-generate",
+        action="store_true",
+        help="Serve an existing generated reader without regenerating it",
+    )
+    p_rich_view_serve.add_argument(
+        "--no-install",
+        action="store_true",
+        help="Do not run npm install when node_modules is missing",
+    )
+    p_rich_view_serve.set_defaults(func=cmd_rich_view_serve)
 
     p_rich_view.set_defaults(func=lambda args: (p_rich_view.print_help(), 0)[1])
 

--- a/src/fava_trails/rich_views.py
+++ b/src/fava_trails/rich_views.py
@@ -37,6 +37,7 @@ class ReaderThought:
     confidence: float
     tags: tuple[str, ...]
     route: str
+    scope: str
 
 
 @dataclass(frozen=True)
@@ -48,6 +49,7 @@ class GenerationResult:
     generated_at: datetime
     thought_count: int
     routes: tuple[str, ...]
+    scopes: tuple[str, ...]
 
 
 def generate_reader(
@@ -75,16 +77,60 @@ def generate_reader(
         generated_at=timestamp,
         thought_count=len(thoughts),
         routes=tuple(thought.route for thought in thoughts),
+        scopes=(safe_scope,),
+    )
+
+
+def generate_reader_for_scopes(
+    *,
+    trails_dir: Path | str,
+    scopes: list[str] | tuple[str, ...] | None,
+    output_dir: Path | str,
+    generated_at: datetime | None = None,
+) -> GenerationResult:
+    """Generate a minimal plain-Astro reader for selected or all discovered scopes."""
+
+    source_root = Path(trails_dir)
+    destination = Path(output_dir)
+    timestamp = generated_at or datetime.now(UTC)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=UTC)
+
+    safe_scopes = tuple(_resolve_reader_scopes(source_root, scopes))
+    all_thoughts: list[ReaderThought] = []
+    seen: dict[str, Path] = {}
+    for scope in safe_scopes:
+        for thought, source_path in _load_reader_thoughts_with_sources(source_root, scope):
+            if thought.thought_id in seen:
+                raise ValueError(f"Duplicate thought_id {thought.thought_id} in {source_path} and {seen[thought.thought_id]}")
+            seen[thought.thought_id] = source_path
+            all_thoughts.append(thought)
+
+    display_scope = safe_scopes[0] if len(safe_scopes) == 1 else "all scopes"
+    all_thoughts = sorted(all_thoughts, key=lambda thought: (thought.scope, thought.thought_id))
+    _write_reader(destination, display_scope, timestamp, all_thoughts, input_scopes=safe_scopes)
+
+    return GenerationResult(
+        scope=display_scope,
+        output_dir=destination,
+        generated_at=timestamp,
+        thought_count=len(all_thoughts),
+        routes=tuple(thought.route for thought in all_thoughts),
+        scopes=safe_scopes,
     )
 
 
 def _load_reader_thoughts(trails_dir: Path, scope: str) -> list[ReaderThought]:
+    return [thought for thought, _source_path in _load_reader_thoughts_with_sources(trails_dir, scope)]
+
+
+def _load_reader_thoughts_with_sources(trails_dir: Path, scope: str) -> list[tuple[ReaderThought, Path]]:
     thoughts_dir = trails_dir / scope / "thoughts"
     if not thoughts_dir.is_dir():
         raise ValueError(f"No FAVA thoughts found for scope {scope!r} at {thoughts_dir}")
 
     seen: dict[str, Path] = {}
-    thoughts: list[ReaderThought] = []
+    thoughts: list[tuple[ReaderThought, Path]] = []
     for path in sorted(p for p in thoughts_dir.rglob("*.md") if p.name != ".gitkeep"):
         raw_text = path.read_text(encoding="utf-8")
         raw_frontmatter = _read_raw_frontmatter(raw_text)
@@ -101,23 +147,50 @@ def _load_reader_thoughts(trails_dir: Path, scope: str) -> list[ReaderThought]:
             namespace = path.parent.name
         source_path = str(path.relative_to(trails_dir))
         fm = record.frontmatter
-        thoughts.append(
-            ReaderThought(
-                thought_id=thought_id,
-                title=_derive_title(raw_frontmatter, record.content),
-                content=record.content,
-                namespace=namespace,
-                source_path=source_path,
-                source_type=fm.source_type.value,
-                validation_status=fm.validation_status.value,
-                agent_id=fm.agent_id,
-                confidence=fm.confidence,
-                tags=tuple(fm.metadata.tags),
-                route=f"/id/{thought_id}/",
-            )
+        thought = ReaderThought(
+            thought_id=thought_id,
+            title=_derive_title(raw_frontmatter, record.content),
+            content=record.content,
+            namespace=namespace,
+            source_path=source_path,
+            source_type=fm.source_type.value,
+            validation_status=fm.validation_status.value,
+            agent_id=fm.agent_id,
+            confidence=fm.confidence,
+            tags=tuple(fm.metadata.tags),
+            route=f"/id/{thought_id}/",
+            scope=scope,
         )
+        thoughts.append((thought, path))
 
-    return sorted(thoughts, key=lambda thought: thought.thought_id)
+    return sorted(thoughts, key=lambda item: item[0].thought_id)
+
+
+def _resolve_reader_scopes(trails_dir: Path, scopes: list[str] | tuple[str, ...] | None) -> list[str]:
+    if scopes:
+        return sorted(dict.fromkeys(sanitize_scope_path(scope) for scope in scopes))
+    discovered = discover_reader_scopes(trails_dir)
+    if not discovered:
+        raise ValueError(f"No FAVA scopes found under {trails_dir}")
+    return discovered
+
+
+def discover_reader_scopes(trails_dir: Path | str) -> list[str]:
+    """Discover scope paths with a thoughts/ directory under trails_dir."""
+
+    root = Path(trails_dir)
+    scopes: list[str] = []
+    if not root.exists():
+        return scopes
+    for thoughts_dir in sorted(root.rglob("thoughts")):
+        if not thoughts_dir.is_dir():
+            continue
+        try:
+            scope = str(thoughts_dir.parent.relative_to(root))
+        except ValueError:
+            continue
+        scopes.append(scope)
+    return sorted(set(scopes))
 
 
 def _validate_reader_thought_id(thought_id: str, source_path: Path) -> None:
@@ -164,8 +237,16 @@ def _truncate_title(value: str, max_length: int = 80) -> str:
     return value[: max_length - 1].rstrip() + "..."
 
 
-def _write_reader(output_dir: Path, scope: str, generated_at: datetime, thoughts: list[ReaderThought]) -> None:
+def _write_reader(
+    output_dir: Path,
+    scope: str,
+    generated_at: datetime,
+    thoughts: list[ReaderThought],
+    *,
+    input_scopes: tuple[str, ...] | None = None,
+) -> None:
     generated_at_iso = generated_at.isoformat()
+    scopes = input_scopes or (scope,)
 
     _prepare_reader_output_dir(output_dir)
 
@@ -175,8 +256,8 @@ def _write_reader(output_dir: Path, scope: str, generated_at: datetime, thoughts
 
     _write_package_json(output_dir)
     _write_astro_config(output_dir)
-    _write_readme(output_dir, scope, generated_at_iso)
-    _write_generated_metadata(output_dir, scope, generated_at_iso, thoughts)
+    _write_readme(output_dir, scope, generated_at_iso, scopes)
+    _write_generated_metadata(output_dir, scope, generated_at_iso, thoughts, scopes)
     _write_index(output_dir, scope, generated_at_iso, thoughts)
     _write_layout(output_dir)
     for thought in thoughts:
@@ -203,6 +284,12 @@ def _prepare_reader_output_dir(output_dir: Path) -> None:
             shutil.rmtree(p)
         elif p.exists():
             p.unlink(missing_ok=True)
+
+
+def is_generated_reader_output_dir(output_dir: Path | str) -> bool:
+    """Return True when output_dir is a previous FAVA reader generation."""
+
+    return _is_generated_reader_output_dir(Path(output_dir))
 
 
 def _is_generated_reader_output_dir(output_dir: Path) -> bool:
@@ -243,7 +330,8 @@ def _write_astro_config(output_dir: Path) -> None:
     )
 
 
-def _write_readme(output_dir: Path, scope: str, generated_at: str) -> None:
+def _write_readme(output_dir: Path, scope: str, generated_at: str, scopes: tuple[str, ...]) -> None:
+    scope_lines = "\n".join(f"  - {input_scope}" for input_scope in scopes)
     (output_dir / "README.md").write_text(
         f"""# FAVA Reader
 
@@ -252,6 +340,10 @@ It is not a live view. Regenerate it when the trail changes.
 
 - Input scope: {scope}
 - Generated at: {generated_at}
+
+## Included scopes
+
+{scope_lines}
 
 ## Build
 
@@ -265,9 +357,16 @@ npm run preview
     )
 
 
-def _write_generated_metadata(output_dir: Path, scope: str, generated_at: str, thoughts: list[ReaderThought]) -> None:
+def _write_generated_metadata(
+    output_dir: Path,
+    scope: str,
+    generated_at: str,
+    thoughts: list[ReaderThought],
+    scopes: tuple[str, ...],
+) -> None:
     metadata = {
         "inputScope": scope,
+        "inputScopes": list(scopes),
         "generatedAt": generated_at,
         "generator": "fava-trails rich-view generate",
         "snapshotNotice": "Static snapshot; not a live view.",
@@ -287,6 +386,7 @@ def _write_index(output_dir: Path, scope: str, generated_at: str, thoughts: list
             "sourceType": thought.source_type,
             "validationStatus": thought.validation_status,
             "sourcePath": thought.source_path,
+            "scope": thought.scope,
         }
         for thought in thoughts
     ]
@@ -386,6 +486,7 @@ const thoughts = {json.dumps(thought_data, indent=2)};
               <span>{{thought.namespace}}</span>
               <span>{{thought.sourceType}}</span>
               <span>{{thought.validationStatus}}</span>
+              <span>{{thought.scope}}</span>
               <span>{{thought.sourcePath}}</span>
             </div>
           </li>
@@ -507,6 +608,7 @@ def _write_thought_page(output_dir: Path, scope: str, generated_at: str, thought
         f"title: {_yaml_string(thought.title)}",
         f"thoughtId: {_yaml_string(thought.thought_id)}",
         f"inputScope: {_yaml_string(scope)}",
+        f"scope: {_yaml_string(thought.scope)}",
         f"generatedAt: {_yaml_string(generated_at)}",
         f"namespace: {_yaml_string(thought.namespace)}",
         f"sourceType: {_yaml_string(thought.source_type)}",

--- a/tests/test_rich_views.py
+++ b/tests/test_rich_views.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
 
+from fava_trails import cli
 from fava_trails.cli import cmd_rich_view_serve
 from fava_trails.rich_views import generate_reader, generate_reader_for_scopes
 
@@ -357,28 +359,50 @@ def test_cli_rich_view_serve_generates_all_scopes_and_starts_loopback_server(tmp
 
     with patch("fava_trails.cli._ensure_reader_node_modules") as ensure_node:
         with patch("fava_trails.cli._wait_for_reader_server"):
-            with patch("subprocess.Popen", return_value=process) as popen:
-                rc = cmd_rich_view_serve(
-                    _make_serve_args(
-                        trails_dir=trails_dir,
-                        out=output_dir,
-                        port=4322,
-                        serve_duration=0,
+            with patch("fava_trails.cli._run_reader_process") as run_process:
+                with patch("subprocess.Popen", return_value=process) as popen:
+                    rc = cmd_rich_view_serve(
+                        _make_serve_args(
+                            trails_dir=trails_dir,
+                            out=output_dir,
+                            port=4322,
+                        )
                     )
-                )
 
     assert rc == 0
     ensure_node.assert_called_once_with(output_dir, skip_install=False)
     popen.assert_called_once_with(
         ["npm", "run", "dev", "--", "--host", "127.0.0.1", "--port", "4322", "--strictPort"],
         cwd=str(output_dir),
+        **cli._reader_process_popen_kwargs(),
     )
-    process.terminate.assert_called_once()
+    run_process.assert_called_once_with(process)
     out = capsys.readouterr().out
     assert "Serving local private FAVA data" in out
     assert "http://127.0.0.1:4322/" in out
     assert "Scopes: mw/eng/alpha" in out
     assert (output_dir / "src/pages/id" / f"{EXPLICIT_TITLE_ID}.md").is_file()
+
+
+def test_cli_rich_view_serve_runtime_loop_does_not_depend_on_hidden_duration_arg(tmp_path):
+    trails_dir = tmp_path / "data-repo" / "trails"
+    output_dir = tmp_path / "reader"
+    _write_thought(trails_dir, "mw/eng/alpha", "decisions", EXPLICIT_TITLE_ID, "# Alpha")
+    process = Mock()
+    process.poll.return_value = None
+    process.wait.return_value = 0
+    args = _make_serve_args(trails_dir=trails_dir, out=output_dir, port=4322)
+
+    assert not hasattr(args, "serve_duration")
+
+    with patch("fava_trails.cli._ensure_reader_node_modules"):
+        with patch("fava_trails.cli._wait_for_reader_server"):
+            with patch("fava_trails.cli._run_reader_process") as run_process:
+                with patch("subprocess.Popen", return_value=process):
+                    rc = cmd_rich_view_serve(args)
+
+    assert rc == 0
+    run_process.assert_called_once_with(process)
 
 
 def test_cli_rich_view_serve_scope_filter_narrows_generated_reader(tmp_path):
@@ -392,16 +416,16 @@ def test_cli_rich_view_serve_scope_filter_narrows_generated_reader(tmp_path):
 
     with patch("fava_trails.cli._ensure_reader_node_modules"):
         with patch("fava_trails.cli._wait_for_reader_server"):
-            with patch("subprocess.Popen", return_value=process):
-                rc = cmd_rich_view_serve(
-                    _make_serve_args(
-                        trails_dir=trails_dir,
-                        out=output_dir,
-                        scope=["mw/eng/beta"],
-                        port=4323,
-                        serve_duration=0,
+            with patch("fava_trails.cli._run_reader_process"):
+                with patch("subprocess.Popen", return_value=process):
+                    rc = cmd_rich_view_serve(
+                        _make_serve_args(
+                            trails_dir=trails_dir,
+                            out=output_dir,
+                            scope=["mw/eng/beta"],
+                            port=4323,
+                        )
                     )
-                )
 
     assert rc == 0
     assert not (output_dir / "src/pages/id" / f"{EXPLICIT_TITLE_ID}.md").exists()
@@ -414,7 +438,6 @@ def test_cli_rich_view_serve_rejects_non_loopback_host(tmp_path, capsys):
             trails_dir=tmp_path / "trails",
             out=tmp_path / "reader",
             host="0.0.0.0",
-            serve_duration=0,
         )
     )
 
@@ -428,7 +451,6 @@ def test_cli_rich_view_serve_no_generate_requires_existing_reader(tmp_path, caps
             trails_dir=tmp_path / "trails",
             out=tmp_path / "not-reader",
             no_generate=True,
-            serve_duration=0,
         )
     )
 
@@ -446,16 +468,16 @@ def test_cli_rich_view_serve_formats_ipv6_loopback_url(tmp_path, capsys):
 
     with patch("fava_trails.cli._ensure_reader_node_modules"):
         with patch("fava_trails.cli._wait_for_reader_server"):
-            with patch("subprocess.Popen", return_value=process):
-                rc = cmd_rich_view_serve(
-                    _make_serve_args(
-                        trails_dir=trails_dir,
-                        out=output_dir,
-                        host="::1",
-                        port=4324,
-                        serve_duration=0,
+            with patch("fava_trails.cli._run_reader_process"):
+                with patch("subprocess.Popen", return_value=process):
+                    rc = cmd_rich_view_serve(
+                        _make_serve_args(
+                            trails_dir=trails_dir,
+                            out=output_dir,
+                            host="::1",
+                            port=4324,
+                        )
                     )
-                )
 
     assert rc == 0
     assert "http://[::1]:4324/" in capsys.readouterr().out
@@ -477,12 +499,57 @@ def test_cli_rich_view_serve_stops_process_when_readiness_fails(tmp_path):
                         trails_dir=trails_dir,
                         out=output_dir,
                         port=4325,
-                        serve_duration=0,
                     )
                 )
 
     assert rc == 1
     process.terminate.assert_called_once()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group cleanup is covered on Unix-like CI")
+def test_stop_reader_process_cleans_child_process_after_parent_exits(tmp_path):
+    pid_file = tmp_path / "child.pid"
+    parent_script = (
+        "import subprocess, sys\n"
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)'])\n"
+        "open(sys.argv[1], 'w', encoding='utf-8').write(str(child.pid))\n"
+    )
+    process = cli._start_reader_process([sys.executable, "-c", parent_script, str(pid_file)], tmp_path)
+    child_pid: int | None = None
+
+    try:
+        process.wait(timeout=5)
+        child_pid = _read_pid_file(pid_file)
+        assert _pid_exists(child_pid)
+
+        cli._stop_reader_process(process, timeout=0.5)
+
+        deadline = time.monotonic() + 5
+        while _pid_exists(child_pid) and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert not _pid_exists(child_pid)
+    finally:
+        if child_pid is not None and _pid_exists(child_pid):
+            cli.os.kill(child_pid, 9)
+
+
+def _read_pid_file(path: Path) -> int:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if path.exists():
+            return int(path.read_text(encoding="utf-8"))
+        time.sleep(0.05)
+    raise AssertionError(f"{path} was not written")
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        cli.os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
 
 
 def _make_serve_args(
@@ -494,7 +561,6 @@ def _make_serve_args(
     port: int = 4321,
     no_generate: bool = False,
     no_install: bool = False,
-    serve_duration: float | None = None,
 ):
     return type(
         "Args",
@@ -507,6 +573,5 @@ def _make_serve_args(
             "port": port,
             "no_generate": no_generate,
             "no_install": no_install,
-            "serve_duration": serve_duration,
         },
     )()

--- a/tests/test_rich_views.py
+++ b/tests/test_rich_views.py
@@ -6,10 +6,12 @@ import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
 
-from fava_trails.rich_views import generate_reader
+from fava_trails.cli import cmd_rich_view_serve
+from fava_trails.rich_views import generate_reader, generate_reader_for_scopes
 
 EXPLICIT_TITLE_ID = "01KTEST000000000000000001"
 HEADING_TITLE_ID = "01KTEST000000000000000002"
@@ -128,6 +130,76 @@ def test_generate_reader_writes_plain_astro_reader_from_fixture_records(tmp_path
     assert 'inputScope: "mw/eng/demo"' in detail_text
     assert 'generatedAt: "2026-07-01T12:00:00+00:00"' in detail_text
     assert "Body with an explicit frontmatter title." in detail_text
+
+
+def test_generate_reader_for_scopes_defaults_to_all_discovered_scopes(tmp_path):
+    trails_dir = tmp_path / "data-repo" / "trails"
+    output_dir = tmp_path / "reader"
+    generated_at = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+
+    _write_thought(trails_dir, "mw/eng/alpha", "decisions", EXPLICIT_TITLE_ID, "# Alpha")
+    _write_thought(trails_dir, "mw/eng/beta", "observations", HEADING_TITLE_ID, "# Beta")
+
+    result = generate_reader_for_scopes(
+        trails_dir=trails_dir,
+        scopes=None,
+        output_dir=output_dir,
+        generated_at=generated_at,
+    )
+
+    assert result.scopes == ("mw/eng/alpha", "mw/eng/beta")
+    assert result.scope == "all scopes"
+    assert result.thought_count == 2
+
+    metadata = (output_dir / "src/data/generated.json").read_text(encoding="utf-8")
+    assert '"inputScope": "all scopes"' in metadata
+    assert '"inputScopes": [\n    "mw/eng/alpha",\n    "mw/eng/beta"\n  ]' in metadata
+    assert f"/id/{EXPLICIT_TITLE_ID}/" in metadata
+    assert f"/id/{HEADING_TITLE_ID}/" in metadata
+    assert f"/thoughts/{EXPLICIT_TITLE_ID}/" not in metadata
+    assert f'"/{EXPLICIT_TITLE_ID}/"' not in metadata
+
+    index = (output_dir / "src/pages/index.astro").read_text(encoding="utf-8")
+    assert "Input scope: all scopes" in index
+    assert "mw/eng/alpha" in index
+    assert "mw/eng/beta" in index
+
+
+def test_generate_reader_for_scopes_scope_filter_narrows_selected_scopes(tmp_path):
+    trails_dir = tmp_path / "data-repo" / "trails"
+    output_dir = tmp_path / "reader"
+    generated_at = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+
+    _write_thought(trails_dir, "mw/eng/alpha", "decisions", EXPLICIT_TITLE_ID, "# Alpha")
+    _write_thought(trails_dir, "mw/eng/beta", "observations", HEADING_TITLE_ID, "# Beta")
+
+    result = generate_reader_for_scopes(
+        trails_dir=trails_dir,
+        scopes=["mw/eng/beta"],
+        output_dir=output_dir,
+        generated_at=generated_at,
+    )
+
+    assert result.scopes == ("mw/eng/beta",)
+    assert result.scope == "mw/eng/beta"
+    assert result.thought_count == 1
+    assert not (output_dir / "src/pages/id" / f"{EXPLICIT_TITLE_ID}.md").exists()
+    assert (output_dir / "src/pages/id" / f"{HEADING_TITLE_ID}.md").is_file()
+
+
+def test_generate_reader_for_scopes_rejects_duplicate_ids_across_scopes(tmp_path):
+    trails_dir = tmp_path / "data-repo" / "trails"
+    duplicate_id = "01KTEST0000000000000000DUP"
+    _write_thought(trails_dir, "mw/eng/alpha", "decisions", duplicate_id, "# Alpha copy")
+    _write_thought(trails_dir, "mw/eng/beta", "observations", duplicate_id, "# Beta copy")
+
+    with pytest.raises(ValueError, match=f"Duplicate thought_id {duplicate_id}"):
+        generate_reader_for_scopes(
+            trails_dir=trails_dir,
+            scopes=None,
+            output_dir=tmp_path / "reader",
+            generated_at=datetime(2026, 7, 1, 12, 0, tzinfo=UTC),
+        )
 
 
 def test_generate_reader_rejects_duplicate_thought_ids(tmp_path):
@@ -273,3 +345,168 @@ def test_cli_rich_view_generate_command_builds_reader_from_fixture_records(tmp_p
     assert (output_dir / "src/pages/index.astro").is_file()
     assert (output_dir / "src/pages/id" / f"{EXPLICIT_TITLE_ID}.md").is_file()
     assert not (output_dir / "src/pages/thoughts" / f"{EXPLICIT_TITLE_ID}.md").exists()
+
+
+def test_cli_rich_view_serve_generates_all_scopes_and_starts_loopback_server(tmp_path, capsys):
+    trails_dir = tmp_path / "data-repo" / "trails"
+    output_dir = tmp_path / "reader"
+    _write_thought(trails_dir, "mw/eng/alpha", "decisions", EXPLICIT_TITLE_ID, "# Alpha")
+    process = Mock()
+    process.poll.return_value = None
+    process.wait.return_value = 0
+
+    with patch("fava_trails.cli._ensure_reader_node_modules") as ensure_node:
+        with patch("fava_trails.cli._wait_for_reader_server"):
+            with patch("subprocess.Popen", return_value=process) as popen:
+                rc = cmd_rich_view_serve(
+                    _make_serve_args(
+                        trails_dir=trails_dir,
+                        out=output_dir,
+                        port=4322,
+                        serve_duration=0,
+                    )
+                )
+
+    assert rc == 0
+    ensure_node.assert_called_once_with(output_dir, skip_install=False)
+    popen.assert_called_once_with(
+        ["npm", "run", "dev", "--", "--host", "127.0.0.1", "--port", "4322", "--strictPort"],
+        cwd=str(output_dir),
+    )
+    process.terminate.assert_called_once()
+    out = capsys.readouterr().out
+    assert "Serving local private FAVA data" in out
+    assert "http://127.0.0.1:4322/" in out
+    assert "Scopes: mw/eng/alpha" in out
+    assert (output_dir / "src/pages/id" / f"{EXPLICIT_TITLE_ID}.md").is_file()
+
+
+def test_cli_rich_view_serve_scope_filter_narrows_generated_reader(tmp_path):
+    trails_dir = tmp_path / "data-repo" / "trails"
+    output_dir = tmp_path / "reader"
+    _write_thought(trails_dir, "mw/eng/alpha", "decisions", EXPLICIT_TITLE_ID, "# Alpha")
+    _write_thought(trails_dir, "mw/eng/beta", "observations", HEADING_TITLE_ID, "# Beta")
+    process = Mock()
+    process.poll.return_value = None
+    process.wait.return_value = 0
+
+    with patch("fava_trails.cli._ensure_reader_node_modules"):
+        with patch("fava_trails.cli._wait_for_reader_server"):
+            with patch("subprocess.Popen", return_value=process):
+                rc = cmd_rich_view_serve(
+                    _make_serve_args(
+                        trails_dir=trails_dir,
+                        out=output_dir,
+                        scope=["mw/eng/beta"],
+                        port=4323,
+                        serve_duration=0,
+                    )
+                )
+
+    assert rc == 0
+    assert not (output_dir / "src/pages/id" / f"{EXPLICIT_TITLE_ID}.md").exists()
+    assert (output_dir / "src/pages/id" / f"{HEADING_TITLE_ID}.md").is_file()
+
+
+def test_cli_rich_view_serve_rejects_non_loopback_host(tmp_path, capsys):
+    rc = cmd_rich_view_serve(
+        _make_serve_args(
+            trails_dir=tmp_path / "trails",
+            out=tmp_path / "reader",
+            host="0.0.0.0",
+            serve_duration=0,
+        )
+    )
+
+    assert rc == 1
+    assert "loopback" in capsys.readouterr().err
+
+
+def test_cli_rich_view_serve_no_generate_requires_existing_reader(tmp_path, capsys):
+    rc = cmd_rich_view_serve(
+        _make_serve_args(
+            trails_dir=tmp_path / "trails",
+            out=tmp_path / "not-reader",
+            no_generate=True,
+            serve_duration=0,
+        )
+    )
+
+    assert rc == 1
+    assert "not a generated FAVA reader" in capsys.readouterr().err
+
+
+def test_cli_rich_view_serve_formats_ipv6_loopback_url(tmp_path, capsys):
+    trails_dir = tmp_path / "data-repo" / "trails"
+    output_dir = tmp_path / "reader"
+    _write_thought(trails_dir, "mw/eng/alpha", "decisions", EXPLICIT_TITLE_ID, "# Alpha")
+    process = Mock()
+    process.poll.return_value = None
+    process.wait.return_value = 0
+
+    with patch("fava_trails.cli._ensure_reader_node_modules"):
+        with patch("fava_trails.cli._wait_for_reader_server"):
+            with patch("subprocess.Popen", return_value=process):
+                rc = cmd_rich_view_serve(
+                    _make_serve_args(
+                        trails_dir=trails_dir,
+                        out=output_dir,
+                        host="::1",
+                        port=4324,
+                        serve_duration=0,
+                    )
+                )
+
+    assert rc == 0
+    assert "http://[::1]:4324/" in capsys.readouterr().out
+
+
+def test_cli_rich_view_serve_stops_process_when_readiness_fails(tmp_path):
+    trails_dir = tmp_path / "data-repo" / "trails"
+    output_dir = tmp_path / "reader"
+    _write_thought(trails_dir, "mw/eng/alpha", "decisions", EXPLICIT_TITLE_ID, "# Alpha")
+    process = Mock()
+    process.poll.return_value = None
+    process.wait.return_value = 0
+
+    with patch("fava_trails.cli._ensure_reader_node_modules"):
+        with patch("fava_trails.cli._wait_for_reader_server", side_effect=TimeoutError("not ready")):
+            with patch("subprocess.Popen", return_value=process):
+                rc = cmd_rich_view_serve(
+                    _make_serve_args(
+                        trails_dir=trails_dir,
+                        out=output_dir,
+                        port=4325,
+                        serve_duration=0,
+                    )
+                )
+
+    assert rc == 1
+    process.terminate.assert_called_once()
+
+
+def _make_serve_args(
+    *,
+    trails_dir: Path | None = None,
+    out: Path | None = None,
+    scope: list[str] | None = None,
+    host: str = "127.0.0.1",
+    port: int = 4321,
+    no_generate: bool = False,
+    no_install: bool = False,
+    serve_duration: float | None = None,
+):
+    return type(
+        "Args",
+        (),
+        {
+            "trails_dir": str(trails_dir) if trails_dir else None,
+            "out": str(out) if out else None,
+            "scope": scope,
+            "host": host,
+            "port": port,
+            "no_generate": no_generate,
+            "no_install": no_install,
+            "serve_duration": serve_duration,
+        },
+    )()


### PR DESCRIPTION
## Summary
- Adds `fava-trails rich-view serve` for a loopback-only local Astro dev server.
- Generates all discovered FAVA scopes by default, with repeated `--scope` flags narrowing the served reader.
- Preserves `/id/<UID>/` fallback routes and keeps bare UID routes out of generated output.

## References
- Parent PRD: #51
- Closes: #53

## Test Plan
- `env UV_CACHE_DIR=/private/tmp/fava-trails-uv-cache uv run pytest tests/test_rich_views.py -v`
- `env UV_CACHE_DIR=/private/tmp/fava-trails-uv-cache uv run ruff check`
- `env UV_CACHE_DIR=/private/tmp/fava-trails-uv-cache uv run pytest tests/test_cli.py::test_cli_help tests/test_rich_views.py -v`
- `env UV_CACHE_DIR=/private/tmp/fava-trails-uv-cache uv run pytest -v`
- `env UV_CACHE_DIR=/private/tmp/fava-trails-uv-cache uv run python -m fava_trails.cli rich-view serve --help`
- Temporary generated-reader smoke: `npm install` and `npm run build` in `/private/tmp/fava-rich-53-3NdATV/reader`
- Temporary local-server smoke via `cmd_rich_view_serve(... no_generate=True, no_install=True, serve_duration=0.0)` on `127.0.0.1:4326`

## Notes
- The command rejects non-loopback hosts so private FAVA trail data is not exposed publicly.
- Raw Markdown body trust-boundary handling remains deferred to #55, where full detail-page rendering is scoped.
