### PR TITLE
chore: bump version to 0.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to FAVA Trails are documented here.
 
 ## Unreleased
 
+## [0.5.8] — 2026-07-08
+
 ### Added
 - `fava-trails rich-view generate --scope <path> --out <dir>`: generates a minimal plain-Astro static reader from FAVA trail thought records (ULID routes, derived titles, snapshot metadata). Implements #52.
 - `fava-trails rich-view serve`: generates or reuses the local FAVA reader and serves it on a loopback-only Astro dev server, defaulting to all discovered scopes while preserving `/id/<UID>/` routes. Implements #53.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ All notable changes to FAVA Trails are documented here.
 ### Added
 - `fava-trails rich-view generate --scope <path> --out <dir>`: generates a minimal plain-Astro static reader from FAVA trail thought records (ULID routes, derived titles, snapshot metadata). Implements #52.
 - `fava-trails rich-view serve`: generates or reuses the local FAVA reader and serves it on a loopback-only Astro dev server, defaulting to all discovered scopes while preserving `/id/<UID>/` routes. Implements #53.
+- `fava-trails-tunnel`: ChatGPT tunnel gateway with a loopback MCP runtime, detached `start`/`stop`/`status` commands, and `/healthz`.
+- MCP tool output schemas for richer client validation and structured responses.
+
+### Fixed
+- Read-only MCP calls no longer create missing scopes.
+- Exact-ULID `get_thought` fallback can find thoughts across scopes and returns `source_trail`.
+- Tunnel sync/freshness semantics no longer assume Git `HEAD`; tunnel-managed autosync is disabled by default and opt-in with a positive `--sync-interval-seconds`.
+- Tunnel startup and cleanup behavior is hardened after timeout or failed launch.
+- Structured MCP errors are preserved across the tunnel gateway.
 
 ## [0.5.7] — 2026-06-30
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fava-trails"
-version = "0.5.7"
+version = "0.5.8"
 description = "FAVA Trails 🫛👣 — Federated Agents Versioned Audit Trail. VCS-backed memory for AI agents via MCP."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/fava_trails/__init__.py
+++ b/src/fava_trails/__init__.py
@@ -1,3 +1,3 @@
 """FAVA Trails — Federated Agents Versioned Audit Trail."""
 
-__version__ = "0.5.5"
+__version__ = "0.5.8"

--- a/uv.lock
+++ b/uv.lock
@@ -477,7 +477,7 @@ wheels = [
 
 [[package]]
 name = "fava-trails"
-version = "0.5.7"
+version = "0.5.8"
 source = { editable = "." }
 dependencies = [
     { name = "any-llm-sdk" },


### PR DESCRIPTION
## Summary
- bump package metadata from 0.5.7 to 0.5.8
- align src/fava_trails/__init__.py with the release version
- move current changelog entries under 0.5.8 dated 2026-07-08

## Verification
- git diff --check
- uv lock --check
- uv run python -c 'import fava_trails; print(fava_trails.__version__)'