### PR TITLE
feat: add ChatGPT tunnel gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ af-config.json
 # Codev VS Code extension settings (shared)
 !.vscode/
 !.vscode/settings.json
+# Local MachineWisdom agent/review artifacts
+.wise-agents/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "python-ulid>=3.0.0",
     "any-llm-sdk>=1.10.0",
     "httpx>=0.27.0",
+    "starlette>=0.52.0",
+    "uvicorn>=0.41.0",
 ]
 
 [project.optional-dependencies]
@@ -43,6 +45,7 @@ Issues = "https://github.com/MachineWisdomAI/fava-trails/issues"
 [project.scripts]
 fava-trails-server = "fava_trails.server:run"
 fava-trails = "fava_trails.cli:main"
+fava-trails-tunnel = "fava_trails.tunnel_cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/fava_trails/cli.py
+++ b/src/fava_trails/cli.py
@@ -322,6 +322,9 @@ def cmd_bootstrap(args: argparse.Namespace) -> int:
     print(f"\nData repo ready: {target}")
     print("\nSet this in your MCP server config:")
     print(f"  FAVA_TRAILS_DATA_REPO={target}")
+    print("\nFor ChatGPT via OpenAI Secure MCP Tunnel:")
+    print("  tunnel-client init --profile fava-trails --mcp-server-url http://127.0.0.1:8765/mcp --tunnel-id <tunnel_id>")
+    print(f"  fava-trails-tunnel start --data-repo {target} --profile fava-trails")
     if remote_url:
         print("\nPush to remote:")
         print(f"  cd {target} && jj git push -b main")
@@ -392,6 +395,9 @@ def cmd_clone(args: argparse.Namespace) -> int:
     print(f"\nData repo ready: {target}")
     print("\nSet this in your MCP server config:")
     print(f"  FAVA_TRAILS_DATA_REPO={target}")
+    print("\nFor ChatGPT via OpenAI Secure MCP Tunnel:")
+    print("  tunnel-client init --profile fava-trails --mcp-server-url http://127.0.0.1:8765/mcp --tunnel-id <tunnel_id>")
+    print(f"  fava-trails-tunnel start --data-repo {target} --profile fava-trails")
     return 0
 
 

--- a/src/fava_trails/cli.py
+++ b/src/fava_trails/cli.py
@@ -323,7 +323,7 @@ def cmd_bootstrap(args: argparse.Namespace) -> int:
     print("\nSet this in your MCP server config:")
     print(f"  FAVA_TRAILS_DATA_REPO={target}")
     print("\nFor ChatGPT via OpenAI Secure MCP Tunnel:")
-    print("  tunnel-client init --profile fava-trails --mcp-server-url http://127.0.0.1:8765/mcp --tunnel-id <tunnel_id>")
+    print("  tunnel-client init --profile fava-trails --mcp-server-url http://127.0.0.1:8765/mcp/ --tunnel-id <tunnel_id>")
     print(f"  fava-trails-tunnel start --data-repo {target} --profile fava-trails")
     if remote_url:
         print("\nPush to remote:")
@@ -396,7 +396,7 @@ def cmd_clone(args: argparse.Namespace) -> int:
     print("\nSet this in your MCP server config:")
     print(f"  FAVA_TRAILS_DATA_REPO={target}")
     print("\nFor ChatGPT via OpenAI Secure MCP Tunnel:")
-    print("  tunnel-client init --profile fava-trails --mcp-server-url http://127.0.0.1:8765/mcp --tunnel-id <tunnel_id>")
+    print("  tunnel-client init --profile fava-trails --mcp-server-url http://127.0.0.1:8765/mcp/ --tunnel-id <tunnel_id>")
     print(f"  fava-trails-tunnel start --data-repo {target} --profile fava-trails")
     return 0
 

--- a/src/fava_trails/http_runtime.py
+++ b/src/fava_trails/http_runtime.py
@@ -1,0 +1,73 @@
+"""Loopback Streamable HTTP runtime for the FAVA Trails MCP server."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any
+
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Mount, Route
+
+from .config import ConfigStore, get_data_repo_root, get_trails_dir
+
+
+class _McpASGIApp:
+    def __init__(self, session_manager: StreamableHTTPSessionManager) -> None:
+        self._session_manager = session_manager
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        await self._session_manager.handle_request(scope, receive, send)
+
+
+def create_streamable_http_app() -> Starlette:
+    """Create a Starlette app exposing the existing MCP server at /mcp."""
+    from . import server as fava_server
+
+    session_manager = StreamableHTTPSessionManager(
+        app=fava_server.server,
+        stateless=False,
+    )
+
+    @asynccontextmanager
+    async def lifespan(app: Starlette):
+        ConfigStore.reset()
+        await fava_server._init_server()
+        async with session_manager.run():
+            yield
+
+    async def healthz(request) -> JSONResponse:
+        data_repo = get_data_repo_root()
+        trails_dir = get_trails_dir()
+        return JSONResponse(
+            {
+                "status": "ok",
+                "runtime": "fava-trails-tunnel",
+                "data_repo": str(data_repo),
+                "trails_dir": str(trails_dir),
+            }
+        )
+
+    return Starlette(
+        lifespan=lifespan,
+        routes=[
+            Route("/healthz", endpoint=healthz, methods=["GET"]),
+            Mount("/mcp", app=_McpASGIApp(session_manager)),
+        ],
+    )
+
+
+def run_streamable_http_server(*, host: str, port: int, log_level: str = "info") -> None:
+    """Run the loopback Streamable HTTP MCP server until interrupted."""
+    import uvicorn
+
+    app = create_streamable_http_app()
+    config = uvicorn.Config(
+        app,
+        host=host,
+        port=port,
+        log_level=log_level,
+        lifespan="on",
+    )
+    uvicorn.Server(config).run()

--- a/src/fava_trails/server.py
+++ b/src/fava_trails/server.py
@@ -282,6 +282,16 @@ STRUCTURED_RESULT_SCHEMA: dict[str, Any] = {
     "additionalProperties": True,
 }
 
+
+def _structured_or_common_error(success_schema: dict[str, Any]) -> dict[str, Any]:
+    """Allow a precise success shape while preserving structured error responses."""
+    return {
+        "anyOf": [
+            success_schema,
+            STRUCTURED_RESULT_SCHEMA,
+        ]
+    }
+
 THOUGHT_SUMMARY_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -346,10 +356,10 @@ USAGE_GUIDE_OUTPUT_SCHEMA: dict[str, Any] = {
 }
 
 TOOL_OUTPUT_SCHEMAS: dict[str, dict[str, Any]] = {
-    "list_scopes": LIST_SCOPES_OUTPUT_SCHEMA,
-    "list_trails": LIST_SCOPES_OUTPUT_SCHEMA,
-    "recall": RECALL_OUTPUT_SCHEMA,
-    "get_usage_guide": USAGE_GUIDE_OUTPUT_SCHEMA,
+    "list_scopes": _structured_or_common_error(LIST_SCOPES_OUTPUT_SCHEMA),
+    "list_trails": _structured_or_common_error(LIST_SCOPES_OUTPUT_SCHEMA),
+    "recall": _structured_or_common_error(RECALL_OUTPUT_SCHEMA),
+    "get_usage_guide": _structured_or_common_error(USAGE_GUIDE_OUTPUT_SCHEMA),
 }
 
 READ_ONLY_TOOLS = {

--- a/src/fava_trails/server.py
+++ b/src/fava_trails/server.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import asyncio
 import functools
 import importlib.resources
-import json
 import logging
 import logging.handlers
 import os
@@ -20,7 +19,7 @@ from typing import Any
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool
+from mcp.types import TextContent, Tool, ToolAnnotations
 
 from .config import (
     ConfigStore,
@@ -269,6 +268,120 @@ def _build_trail_name_desc() -> str:
     )
 
 TRAIL_NAME_DESC = _build_trail_name_desc()
+
+STRUCTURED_RESULT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {"type": "string"},
+        "message": {"type": "string"},
+        "warning": {"type": "string"},
+        "hook_feedback": {"type": "object", "additionalProperties": True},
+        "push_warning": {"type": "string"},
+    },
+    "required": ["status"],
+    "additionalProperties": True,
+}
+
+THOUGHT_SUMMARY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "thought_id": {"type": "string"},
+        "source_type": {"type": "string"},
+        "validation_status": {"type": "string"},
+        "confidence": {"type": "number"},
+        "agent_id": {"type": "string"},
+        "created_at": {"type": ["string", "null"]},
+        "content_preview": {"type": "string"},
+        "content": {"type": "string"},
+        "source_trail": {"type": "string"},
+        "metadata": {"type": "object", "additionalProperties": True},
+        "relationships": {"type": "array", "items": {"type": "object", "additionalProperties": True}},
+    },
+    "additionalProperties": True,
+}
+
+LIST_SCOPES_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {"type": "string"},
+        "count": {"type": "integer"},
+        "scopes": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "thought_count": {"type": "integer"},
+                },
+                "required": ["path"],
+                "additionalProperties": True,
+            },
+        },
+    },
+    "required": ["status", "count", "scopes"],
+    "additionalProperties": True,
+}
+
+RECALL_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {"type": "string"},
+        "count": {"type": "integer"},
+        "thoughts": {"type": "array", "items": THOUGHT_SUMMARY_SCHEMA},
+        "filters": {"type": "object", "additionalProperties": True},
+    },
+    "required": ["status", "count", "thoughts", "filters"],
+    "additionalProperties": True,
+}
+
+USAGE_GUIDE_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {"type": "string"},
+        "content": {"type": "string"},
+        "message": {"type": "string"},
+    },
+    "required": ["status"],
+    "additionalProperties": True,
+}
+
+TOOL_OUTPUT_SCHEMAS: dict[str, dict[str, Any]] = {
+    "list_scopes": LIST_SCOPES_OUTPUT_SCHEMA,
+    "list_trails": LIST_SCOPES_OUTPUT_SCHEMA,
+    "recall": RECALL_OUTPUT_SCHEMA,
+    "get_usage_guide": USAGE_GUIDE_OUTPUT_SCHEMA,
+}
+
+READ_ONLY_TOOLS = {
+    "conflicts",
+    "diff",
+    "get_thought",
+    "get_usage_guide",
+    "list_scopes",
+    "list_trails",
+    "recall",
+}
+
+DESTRUCTIVE_TOOLS = {
+    "change_scope",
+    "forget",
+    "rollback",
+    "supersede",
+    "update_thought",
+}
+
+OPEN_WORLD_TOOLS = {
+    "change_scope",
+    "forget",
+    "learn_preference",
+    "propose_truth",
+    "rollback",
+    "save_thought",
+    "start_thought",
+    "supersede",
+    "sync",
+    "update_thought",
+}
 
 TOOL_DEFINITIONS: list[dict[str, Any]] = [
     {
@@ -538,9 +651,94 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
 ]
 
 
+def _decorate_tool_definitions() -> None:
+    """Attach output schemas and annotations to static tool definitions."""
+    for td in TOOL_DEFINITIONS:
+        name = td["name"]
+        td["outputSchema"] = TOOL_OUTPUT_SCHEMAS.get(name, STRUCTURED_RESULT_SCHEMA)
+        annotations: dict[str, Any] = {
+            "readOnlyHint": name in READ_ONLY_TOOLS,
+            "destructiveHint": name in DESTRUCTIVE_TOOLS,
+            "openWorldHint": name in OPEN_WORLD_TOOLS,
+        }
+        if name in READ_ONLY_TOOLS:
+            annotations["idempotentHint"] = True
+        td["annotations"] = annotations
+
+
+_decorate_tool_definitions()
+
+
+def _summarize_tool_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Return log-safe tool arguments without thought bodies or secrets."""
+    summary: dict[str, Any] = {}
+    for key in (
+        "trail_name",
+        "target_trail_name",
+        "thought_id",
+        "query",
+        "namespace",
+        "prefix",
+        "limit",
+        "include_stats",
+        "include_superseded",
+        "include_relationships",
+        "op_id",
+        "revision",
+        "source_type",
+        "preference_type",
+    ):
+        if key in arguments:
+            summary[key] = arguments[key]
+
+    if "trail_names" in arguments:
+        trail_names = arguments.get("trail_names") or []
+        summary["trail_names_count"] = len(trail_names)
+        summary["trail_names"] = trail_names[:5]
+    if "scope" in arguments:
+        scope = arguments.get("scope") or {}
+        summary["scope_keys"] = sorted(scope.keys()) if isinstance(scope, dict) else type(scope).__name__
+    if "metadata" in arguments:
+        metadata = arguments.get("metadata") or {}
+        summary["metadata_keys"] = (
+            sorted(metadata.keys()) if isinstance(metadata, dict) else type(metadata).__name__
+        )
+    if "relationships" in arguments:
+        relationships = arguments.get("relationships") or []
+        summary["relationships_count"] = len(relationships)
+    for text_key in ("content", "reason", "description"):
+        if text_key in arguments:
+            value = arguments.get(text_key)
+            summary[f"{text_key}_length"] = len(value) if isinstance(value, str) else None
+    return summary
+
+
+def _summarize_tool_result(result: Any) -> dict[str, Any]:
+    """Return log-safe result facts for call telemetry."""
+    if not isinstance(result, dict):
+        return {"result_type": type(result).__name__}
+    summary: dict[str, Any] = {"status": result.get("status")}
+    for key in ("count", "has_conflicts"):
+        if key in result:
+            summary[key] = result[key]
+    if "thoughts" in result and isinstance(result["thoughts"], list):
+        summary["thoughts_count"] = len(result["thoughts"])
+    if "scopes" in result and isinstance(result["scopes"], list):
+        summary["scopes_count"] = len(result["scopes"])
+    if "conflicts" in result and isinstance(result["conflicts"], list):
+        summary["conflicts_count"] = len(result["conflicts"])
+    if "thought" in result and isinstance(result["thought"], dict):
+        summary["thought_id"] = result["thought"].get("thought_id")
+    if "new_thought" in result and isinstance(result["new_thought"], dict):
+        summary["new_thought_id"] = result["new_thought"].get("thought_id")
+    if "message" in result:
+        summary["message_length"] = len(str(result["message"]))
+    return summary
+
+
 def with_tool_timeout(
-    fn: Callable[..., Coroutine[Any, Any, list[TextContent]]],
-) -> Callable[..., Coroutine[Any, Any, list[TextContent]]]:
+    fn: Callable[..., Coroutine[Any, Any, Any]],
+) -> Callable[..., Coroutine[Any, Any, Any]]:
     """Decorator: wraps an MCP tool handler with a configurable asyncio timeout.
 
     Reads ``tool_timeout_secs`` from GlobalConfig at call time (not decoration time)
@@ -548,7 +746,7 @@ def with_tool_timeout(
     Set ``tool_timeout_secs: 0`` in config.yaml to disable.
     """
     @functools.wraps(fn)
-    async def wrapper(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    async def wrapper(name: str, arguments: dict[str, Any]) -> Any:
         timeout = ConfigStore.get().global_config.tool_timeout_secs
         if timeout <= 0:
             return await fn(name, arguments)
@@ -565,7 +763,7 @@ def with_tool_timeout(
                     "For propose_truth, the LLM provider may be unresponsive — retry."
                 ),
             }
-            return [TextContent(type="text", text=json.dumps(result, indent=2))]
+            return result
     return wrapper
 
 
@@ -577,6 +775,8 @@ async def handle_list_tools() -> list[Tool]:
             name=td["name"],
             description=td["description"],
             inputSchema=td["inputSchema"],
+            outputSchema=td["outputSchema"],
+            annotations=ToolAnnotations(**td["annotations"]),
         )
         for td in TOOL_DEFINITIONS
     ]
@@ -584,7 +784,7 @@ async def handle_list_tools() -> list[Tool]:
 
 @server.call_tool()
 @with_tool_timeout
-async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+async def handle_call_tool(name: str, arguments: dict[str, Any]) -> Any:
     """Route tool calls to handlers. Responses are structured JSON (except get_usage_guide which returns markdown)."""
     from .tools.navigation import (
         handle_conflicts,
@@ -606,18 +806,24 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextCon
         handle_update_thought,
     )
 
+    logger.info("Tool call started: %s %s", name, _summarize_tool_arguments(arguments))
+    result: Any
     try:
         # Tools that don't need a trail
         if name in ("list_scopes", "list_trails"):
             result = await handle_list_scopes(arguments)
-            return [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
+            logger.info("Tool call completed: %s %s", name, _summarize_tool_result(result))
+            return result
 
         if name == "get_usage_guide":
             content = _load_usage_guide()
             if content.startswith("Error:"):
                 result = {"status": "error", "message": content}
-                return [TextContent(type="text", text=json.dumps(result, indent=2))]
-            return [TextContent(type="text", text=content)]
+                logger.info("Tool call completed: %s %s", name, _summarize_tool_result(result))
+                return result
+            result = {"status": "ok", "content": content}
+            logger.info("Tool call completed: %s %s", name, _summarize_tool_result(result))
+            return ([TextContent(type="text", text=content)], result)
 
         # All other tools need a trail
         trail = await _get_trail(arguments.get("trail_name"))
@@ -660,7 +866,12 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextCon
                             for c in active_conflicts
                         ],
                     }
-                    return [TextContent(type="text", text=json.dumps(conflict_result, indent=2, default=str))]
+                    logger.info(
+                        "Tool call completed: %s %s",
+                        name,
+                        _summarize_tool_result(conflict_result),
+                    )
+                    return conflict_result
 
         # Route to handler
         if name == "recall":
@@ -731,7 +942,8 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextCon
         logger.exception(f"Tool {name} failed")
         result = {"status": "error", "message": f"Tool '{name}' failed: {str(e)}"}
 
-    return [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
+    logger.info("Tool call completed: %s %s", name, _summarize_tool_result(result))
+    return result
 
 
 def run():

--- a/src/fava_trails/tunnel_cli.py
+++ b/src/fava_trails/tunnel_cli.py
@@ -1,0 +1,549 @@
+"""CLI for running a FAVA Trails MCP runtime behind OpenAI Secure MCP Tunnel."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn
+
+import yaml
+
+from .cli import _find_jj_bin
+from .config import ConfigStore
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8765
+DEFAULT_PROFILE = "fava-trails"
+DEFAULT_MCP_PATH = "/mcp"
+
+
+@dataclass(frozen=True)
+class GatewayConfig:
+    data_repo: Path
+    trails_dir: Path
+    host: str
+    port: int
+    mcp_path: str
+    profile: str
+    tunnel_client: str
+    trust_gate_env: str
+
+    @property
+    def mcp_url(self) -> str:
+        return f"http://{self.host}:{self.port}{self.mcp_path}"
+
+    @property
+    def health_url(self) -> str:
+        return f"http://{self.host}:{self.port}/healthz"
+
+
+def _state_home() -> Path:
+    return Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state"))
+
+
+def _state_dir(data_repo: Path, profile: str) -> Path:
+    digest = hashlib.sha256(f"{data_repo.resolve()}|{profile}".encode()).hexdigest()[:12]
+    safe_profile = "".join(c if c.isalnum() or c in "._-" else "-" for c in profile).strip("-") or "default"
+    return _state_home() / "fava-trails" / "tunnel" / f"{safe_profile}-{digest}"
+
+
+def _pid_file(state_dir: Path) -> Path:
+    return state_dir / "supervisor.pid"
+
+
+def _metadata_file(state_dir: Path) -> Path:
+    return state_dir / "metadata.json"
+
+
+def _ready_file(state_dir: Path) -> Path:
+    return state_dir / "ready.json"
+
+
+def _log_file(state_dir: Path) -> Path:
+    return state_dir / "gateway.log"
+
+
+def _read_pid(path: Path) -> int | None:
+    try:
+        return int(path.read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _is_pid_running(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _validate_loopback_host(host: str) -> None:
+    if host not in {"127.0.0.1", "localhost", "::1"}:
+        raise ValueError("fava-trails-tunnel only binds the private MCP runtime to a loopback host")
+
+
+def _check_port_available(host: str, port: int) -> None:
+    with socket.socket(socket.AF_INET6 if host == "::1" else socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind((host, port))
+        except OSError as exc:
+            raise ValueError(f"port {port} is not available on {host}") from exc
+
+
+def _resolve_data_repo(args: argparse.Namespace) -> Path:
+    value = getattr(args, "data_repo", None) or os.environ.get("FAVA_TRAILS_DATA_REPO")
+    if not value:
+        raise ValueError("FAVA_TRAILS_DATA_REPO is required; pass --data-repo for tunnel mode")
+    return Path(value).expanduser().resolve()
+
+
+def _load_gateway_config(args: argparse.Namespace, *, require_tunnel_client: bool = True) -> GatewayConfig:
+    data_repo = _resolve_data_repo(args)
+    if not data_repo.is_dir():
+        raise ValueError(f"data repo not found: {data_repo}")
+
+    config_path = data_repo / "config.yaml"
+    if not config_path.is_file():
+        raise ValueError(f"missing data repo config.yaml: {config_path}")
+
+    try:
+        config_data = yaml.safe_load(config_path.read_text()) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f"invalid data repo config.yaml: {exc}") from exc
+
+    trails_value = config_data.get("trails_dir", "trails")
+    trails_dir = Path(trails_value)
+    if not trails_dir.is_absolute():
+        trails_dir = data_repo / trails_dir
+    if not trails_dir.is_dir():
+        raise ValueError(f"trails directory not found: {trails_dir}")
+
+    if _find_jj_bin() is None:
+        raise ValueError("jj not found. Install with: fava-trails install-jj")
+
+    trust_gate = config_data.get("trust_gate", "llm-oneshot")
+    trust_gate_env = config_data.get("openrouter_api_key_env", "OPENROUTER_API_KEY")
+    if trust_gate == "llm-oneshot" and not os.environ.get(trust_gate_env):
+        raise ValueError(f"Trust Gate provider config missing: set {trust_gate_env}")
+
+    host = getattr(args, "host", DEFAULT_HOST)
+    port = getattr(args, "port", DEFAULT_PORT)
+    mcp_path = getattr(args, "mcp_path", DEFAULT_MCP_PATH)
+    profile = getattr(args, "profile", DEFAULT_PROFILE)
+    tunnel_client_arg = getattr(args, "tunnel_client", None) or "tunnel-client"
+    tunnel_client = shutil.which(tunnel_client_arg) or (
+        str(Path(tunnel_client_arg).expanduser()) if Path(tunnel_client_arg).expanduser().is_file() else ""
+    )
+    if require_tunnel_client and not tunnel_client:
+        raise ValueError("tunnel-client not found on PATH; install OpenAI tunnel-client or pass --tunnel-client")
+
+    _validate_loopback_host(host)
+
+    return GatewayConfig(
+        data_repo=data_repo,
+        trails_dir=trails_dir,
+        host=host,
+        port=port,
+        mcp_path=mcp_path,
+        profile=profile,
+        tunnel_client=tunnel_client or tunnel_client_arg,
+        trust_gate_env=trust_gate_env,
+    )
+
+
+def _runtime_env(config: GatewayConfig) -> dict[str, str]:
+    env = os.environ.copy()
+    env["FAVA_TRAILS_DATA_REPO"] = str(config.data_repo)
+    env.setdefault("FAVA_TRAILS_SCOPE_HINT", "")
+    env.setdefault("FAVA_TRAILS_LOG_DIR", str(config.data_repo / "logs"))
+    return env
+
+
+def _wait_for_health(url: str, process: subprocess.Popen, *, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise subprocess.SubprocessError("private MCP runtime exited before becoming ready")
+        try:
+            with urllib.request.urlopen(url, timeout=0.5) as response:
+                if response.status == 200:
+                    return
+        except (OSError, urllib.error.URLError) as exc:
+            last_error = exc
+        time.sleep(0.1)
+    raise TimeoutError(f"timed out waiting for private MCP runtime at {url}: {last_error}")
+
+
+def _start_http_runtime(config: GatewayConfig, *, stdout=None, stderr=None) -> subprocess.Popen:
+    command = [
+        sys.executable,
+        "-m",
+        "fava_trails.tunnel_cli",
+        "_serve-http",
+        "--data-repo",
+        str(config.data_repo),
+        "--host",
+        config.host,
+        "--port",
+        str(config.port),
+        "--mcp-path",
+        config.mcp_path,
+    ]
+    return subprocess.Popen(
+        command,
+        env=_runtime_env(config),
+        stdout=stdout,
+        stderr=stderr,
+        start_new_session=os.name != "nt",
+    )
+
+
+def _run_tunnel_doctor(config: GatewayConfig) -> None:
+    result = subprocess.run(
+        [config.tunnel_client, "doctor", "--profile", config.profile, "--explain"],
+        check=False,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise subprocess.SubprocessError(
+            f"tunnel-client doctor failed for profile {config.profile!r}"
+        )
+
+
+def _start_tunnel_client(config: GatewayConfig) -> subprocess.Popen:
+    return subprocess.Popen(
+        [config.tunnel_client, "run", "--profile", config.profile],
+        start_new_session=os.name != "nt",
+    )
+
+
+def _terminate_process(process: subprocess.Popen, *, timeout: float = 5.0) -> None:
+    if process.poll() is not None:
+        return
+    pid = process.pid
+    if os.name != "nt":
+        try:
+            os.killpg(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+        except PermissionError:
+            process.terminate()
+    else:
+        process.terminate()
+    try:
+        process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        if os.name != "nt":
+            try:
+                os.killpg(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                return
+            process.wait(timeout=timeout)
+        else:
+            process.kill()
+            process.wait(timeout=timeout)
+
+
+def _write_metadata(state_dir: Path, config: GatewayConfig, *, pid: int) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "pid": pid,
+        "data_repo": str(config.data_repo),
+        "trails_dir": str(config.trails_dir),
+        "mcp_url": config.mcp_url,
+        "health_url": config.health_url,
+        "profile": config.profile,
+        "log_file": str(_log_file(state_dir)),
+    }
+    _metadata_file(state_dir).write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def _write_ready(state_dir: Path, config: GatewayConfig, *, tunnel_pid: int) -> None:
+    payload = {
+        "status": "ready",
+        "tunnel_pid": tunnel_pid,
+        "mcp_url": config.mcp_url,
+        "profile": config.profile,
+        "ready_at": time.time(),
+    }
+    _ready_file(state_dir).write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def _print_startup(config: GatewayConfig, *, state_dir: Path | None = None) -> None:
+    print("FAVA Trails ChatGPT tunnel gateway")
+    print(f"  Data repo:  {config.data_repo}")
+    print(f"  Trails dir: {config.trails_dir}")
+    print(f"  MCP URL:    {config.mcp_url}")
+    print(f"  Tunnel:     OpenAI Secure MCP Tunnel profile {config.profile!r}")
+    if state_dir:
+        print(f"  State:      {state_dir}")
+        print(f"  Log:        {_log_file(state_dir)}")
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    http_process: subprocess.Popen | None = None
+    tunnel_process: subprocess.Popen | None = None
+    try:
+        config = _load_gateway_config(args)
+        _check_port_available(config.host, config.port)
+        state_dir = Path(args.state_dir).expanduser().resolve() if getattr(args, "state_dir", None) else None
+        if state_dir:
+            try:
+                _ready_file(state_dir).unlink()
+            except FileNotFoundError:
+                pass
+            _write_metadata(state_dir, config, pid=os.getpid())
+            _pid_file(state_dir).write_text(f"{os.getpid()}\n")
+        _print_startup(config, state_dir=state_dir)
+
+        http_process = _start_http_runtime(config)
+        _wait_for_health(config.health_url, http_process, timeout=args.ready_timeout)
+        print("  Private MCP runtime: ready")
+
+        if not getattr(args, "skip_tunnel_doctor", False):
+            _run_tunnel_doctor(config)
+            print("  tunnel-client doctor: ok")
+
+        tunnel_process = _start_tunnel_client(config)
+        if state_dir:
+            _write_ready(state_dir, config, tunnel_pid=tunnel_process.pid)
+        print(f"  tunnel-client: running (pid {tunnel_process.pid})")
+        return tunnel_process.wait()
+    except KeyboardInterrupt:
+        print("\nStopping FAVA Trails tunnel gateway.")
+        return 0
+    except (OSError, ValueError, subprocess.SubprocessError, TimeoutError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        if tunnel_process is not None:
+            _terminate_process(tunnel_process)
+        if http_process is not None:
+            _terminate_process(http_process)
+        state_dir_value = getattr(args, "state_dir", None)
+        if state_dir_value:
+            state_dir = Path(state_dir_value).expanduser().resolve()
+            try:
+                _pid_file(state_dir).unlink()
+            except FileNotFoundError:
+                pass
+
+
+def cmd_start(args: argparse.Namespace) -> int:
+    try:
+        config = _load_gateway_config(args)
+        _check_port_available(config.host, config.port)
+        state_dir = _state_dir(config.data_repo, config.profile)
+        pid_path = _pid_file(state_dir)
+        existing_pid = _read_pid(pid_path)
+        if existing_pid and _is_pid_running(existing_pid):
+            print(f"Gateway already running (pid {existing_pid})")
+            return 0
+
+        state_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            _ready_file(state_dir).unlink()
+        except FileNotFoundError:
+            pass
+        log_path = _log_file(state_dir)
+        log = log_path.open("ab")
+        command = [
+            sys.executable,
+            "-m",
+            "fava_trails.tunnel_cli",
+            "run",
+            "--data-repo",
+            str(config.data_repo),
+            "--profile",
+            config.profile,
+            "--host",
+            config.host,
+            "--port",
+            str(config.port),
+            "--mcp-path",
+            config.mcp_path,
+            "--tunnel-client",
+            config.tunnel_client,
+            "--ready-timeout",
+            str(args.ready_timeout),
+            "--state-dir",
+            str(state_dir),
+        ]
+        process = subprocess.Popen(
+            command,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            env=_runtime_env(config),
+            start_new_session=os.name != "nt",
+        )
+        log.close()
+        pid_path.write_text(f"{process.pid}\n")
+        _write_metadata(state_dir, config, pid=process.pid)
+
+        deadline = time.monotonic() + args.ready_timeout
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                print(f"Error: gateway exited during startup; see {log_path}", file=sys.stderr)
+                return 1
+            if _ready_file(state_dir).is_file():
+                _print_startup(config, state_dir=state_dir)
+                print(f"  Supervisor PID: {process.pid}")
+                return 0
+            time.sleep(0.1)
+        print(f"Error: timed out waiting for gateway startup; see {log_path}", file=sys.stderr)
+        return 1
+    except (OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    try:
+        config = _load_gateway_config(args, require_tunnel_client=False)
+        state_dir = _state_dir(config.data_repo, config.profile)
+        pid = _read_pid(_pid_file(state_dir))
+        if pid and _is_pid_running(pid):
+            print(f"Gateway running (pid {pid})")
+            print(f"  State: {state_dir}")
+            print(f"  Log:   {_log_file(state_dir)}")
+            return 0
+        print("Gateway not running")
+        print(f"  State: {state_dir}")
+        return 1
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def cmd_stop(args: argparse.Namespace) -> int:
+    try:
+        config = _load_gateway_config(args, require_tunnel_client=False)
+        state_dir = _state_dir(config.data_repo, config.profile)
+        pid_path = _pid_file(state_dir)
+        pid = _read_pid(pid_path)
+        if not pid or not _is_pid_running(pid):
+            print("Gateway not running")
+            return 0
+        if os.name != "nt":
+            os.killpg(pid, signal.SIGTERM)
+        else:
+            os.kill(pid, signal.SIGTERM)
+        deadline = time.monotonic() + args.timeout
+        while time.monotonic() < deadline:
+            if not _is_pid_running(pid):
+                break
+            time.sleep(0.1)
+        if _is_pid_running(pid):
+            if os.name != "nt":
+                os.killpg(pid, signal.SIGKILL)
+            else:
+                os.kill(pid, signal.SIGTERM)
+        try:
+            pid_path.unlink()
+        except FileNotFoundError:
+            pass
+        print(f"Stopped gateway pid {pid}")
+        return 0
+    except (OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def cmd_serve_http(args: argparse.Namespace) -> int:
+    try:
+        _validate_loopback_host(args.host)
+        os.environ["FAVA_TRAILS_DATA_REPO"] = str(_resolve_data_repo(args))
+        ConfigStore.reset()
+        from .http_runtime import run_streamable_http_server
+
+        run_streamable_http_server(host=args.host, port=args.port)
+        return 0
+    except (OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def _add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--data-repo", default=None, help="FAVA Trails data repo path (required if env is unset)")
+    parser.add_argument("--profile", default=DEFAULT_PROFILE, help=f"tunnel-client profile (default: {DEFAULT_PROFILE})")
+    parser.add_argument("--host", default=DEFAULT_HOST, help=f"Loopback host for private MCP runtime (default: {DEFAULT_HOST})")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help=f"Port for private MCP runtime (default: {DEFAULT_PORT})")
+    parser.add_argument("--mcp-path", default=DEFAULT_MCP_PATH, help=f"MCP path (default: {DEFAULT_MCP_PATH})")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="fava-trails-tunnel",
+        description="Run FAVA Trails behind OpenAI Secure MCP Tunnel.",
+    )
+    subparsers = parser.add_subparsers(dest="command", metavar="<command>")
+
+    p_run = subparsers.add_parser("run", help="Run the gateway in the foreground")
+    _add_common_args(p_run)
+    p_run.add_argument("--tunnel-client", default="tunnel-client", help="Path to tunnel-client binary")
+    p_run.add_argument("--ready-timeout", type=float, default=20.0, help="Seconds to wait for local MCP readiness")
+    p_run.add_argument("--skip-tunnel-doctor", action="store_true", help="Skip tunnel-client doctor before run")
+    p_run.add_argument("--state-dir", default=None, help=argparse.SUPPRESS)
+    p_run.set_defaults(func=cmd_run)
+
+    p_start = subparsers.add_parser("start", help="Start the gateway as a detached daemon")
+    _add_common_args(p_start)
+    p_start.add_argument("--tunnel-client", default="tunnel-client", help="Path to tunnel-client binary")
+    p_start.add_argument("--ready-timeout", type=float, default=20.0, help="Seconds to wait for local MCP readiness")
+    p_start.set_defaults(func=cmd_start)
+
+    p_stop = subparsers.add_parser("stop", help="Stop a detached gateway")
+    _add_common_args(p_stop)
+    p_stop.add_argument("--timeout", type=float, default=5.0, help="Seconds to wait before forcing stop")
+    p_stop.set_defaults(func=cmd_stop)
+
+    p_status = subparsers.add_parser("status", help="Show gateway status")
+    _add_common_args(p_status)
+    p_status.set_defaults(func=cmd_status)
+
+    return parser
+
+
+def _build_serve_http_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="fava-trails-tunnel _serve-http")
+    _add_common_args(parser)
+    parser.set_defaults(func=cmd_serve_http)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> NoReturn:
+    argv = sys.argv[1:] if argv is None else argv
+    if argv and argv[0] == "_serve-http":
+        parser = _build_serve_http_parser()
+        args = parser.parse_args(argv[1:])
+        sys.exit(args.func(args))
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        sys.exit(0)
+    sys.exit(args.func(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fava_trails/tunnel_cli.py
+++ b/src/fava_trails/tunnel_cli.py
@@ -379,6 +379,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             try:
                 _ready_file(state_dir).unlink()
             except FileNotFoundError:
+                # The ready marker is absent on first startup or after previous cleanup.
                 pass
             _write_metadata(state_dir, config, pid=os.getpid())
             _pid_file(state_dir).write_text(f"{os.getpid()}\n")
@@ -423,10 +424,12 @@ def cmd_run(args: argparse.Namespace) -> int:
             try:
                 _pid_file(state_dir).unlink()
             except FileNotFoundError:
+                # Shutdown may race with earlier cleanup that already removed the PID file.
                 pass
             try:
                 _ready_file(state_dir).unlink()
             except FileNotFoundError:
+                # The ready marker may already be absent during shutdown cleanup.
                 pass
         signal.signal(signal.SIGINT, original_sigint)
         signal.signal(signal.SIGTERM, original_sigterm)
@@ -447,6 +450,7 @@ def cmd_start(args: argparse.Namespace) -> int:
         try:
             _ready_file(state_dir).unlink()
         except FileNotFoundError:
+            # The ready marker is absent on first startup or after previous cleanup.
             pass
         log_path = _log_file(state_dir)
         log = log_path.open("ab")
@@ -555,10 +559,12 @@ def cmd_stop(args: argparse.Namespace) -> int:
         try:
             pid_path.unlink()
         except FileNotFoundError:
+            # Stop is idempotent; another cleanup path may already have removed it.
             pass
         try:
             _ready_file(state_dir).unlink()
         except FileNotFoundError:
+            # Stop is idempotent; the ready marker may already be absent.
             pass
         print(f"Stopped gateway pid {pid}")
         return 0

--- a/src/fava_trails/tunnel_cli.py
+++ b/src/fava_trails/tunnel_cli.py
@@ -376,11 +376,8 @@ def cmd_run(args: argparse.Namespace) -> int:
         _check_port_available(config.host, config.port)
         state_dir = Path(args.state_dir).expanduser().resolve() if getattr(args, "state_dir", None) else None
         if state_dir:
-            try:
-                _ready_file(state_dir).unlink()
-            except FileNotFoundError:
-                # The ready marker is absent on first startup or after previous cleanup.
-                pass
+            # The ready marker is absent on first startup or after previous cleanup.
+            _ready_file(state_dir).unlink(missing_ok=True)
             _write_metadata(state_dir, config, pid=os.getpid())
             _pid_file(state_dir).write_text(f"{os.getpid()}\n")
         _print_startup(config, state_dir=state_dir)
@@ -421,16 +418,9 @@ def cmd_run(args: argparse.Namespace) -> int:
         state_dir_value = getattr(args, "state_dir", None)
         if state_dir_value:
             state_dir = Path(state_dir_value).expanduser().resolve()
-            try:
-                _pid_file(state_dir).unlink()
-            except FileNotFoundError:
-                # Shutdown may race with earlier cleanup that already removed the PID file.
-                pass
-            try:
-                _ready_file(state_dir).unlink()
-            except FileNotFoundError:
-                # The ready marker may already be absent during shutdown cleanup.
-                pass
+            # Shutdown may race with earlier cleanup that already removed state files.
+            _pid_file(state_dir).unlink(missing_ok=True)
+            _ready_file(state_dir).unlink(missing_ok=True)
         signal.signal(signal.SIGINT, original_sigint)
         signal.signal(signal.SIGTERM, original_sigterm)
 
@@ -447,11 +437,8 @@ def cmd_start(args: argparse.Namespace) -> int:
             return 0
 
         state_dir.mkdir(parents=True, exist_ok=True)
-        try:
-            _ready_file(state_dir).unlink()
-        except FileNotFoundError:
-            # The ready marker is absent on first startup or after previous cleanup.
-            pass
+        # The ready marker is absent on first startup or after previous cleanup.
+        _ready_file(state_dir).unlink(missing_ok=True)
         log_path = _log_file(state_dir)
         log = log_path.open("ab")
         command = [
@@ -556,16 +543,9 @@ def cmd_stop(args: argparse.Namespace) -> int:
                 _terminate_pid_group(child_pid, timeout=args.timeout)
         if _is_pid_running(pid):
             _terminate_pid_group(pid, timeout=0)
-        try:
-            pid_path.unlink()
-        except FileNotFoundError:
-            # Stop is idempotent; another cleanup path may already have removed it.
-            pass
-        try:
-            _ready_file(state_dir).unlink()
-        except FileNotFoundError:
-            # Stop is idempotent; the ready marker may already be absent.
-            pass
+        # Stop is idempotent; another cleanup path may already have removed state files.
+        pid_path.unlink(missing_ok=True)
+        _ready_file(state_dir).unlink(missing_ok=True)
         print(f"Stopped gateway pid {pid}")
         return 0
     except (OSError, ValueError) as exc:

--- a/src/fava_trails/tunnel_cli.py
+++ b/src/fava_trails/tunnel_cli.py
@@ -26,7 +26,7 @@ from .config import ConfigStore
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
 DEFAULT_PROFILE = "fava-trails"
-DEFAULT_MCP_PATH = "/mcp"
+DEFAULT_MCP_PATH = "/mcp/"
 
 
 @dataclass(frozen=True)

--- a/src/fava_trails/tunnel_cli.py
+++ b/src/fava_trails/tunnel_cli.py
@@ -188,7 +188,7 @@ def _runtime_env(config: GatewayConfig) -> dict[str, str]:
     env = os.environ.copy()
     env["FAVA_TRAILS_DATA_REPO"] = str(config.data_repo)
     env.setdefault("FAVA_TRAILS_SCOPE_HINT", "")
-    env.setdefault("FAVA_TRAILS_LOG_DIR", str(config.data_repo / "logs"))
+    env.setdefault("FAVA_TRAILS_LOG_DIR", str(Path.home() / ".fava-trails" / "logs"))
     return env
 
 
@@ -390,7 +390,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         _wait_for_health(config.health_url, http_process, timeout=args.ready_timeout)
         print("  Private MCP runtime: ready")
 
-        if not getattr(args, "skip_tunnel_doctor", False):
+        if getattr(args, "tunnel_doctor", False):
             _run_tunnel_doctor(config)
             print("  tunnel-client doctor: ok")
 
@@ -472,6 +472,8 @@ def cmd_start(args: argparse.Namespace) -> int:
             "--state-dir",
             str(state_dir),
         ]
+        if getattr(args, "tunnel_doctor", False):
+            command.append("--tunnel-doctor")
         process = subprocess.Popen(
             command,
             stdout=log,
@@ -598,7 +600,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_common_args(p_run)
     p_run.add_argument("--tunnel-client", default="tunnel-client", help="Path to tunnel-client binary")
     p_run.add_argument("--ready-timeout", type=float, default=20.0, help="Seconds to wait for local MCP readiness")
-    p_run.add_argument("--skip-tunnel-doctor", action="store_true", help="Skip tunnel-client doctor before run")
+    p_run.add_argument("--tunnel-doctor", action="store_true", help="Run tunnel-client doctor before starting the tunnel")
     p_run.add_argument("--state-dir", default=None, help=argparse.SUPPRESS)
     p_run.set_defaults(func=cmd_run)
 
@@ -606,6 +608,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_common_args(p_start)
     p_start.add_argument("--tunnel-client", default="tunnel-client", help="Path to tunnel-client binary")
     p_start.add_argument("--ready-timeout", type=float, default=20.0, help="Seconds to wait for local MCP readiness")
+    p_start.add_argument("--tunnel-doctor", action="store_true", help="Run tunnel-client doctor before starting the tunnel")
     p_start.set_defaults(func=cmd_start)
 
     p_stop = subparsers.add_parser("stop", help="Stop a detached gateway")

--- a/src/fava_trails/tunnel_cli.py
+++ b/src/fava_trails/tunnel_cli.py
@@ -49,6 +49,12 @@ class GatewayConfig:
         return f"http://{self.host}:{self.port}/healthz"
 
 
+@dataclass(frozen=True)
+class GatewayIdentity:
+    data_repo: Path
+    profile: str
+
+
 def _state_home() -> Path:
     return Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state"))
 
@@ -115,10 +121,19 @@ def _resolve_data_repo(args: argparse.Namespace) -> Path:
     return Path(value).expanduser().resolve()
 
 
-def _load_gateway_config(args: argparse.Namespace, *, require_tunnel_client: bool = True) -> GatewayConfig:
+def _resolve_gateway_identity(args: argparse.Namespace) -> GatewayIdentity:
     data_repo = _resolve_data_repo(args)
     if not data_repo.is_dir():
         raise ValueError(f"data repo not found: {data_repo}")
+    return GatewayIdentity(
+        data_repo=data_repo,
+        profile=getattr(args, "profile", DEFAULT_PROFILE),
+    )
+
+
+def _load_gateway_config(args: argparse.Namespace, *, require_tunnel_client: bool = True) -> GatewayConfig:
+    identity = _resolve_gateway_identity(args)
+    data_repo = identity.data_repo
 
     config_path = data_repo / "config.yaml"
     if not config_path.is_file():
@@ -147,7 +162,7 @@ def _load_gateway_config(args: argparse.Namespace, *, require_tunnel_client: boo
     host = getattr(args, "host", DEFAULT_HOST)
     port = getattr(args, "port", DEFAULT_PORT)
     mcp_path = getattr(args, "mcp_path", DEFAULT_MCP_PATH)
-    profile = getattr(args, "profile", DEFAULT_PROFILE)
+    profile = identity.profile
     tunnel_client_arg = getattr(args, "tunnel_client", None) or "tunnel-client"
     tunnel_client = shutil.which(tunnel_client_arg) or (
         str(Path(tunnel_client_arg).expanduser()) if Path(tunnel_client_arg).expanduser().is_file() else ""
@@ -263,7 +278,48 @@ def _terminate_process(process: subprocess.Popen, *, timeout: float = 5.0) -> No
             process.wait(timeout=timeout)
 
 
-def _write_metadata(state_dir: Path, config: GatewayConfig, *, pid: int) -> None:
+def _terminate_pid_group(pid: int, *, timeout: float = 5.0) -> None:
+    if not _is_pid_running(pid):
+        return
+    if os.name != "nt":
+        try:
+            os.killpg(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+    else:
+        os.kill(pid, signal.SIGTERM)
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _is_pid_running(pid):
+            return
+        time.sleep(0.1)
+
+    if os.name != "nt":
+        try:
+            os.killpg(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+    else:
+        os.kill(pid, signal.SIGTERM)
+
+
+def _read_json_file(path: Path) -> dict:
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _write_metadata(
+    state_dir: Path,
+    config: GatewayConfig,
+    *,
+    pid: int,
+    http_pid: int | None = None,
+    tunnel_pid: int | None = None,
+) -> None:
     state_dir.mkdir(parents=True, exist_ok=True)
     payload = {
         "pid": pid,
@@ -274,12 +330,17 @@ def _write_metadata(state_dir: Path, config: GatewayConfig, *, pid: int) -> None
         "profile": config.profile,
         "log_file": str(_log_file(state_dir)),
     }
+    if http_pid is not None:
+        payload["http_pid"] = http_pid
+    if tunnel_pid is not None:
+        payload["tunnel_pid"] = tunnel_pid
     _metadata_file(state_dir).write_text(json.dumps(payload, indent=2) + "\n")
 
 
-def _write_ready(state_dir: Path, config: GatewayConfig, *, tunnel_pid: int) -> None:
+def _write_ready(state_dir: Path, config: GatewayConfig, *, http_pid: int, tunnel_pid: int) -> None:
     payload = {
         "status": "ready",
+        "http_pid": http_pid,
         "tunnel_pid": tunnel_pid,
         "mcp_url": config.mcp_url,
         "profile": config.profile,
@@ -302,7 +363,15 @@ def _print_startup(config: GatewayConfig, *, state_dir: Path | None = None) -> N
 def cmd_run(args: argparse.Namespace) -> int:
     http_process: subprocess.Popen | None = None
     tunnel_process: subprocess.Popen | None = None
+    original_sigint = signal.getsignal(signal.SIGINT)
+    original_sigterm = signal.getsignal(signal.SIGTERM)
+
+    def handle_shutdown(signum, frame):  # noqa: ARG001
+        raise KeyboardInterrupt
+
     try:
+        signal.signal(signal.SIGINT, handle_shutdown)
+        signal.signal(signal.SIGTERM, handle_shutdown)
         config = _load_gateway_config(args)
         _check_port_available(config.host, config.port)
         state_dir = Path(args.state_dir).expanduser().resolve() if getattr(args, "state_dir", None) else None
@@ -316,6 +385,8 @@ def cmd_run(args: argparse.Namespace) -> int:
         _print_startup(config, state_dir=state_dir)
 
         http_process = _start_http_runtime(config)
+        if state_dir:
+            _write_metadata(state_dir, config, pid=os.getpid(), http_pid=http_process.pid)
         _wait_for_health(config.health_url, http_process, timeout=args.ready_timeout)
         print("  Private MCP runtime: ready")
 
@@ -325,7 +396,14 @@ def cmd_run(args: argparse.Namespace) -> int:
 
         tunnel_process = _start_tunnel_client(config)
         if state_dir:
-            _write_ready(state_dir, config, tunnel_pid=tunnel_process.pid)
+            _write_metadata(
+                state_dir,
+                config,
+                pid=os.getpid(),
+                http_pid=http_process.pid,
+                tunnel_pid=tunnel_process.pid,
+            )
+            _write_ready(state_dir, config, http_pid=http_process.pid, tunnel_pid=tunnel_process.pid)
         print(f"  tunnel-client: running (pid {tunnel_process.pid})")
         return tunnel_process.wait()
     except KeyboardInterrupt:
@@ -346,6 +424,12 @@ def cmd_run(args: argparse.Namespace) -> int:
                 _pid_file(state_dir).unlink()
             except FileNotFoundError:
                 pass
+            try:
+                _ready_file(state_dir).unlink()
+            except FileNotFoundError:
+                pass
+        signal.signal(signal.SIGINT, original_sigint)
+        signal.signal(signal.SIGTERM, original_sigterm)
 
 
 def cmd_start(args: argparse.Namespace) -> int:
@@ -418,8 +502,8 @@ def cmd_start(args: argparse.Namespace) -> int:
 
 def cmd_status(args: argparse.Namespace) -> int:
     try:
-        config = _load_gateway_config(args, require_tunnel_client=False)
-        state_dir = _state_dir(config.data_repo, config.profile)
+        identity = _resolve_gateway_identity(args)
+        state_dir = _state_dir(identity.data_repo, identity.profile)
         pid = _read_pid(_pid_file(state_dir))
         if pid and _is_pid_running(pid):
             print(f"Gateway running (pid {pid})")
@@ -436,29 +520,42 @@ def cmd_status(args: argparse.Namespace) -> int:
 
 def cmd_stop(args: argparse.Namespace) -> int:
     try:
-        config = _load_gateway_config(args, require_tunnel_client=False)
-        state_dir = _state_dir(config.data_repo, config.profile)
+        identity = _resolve_gateway_identity(args)
+        state_dir = _state_dir(identity.data_repo, identity.profile)
         pid_path = _pid_file(state_dir)
         pid = _read_pid(pid_path)
         if not pid or not _is_pid_running(pid):
             print("Gateway not running")
             return 0
-        if os.name != "nt":
-            os.killpg(pid, signal.SIGTERM)
-        else:
-            os.kill(pid, signal.SIGTERM)
+        metadata = _read_json_file(_metadata_file(state_dir))
+        ready = _read_json_file(_ready_file(state_dir))
+        child_pids = [
+            value
+            for value in (
+                metadata.get("tunnel_pid"),
+                metadata.get("http_pid"),
+                ready.get("tunnel_pid"),
+                ready.get("http_pid"),
+            )
+            if isinstance(value, int) and value > 0
+        ]
+        _terminate_pid_group(pid, timeout=args.timeout)
         deadline = time.monotonic() + args.timeout
         while time.monotonic() < deadline:
             if not _is_pid_running(pid):
                 break
             time.sleep(0.1)
+        for child_pid in dict.fromkeys(child_pids):
+            if child_pid != pid:
+                _terminate_pid_group(child_pid, timeout=args.timeout)
         if _is_pid_running(pid):
-            if os.name != "nt":
-                os.killpg(pid, signal.SIGKILL)
-            else:
-                os.kill(pid, signal.SIGTERM)
+            _terminate_pid_group(pid, timeout=0)
         try:
             pid_path.unlink()
+        except FileNotFoundError:
+            pass
+        try:
+            _ready_file(state_dir).unlink()
         except FileNotFoundError:
             pass
         print(f"Stopped gateway pid {pid}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -259,6 +259,8 @@ def test_bootstrap_prints_integration_hint(tmp_path, capsys):
     assert rc == 0
     captured = capsys.readouterr()
     assert "fava-trails integrate codev" in captured.out
+    assert "fava-trails-tunnel start" in captured.out
+    assert "tunnel-client init" in captured.out
 
 
 def test_bootstrap_with_remote(tmp_path):

--- a/tests/test_server_instructions.py
+++ b/tests/test_server_instructions.py
@@ -1,14 +1,16 @@
 """Tests for MCP server instructions field and tool description enhancements."""
 
-import json
-
+import jsonschema
 import pytest
 from mcp.types import TextContent
 
+from fava_trails.config import ConfigStore
 from fava_trails.server import (
     TOOL_DEFINITIONS,
     _build_server_instructions,
     _load_usage_guide,
+    handle_call_tool,
+    handle_list_tools,
     server,
     with_tool_timeout,
 )
@@ -115,6 +117,98 @@ class TestToolDescriptionEnhancements:
         assert "new to fava-trails" in desc or "unsure how to use" in desc
 
 
+class TestToolMetadata:
+    """Tests for ChatGPT-facing tool schemas and annotations."""
+
+    def test_all_tools_have_output_schema(self):
+        """Every advertised tool must declare an output schema."""
+        for td in TOOL_DEFINITIONS:
+            assert "outputSchema" in td, td["name"]
+            assert td["outputSchema"]["type"] == "object"
+
+    def test_all_tools_have_annotations(self):
+        """Every advertised tool must include MCP tool annotations."""
+        for td in TOOL_DEFINITIONS:
+            annotations = td.get("annotations")
+            assert isinstance(annotations, dict), td["name"]
+            assert "readOnlyHint" in annotations
+            assert "destructiveHint" in annotations
+            assert "openWorldHint" in annotations
+
+    def test_read_only_tools_are_annotated(self):
+        """Read-only query tools must be marked read-only for ChatGPT."""
+        read_only = {
+            "conflicts",
+            "diff",
+            "get_thought",
+            "get_usage_guide",
+            "list_scopes",
+            "list_trails",
+            "recall",
+        }
+        for td in TOOL_DEFINITIONS:
+            if td["name"] in read_only:
+                assert td["annotations"]["readOnlyHint"] is True
+                assert td["annotations"]["idempotentHint"] is True
+
+    def test_destructive_tools_are_annotated(self):
+        """Mutation tools with replacement/rollback semantics must be flagged."""
+        destructive = {"change_scope", "forget", "rollback", "supersede", "update_thought"}
+        for td in TOOL_DEFINITIONS:
+            if td["name"] in destructive:
+                assert td["annotations"]["destructiveHint"] is True
+
+    @pytest.mark.asyncio
+    async def test_handle_list_tools_passes_metadata_to_mcp_tool(self):
+        """ListTools responses must expose schemas and annotations."""
+        tools = await handle_list_tools()
+        by_name = {tool.name: tool for tool in tools}
+
+        recall = by_name["recall"]
+        assert recall.outputSchema
+        assert recall.outputSchema["required"] == ["status", "count", "thoughts", "filters"]
+        assert recall.annotations
+        assert recall.annotations.readOnlyHint is True
+
+        save_thought = by_name["save_thought"]
+        assert save_thought.outputSchema
+        assert save_thought.annotations
+        assert save_thought.annotations.readOnlyHint is False
+        assert save_thought.annotations.openWorldHint is True
+
+    @pytest.mark.asyncio
+    async def test_list_scopes_returns_structured_schema_valid_result(self, tmp_path, monkeypatch):
+        """JSON tools return structured dicts matching their output schema."""
+        data_repo = tmp_path / "fava-trails-data"
+        thoughts_dir = data_repo / "trails" / "mwai" / "eng" / "demo" / "thoughts"
+        thoughts_dir.mkdir(parents=True)
+        monkeypatch.setenv("FAVA_TRAILS_DATA_REPO", str(data_repo))
+        ConfigStore.reset()
+
+        result = await handle_call_tool("list_scopes", {"prefix": "mwai/eng"})
+
+        assert result["status"] == "ok"
+        assert result["scopes"] == [{"path": "mwai/eng/demo"}]
+        jsonschema.validate(
+            result,
+            next(td["outputSchema"] for td in TOOL_DEFINITIONS if td["name"] == "list_scopes"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_usage_guide_returns_text_and_structured_content(self):
+        """Markdown guide keeps text content and adds structured content."""
+        content, structured = await handle_call_tool("get_usage_guide", {})
+
+        assert len(content) == 1
+        assert isinstance(content[0], TextContent)
+        assert structured["status"] == "ok"
+        assert structured["content"] == content[0].text
+        jsonschema.validate(
+            structured,
+            next(td["outputSchema"] for td in TOOL_DEFINITIONS if td["name"] == "get_usage_guide"),
+        )
+
+
 class TestGetUsageGuide:
     """Tests for the get_usage_guide tool."""
 
@@ -183,10 +277,9 @@ class TestWithToolTimeout:
 
         wrapped = with_tool_timeout(_hanging_handler)
         result = await wrapped("sync", {})
-        payload = json.loads(result[0].text)
-        assert payload["status"] == "error"
-        assert "timed out" in payload["message"].lower()
-        assert "sync" in payload["message"]
+        assert result["status"] == "error"
+        assert "timed out" in result["message"].lower()
+        assert "sync" in result["message"]
 
     @pytest.mark.asyncio
     async def test_disabled_when_zero(self):

--- a/tests/test_server_instructions.py
+++ b/tests/test_server_instructions.py
@@ -124,7 +124,7 @@ class TestToolMetadata:
         """Every advertised tool must declare an output schema."""
         for td in TOOL_DEFINITIONS:
             assert "outputSchema" in td, td["name"]
-            assert td["outputSchema"]["type"] == "object"
+            assert td["outputSchema"].get("type") == "object" or "anyOf" in td["outputSchema"]
 
     def test_all_tools_have_annotations(self):
         """Every advertised tool must include MCP tool annotations."""
@@ -166,7 +166,12 @@ class TestToolMetadata:
 
         recall = by_name["recall"]
         assert recall.outputSchema
-        assert recall.outputSchema["required"] == ["status", "count", "thoughts", "filters"]
+        assert recall.outputSchema["anyOf"][0]["required"] == [
+            "status",
+            "count",
+            "thoughts",
+            "filters",
+        ]
         assert recall.annotations
         assert recall.annotations.readOnlyHint is True
 
@@ -175,6 +180,24 @@ class TestToolMetadata:
         assert save_thought.annotations
         assert save_thought.annotations.readOnlyHint is False
         assert save_thought.annotations.openWorldHint is True
+
+    def test_all_tool_schemas_accept_common_error_result(self):
+        """Structured error payloads must not be hidden by output validation."""
+        payload = {"status": "error", "message": "simulated failure"}
+
+        for td in TOOL_DEFINITIONS:
+            jsonschema.validate(payload, td["outputSchema"])
+
+    def test_tool_specific_schemas_accept_blocked_result(self):
+        """Blocked/conflict responses should still satisfy structured schemas."""
+        payload = {
+            "status": "blocked",
+            "message": "operation blocked",
+            "conflicts": [{"file": "thoughts/example.md", "description": "conflict"}],
+        }
+
+        for td in TOOL_DEFINITIONS:
+            jsonschema.validate(payload, td["outputSchema"])
 
     @pytest.mark.asyncio
     async def test_list_scopes_returns_structured_schema_valid_result(self, tmp_path, monkeypatch):

--- a/tests/test_tunnel_cli.py
+++ b/tests/test_tunnel_cli.py
@@ -21,6 +21,7 @@ from fava_trails.tunnel_cli import (
     cmd_run,
     cmd_start,
     cmd_status,
+    cmd_stop,
 )
 
 
@@ -155,14 +156,81 @@ def test_start_writes_state_and_pid(tmp_path, monkeypatch, capsys):
 
 def test_status_reports_not_running_for_missing_pid(tmp_path, monkeypatch, capsys):
     data_repo = _make_data_repo(tmp_path)
-    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
 
-    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+    with patch("fava_trails.tunnel_cli._load_gateway_config", side_effect=AssertionError):
         rc = cmd_status(_args(data_repo=str(data_repo)))
 
     assert rc == 1
     assert "not running" in capsys.readouterr().out
+
+
+def test_stop_does_not_require_startup_only_environment(tmp_path, monkeypatch, capsys):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    state_dir = tunnel_cli._state_dir(data_repo.resolve(), DEFAULT_PROFILE)
+    state_dir.mkdir(parents=True)
+    tunnel_cli._pid_file(state_dir).write_text("4321\n")
+
+    with patch("fava_trails.tunnel_cli._load_gateway_config", side_effect=AssertionError):
+        with patch("fava_trails.tunnel_cli._is_pid_running", side_effect=[True, False, False]):
+            with patch("fava_trails.tunnel_cli._terminate_pid_group") as terminate_pid_group:
+                rc = cmd_stop(_args(data_repo=str(data_repo), timeout=0.01))
+
+    assert rc == 0
+    terminate_pid_group.assert_called_once_with(4321, timeout=0.01)
+    assert "Stopped gateway pid 4321" in capsys.readouterr().out
+
+
+def test_stop_terminates_recorded_child_process_groups(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    state_dir = tunnel_cli._state_dir(data_repo.resolve(), DEFAULT_PROFILE)
+    state_dir.mkdir(parents=True)
+    tunnel_cli._pid_file(state_dir).write_text("4321\n")
+    tunnel_cli._metadata_file(state_dir).write_text('{"pid":4321,"http_pid":111,"tunnel_pid":222}\n')
+    tunnel_cli._ready_file(state_dir).write_text('{"status":"ready","http_pid":111,"tunnel_pid":222}\n')
+
+    with patch("fava_trails.tunnel_cli._is_pid_running", side_effect=[True, False, False]):
+        with patch("fava_trails.tunnel_cli._terminate_pid_group") as terminate_pid_group:
+            rc = cmd_stop(_args(data_repo=str(data_repo), timeout=0.01))
+
+    assert rc == 0
+    assert [call.args[0] for call in terminate_pid_group.call_args_list] == [4321, 222, 111]
+    assert not tunnel_cli._ready_file(state_dir).exists()
+
+
+def test_run_cleans_children_when_interrupted(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    args = _args(data_repo=str(data_repo))
+
+    http_process = MagicMock()
+    http_process.poll.return_value = None
+    http_process.pid = 111
+    tunnel_process = MagicMock()
+    tunnel_process.wait.side_effect = KeyboardInterrupt
+    tunnel_process.poll.return_value = None
+    tunnel_process.pid = 222
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with patch("fava_trails.tunnel_cli._check_port_available"):
+                with patch("fava_trails.tunnel_cli._start_http_runtime", return_value=http_process):
+                    with patch("fava_trails.tunnel_cli._wait_for_health"):
+                        with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+                            with patch("fava_trails.tunnel_cli._start_tunnel_client", return_value=tunnel_process):
+                                with patch("fava_trails.tunnel_cli._terminate_process") as terminate_process:
+                                    rc = cmd_run(args)
+
+    assert rc == 0
+    assert [call.args[0] for call in terminate_process.call_args_list] == [
+        tunnel_process,
+        http_process,
+    ]
 
 
 def test_tunnel_cli_help_mentions_start():

--- a/tests/test_tunnel_cli.py
+++ b/tests/test_tunnel_cli.py
@@ -1,0 +1,193 @@
+"""Tests for the fava-trails-tunnel CLI."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from fava_trails import tunnel_cli
+from fava_trails.config import ConfigStore
+from fava_trails.http_runtime import create_streamable_http_app
+from fava_trails.tunnel_cli import (
+    DEFAULT_HOST,
+    DEFAULT_MCP_PATH,
+    DEFAULT_PORT,
+    DEFAULT_PROFILE,
+    _load_gateway_config,
+    cmd_run,
+    cmd_start,
+    cmd_status,
+)
+
+
+def _args(**overrides):
+    values = {
+        "data_repo": None,
+        "profile": DEFAULT_PROFILE,
+        "host": DEFAULT_HOST,
+        "port": DEFAULT_PORT,
+        "mcp_path": DEFAULT_MCP_PATH,
+        "tunnel_client": "tunnel-client",
+        "ready_timeout": 0.1,
+        "skip_tunnel_doctor": False,
+        "state_dir": None,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _make_data_repo(tmp_path: Path, *, openrouter_env: str = "OPENROUTER_API_KEY") -> Path:
+    data_repo = tmp_path / "fava-trails-data"
+    data_repo.mkdir()
+    (data_repo / "trails").mkdir()
+    (data_repo / "config.yaml").write_text(
+        f"trails_dir: trails\nopenrouter_api_key_env: {openrouter_env}\n"
+    )
+    return data_repo
+
+
+def test_load_gateway_config_requires_explicit_data_repo(monkeypatch):
+    monkeypatch.delenv("FAVA_TRAILS_DATA_REPO", raising=False)
+
+    with pytest.raises(ValueError, match="FAVA_TRAILS_DATA_REPO is required"):
+        _load_gateway_config(_args())
+
+
+def test_load_gateway_config_validates_trust_gate_env(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
+                _load_gateway_config(_args(data_repo=str(data_repo)))
+
+
+def test_load_gateway_config_builds_loopback_mcp_url(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            config = _load_gateway_config(_args(data_repo=str(data_repo)))
+
+    assert config.data_repo == data_repo.resolve()
+    assert config.trails_dir == data_repo / "trails"
+    assert config.mcp_url == "http://127.0.0.1:8765/mcp"
+    assert config.profile == "fava-trails"
+
+
+def test_load_gateway_config_rejects_non_loopback_host(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with pytest.raises(ValueError, match="loopback"):
+                _load_gateway_config(_args(data_repo=str(data_repo), host="0.0.0.0"))
+
+
+def test_run_starts_http_checks_doctor_and_runs_tunnel(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    args = _args(data_repo=str(data_repo))
+
+    http_process = MagicMock()
+    http_process.poll.return_value = None
+    http_process.pid = 111
+    tunnel_process = MagicMock()
+    tunnel_process.wait.return_value = 0
+    tunnel_process.poll.return_value = 0
+    tunnel_process.pid = 222
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with patch("fava_trails.tunnel_cli._check_port_available"):
+                with patch("fava_trails.tunnel_cli._start_http_runtime", return_value=http_process) as start_http:
+                    with patch("fava_trails.tunnel_cli._wait_for_health") as wait_health:
+                        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as run:
+                            with patch("fava_trails.tunnel_cli._start_tunnel_client", return_value=tunnel_process) as start_tunnel:
+                                rc = cmd_run(args)
+
+    assert rc == 0
+    start_http.assert_called_once()
+    wait_health.assert_called_once()
+    run.assert_called_once()
+    start_tunnel.assert_called_once()
+
+
+def test_start_writes_state_and_pid(tmp_path, monkeypatch, capsys):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    args = _args(data_repo=str(data_repo))
+
+    process = MagicMock()
+    process.pid = 4321
+    process.poll.return_value = None
+
+    state_dir = tunnel_cli._state_dir(data_repo.resolve(), DEFAULT_PROFILE)
+
+    def fake_popen(*args, **kwargs):
+        state_dir.mkdir(parents=True, exist_ok=True)
+        tunnel_cli._ready_file(state_dir).write_text('{"status":"ready"}\n')
+        return process
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with patch("fava_trails.tunnel_cli._check_port_available"):
+                with patch("subprocess.Popen", side_effect=fake_popen):
+                    rc = cmd_start(args)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "OpenAI Secure MCP Tunnel" in out
+    assert "Supervisor PID: 4321" in out
+    state_dirs = list((tmp_path / "state" / "fava-trails" / "tunnel").iterdir())
+    assert len(state_dirs) == 1
+    assert (state_dirs[0] / "supervisor.pid").read_text() == "4321\n"
+    assert "http://127.0.0.1:8765/mcp" in (state_dirs[0] / "metadata.json").read_text()
+
+
+def test_status_reports_not_running_for_missing_pid(tmp_path, monkeypatch, capsys):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        rc = cmd_status(_args(data_repo=str(data_repo)))
+
+    assert rc == 1
+    assert "not running" in capsys.readouterr().out
+
+
+def test_tunnel_cli_help_mentions_start():
+    parser = tunnel_cli.build_parser()
+    help_text = parser.format_help()
+    assert "start" in help_text
+    assert "run" in help_text
+
+
+def test_http_runtime_healthz_reports_data_repo(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("FAVA_TRAILS_DATA_REPO", str(data_repo))
+    ConfigStore.reset()
+
+    async def noop_init_server():
+        return None
+
+    with patch("fava_trails.server._init_server", new=noop_init_server):
+        app = create_streamable_http_app()
+        with TestClient(app) as client:
+            response = client.get("/healthz")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["runtime"] == "fava-trails-tunnel"
+    assert payload["data_repo"] == str(data_repo)
+    assert payload["trails_dir"] == str(data_repo / "trails")

--- a/tests/test_tunnel_cli.py
+++ b/tests/test_tunnel_cli.py
@@ -79,7 +79,7 @@ def test_load_gateway_config_builds_loopback_mcp_url(tmp_path, monkeypatch):
 
     assert config.data_repo == data_repo.resolve()
     assert config.trails_dir == data_repo / "trails"
-    assert config.mcp_url == "http://127.0.0.1:8765/mcp"
+    assert config.mcp_url == "http://127.0.0.1:8765/mcp/"
     assert config.profile == "fava-trails"
 
 
@@ -194,7 +194,7 @@ def test_start_writes_state_and_pid(tmp_path, monkeypatch, capsys):
     state_dirs = list((tmp_path / "state" / "fava-trails" / "tunnel").iterdir())
     assert len(state_dirs) == 1
     assert (state_dirs[0] / "supervisor.pid").read_text() == "4321\n"
-    assert "http://127.0.0.1:8765/mcp" in (state_dirs[0] / "metadata.json").read_text()
+    assert "http://127.0.0.1:8765/mcp/" in (state_dirs[0] / "metadata.json").read_text()
 
 
 def test_start_passes_tunnel_doctor_to_supervisor_when_requested(tmp_path, monkeypatch):

--- a/tests/test_tunnel_cli.py
+++ b/tests/test_tunnel_cli.py
@@ -18,6 +18,7 @@ from fava_trails.tunnel_cli import (
     DEFAULT_PORT,
     DEFAULT_PROFILE,
     _load_gateway_config,
+    _runtime_env,
     cmd_run,
     cmd_start,
     cmd_status,
@@ -34,7 +35,7 @@ def _args(**overrides):
         "mcp_path": DEFAULT_MCP_PATH,
         "tunnel_client": "tunnel-client",
         "ready_timeout": 0.1,
-        "skip_tunnel_doctor": False,
+        "tunnel_doctor": False,
         "state_dir": None,
     }
     values.update(overrides)
@@ -92,7 +93,23 @@ def test_load_gateway_config_rejects_non_loopback_host(tmp_path, monkeypatch):
                 _load_gateway_config(_args(data_repo=str(data_repo), host="0.0.0.0"))
 
 
-def test_run_starts_http_checks_doctor_and_runs_tunnel(tmp_path, monkeypatch):
+def test_runtime_env_uses_user_log_dir_by_default(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    monkeypatch.delenv("FAVA_TRAILS_LOG_DIR", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            config = _load_gateway_config(_args(data_repo=str(data_repo)))
+
+    env = _runtime_env(config)
+
+    assert env["FAVA_TRAILS_DATA_REPO"] == str(data_repo.resolve())
+    assert env["FAVA_TRAILS_LOG_DIR"] == str(Path.home() / ".fava-trails" / "logs")
+
+
+def test_run_starts_http_and_runs_tunnel_without_doctor_by_default(tmp_path, monkeypatch):
     data_repo = _make_data_repo(tmp_path)
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     args = _args(data_repo=str(data_repo))
@@ -110,15 +127,41 @@ def test_run_starts_http_checks_doctor_and_runs_tunnel(tmp_path, monkeypatch):
             with patch("fava_trails.tunnel_cli._check_port_available"):
                 with patch("fava_trails.tunnel_cli._start_http_runtime", return_value=http_process) as start_http:
                     with patch("fava_trails.tunnel_cli._wait_for_health") as wait_health:
-                        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as run:
+                        with patch("subprocess.run") as run:
                             with patch("fava_trails.tunnel_cli._start_tunnel_client", return_value=tunnel_process) as start_tunnel:
                                 rc = cmd_run(args)
 
     assert rc == 0
     start_http.assert_called_once()
     wait_health.assert_called_once()
-    run.assert_called_once()
+    run.assert_not_called()
     start_tunnel.assert_called_once()
+
+
+def test_run_checks_doctor_when_requested(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    args = _args(data_repo=str(data_repo), tunnel_doctor=True)
+
+    http_process = MagicMock()
+    http_process.poll.return_value = None
+    http_process.pid = 111
+    tunnel_process = MagicMock()
+    tunnel_process.wait.return_value = 0
+    tunnel_process.poll.return_value = 0
+    tunnel_process.pid = 222
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with patch("fava_trails.tunnel_cli._check_port_available"):
+                with patch("fava_trails.tunnel_cli._start_http_runtime", return_value=http_process):
+                    with patch("fava_trails.tunnel_cli._wait_for_health"):
+                        with patch("subprocess.run", return_value=MagicMock(returncode=0)) as run:
+                            with patch("fava_trails.tunnel_cli._start_tunnel_client", return_value=tunnel_process):
+                                rc = cmd_run(args)
+
+    assert rc == 0
+    run.assert_called_once()
 
 
 def test_start_writes_state_and_pid(tmp_path, monkeypatch, capsys):
@@ -152,6 +195,33 @@ def test_start_writes_state_and_pid(tmp_path, monkeypatch, capsys):
     assert len(state_dirs) == 1
     assert (state_dirs[0] / "supervisor.pid").read_text() == "4321\n"
     assert "http://127.0.0.1:8765/mcp" in (state_dirs[0] / "metadata.json").read_text()
+
+
+def test_start_passes_tunnel_doctor_to_supervisor_when_requested(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    args = _args(data_repo=str(data_repo), tunnel_doctor=True)
+
+    process = MagicMock()
+    process.pid = 4321
+    process.poll.return_value = None
+
+    state_dir = tunnel_cli._state_dir(data_repo.resolve(), DEFAULT_PROFILE)
+
+    def fake_popen(command, *args, **kwargs):
+        state_dir.mkdir(parents=True, exist_ok=True)
+        tunnel_cli._ready_file(state_dir).write_text('{"status":"ready"}\n')
+        assert "--tunnel-doctor" in command
+        return process
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with patch("fava_trails.tunnel_cli._check_port_available"):
+                with patch("subprocess.Popen", side_effect=fake_popen):
+                    rc = cmd_start(args)
+
+    assert rc == 0
 
 
 def test_status_reports_not_running_for_missing_pid(tmp_path, monkeypatch, capsys):

--- a/uv.lock
+++ b/uv.lock
@@ -486,6 +486,8 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-ulid" },
     { name = "pyyaml" },
+    { name = "starlette" },
+    { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
@@ -539,6 +541,8 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "python-ulid", specifier = ">=3.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "starlette", specifier = ">=0.52.0" },
+    { name = "uvicorn", specifier = ">=0.41.0" },
 ]
 provides-extras = ["bedrock", "groq", "anthropic", "gemini", "mistral", "ollama", "secom", "all"]
 


### PR DESCRIPTION
## Summary

- Add `fava-trails-tunnel` for running a repo-owned ChatGPT gateway behind OpenAI Secure MCP Tunnel.
- Add a loopback Streamable HTTP MCP runtime at `/mcp` with `/healthz` readiness context.
- Validate explicit data repo, JJ, Trust Gate provider config, loopback binding, port availability, and `tunnel-client` profile health before running the tunnel.
- Advertise the tunnel startup command from data repo bootstrap/clone output.

Closes #64

## Validation

- `uv run ruff check`
- `uv run pytest -q` (`651 passed`, one Starlette `TestClient` deprecation warning)
