### PR TITLE
fix: disable tunnel autosync by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,17 +190,17 @@ Both machines push/pull through the same git remote. Use the `sync` MCP tool to 
 ### ChatGPT tunnel freshness
 
 `fava-trails-tunnel start` runs the private MCP runtime behind the OpenAI Secure
-MCP Tunnel and keeps the data repo fresh by syncing on startup and every 60
-seconds by default:
+MCP Tunnel. Tunnel-managed data repo sync is disabled by default; use the
+normal `sync` MCP tool when you want to fetch/rebase shared trail data.
 
 ```bash
 fava-trails-tunnel start --data-repo /path/to/fava-trails-data --profile fava-trails
 ```
 
-Use `--sync-interval-seconds N` to adjust the interval, or `0` to disable
-tunnel-managed sync. Use `--sync-timeout-seconds N` to bound each sync attempt.
-The health endpoint and status command report whether the tunnel is fresh or
-degraded:
+Pass `--sync-interval-seconds N` only if you intentionally want the tunnel to
+sync on startup and every `N` seconds; `0` fully disables the autosync code path.
+Use `--sync-timeout-seconds N` to bound each opt-in sync attempt. The health
+endpoint and status command report the tunnel runtime and any opt-in sync state:
 
 ```bash
 curl http://127.0.0.1:8765/healthz

--- a/src/fava_trails/tunnel_cli.py
+++ b/src/fava_trails/tunnel_cli.py
@@ -29,7 +29,7 @@ DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
 DEFAULT_PROFILE = "fava-trails"
 DEFAULT_MCP_PATH = "/mcp/"
-DEFAULT_SYNC_INTERVAL_SECONDS = 60.0
+DEFAULT_SYNC_INTERVAL_SECONDS = 0.0
 DEFAULT_SYNC_TIMEOUT_SECONDS = 30.0
 DETACHED_STARTUP_GRACE_SECONDS = 5.0
 
@@ -329,10 +329,19 @@ def _read_json_file(path: Path) -> dict:
     return payload if isinstance(payload, dict) else {}
 
 
-def _git_output(data_repo: Path, *args: str) -> str | None:
+def _jj_output(data_repo: Path, *args: str) -> str | None:
+    jj_bin = _find_jj_bin() or "jj"
     try:
         result = subprocess.run(
-            ["git", "-C", str(data_repo), *args],
+            [
+                jj_bin,
+                "--repository",
+                str(data_repo),
+                "--ignore-working-copy",
+                "--color=never",
+                "--no-pager",
+                *args,
+            ],
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
@@ -346,12 +355,13 @@ def _git_output(data_repo: Path, *args: str) -> str | None:
 
 
 def _repo_revision_state(config: GatewayConfig) -> dict[str, str | bool | None]:
-    local_head = _git_output(config.data_repo, "rev-parse", "HEAD")
-    remote_main = _git_output(config.data_repo, "rev-parse", "origin/main")
+    template = 'commit_id ++ "\n"'
+    local_main = _jj_output(config.data_repo, "log", "--no-graph", "-r", "main", "-T", template)
+    remote_main = _jj_output(config.data_repo, "log", "--no-graph", "-r", "main@origin", "-T", template)
     return {
-        "local_head": local_head,
+        "local_main": local_main,
         "remote_main": remote_main,
-        "stale": bool(local_head and remote_main and local_head != remote_main),
+        "stale": bool(local_main and remote_main and local_main != remote_main),
     }
 
 
@@ -365,6 +375,7 @@ def _write_health_state(
     sync_finished_at: float | None = None,
     dirty_paths: list[str] | None = None,
     case_collisions: list[list[str]] | None = None,
+    include_revision: bool = True,
 ) -> dict:
     payload = {
         "status": status,
@@ -373,8 +384,9 @@ def _write_health_state(
         "trails_dir": str(config.trails_dir),
         "sync_started_at": sync_started_at,
         "sync_finished_at": sync_finished_at,
-        **_repo_revision_state(config),
     }
+    if include_revision:
+        payload.update(_repo_revision_state(config))
     if dirty_paths:
         payload["dirty_paths"] = dirty_paths
     if case_collisions:
@@ -449,6 +461,7 @@ def _start_sync_worker(
             config,
             status="disabled",
             message="tunnel-managed sync disabled",
+            include_revision=False,
         )
         return None
 
@@ -574,6 +587,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 config,
                 status="disabled",
                 message="tunnel-managed sync disabled",
+                include_revision=False,
             )
             print("  Data repo sync: disabled")
 

--- a/tests/test_tunnel_cli.py
+++ b/tests/test_tunnel_cli.py
@@ -38,7 +38,7 @@ def _args(**overrides):
         "ready_timeout": 0.1,
         "tunnel_doctor": False,
         "state_dir": None,
-        "sync_interval_seconds": 60.0,
+        "sync_interval_seconds": 0.0,
         "sync_timeout_seconds": 30.0,
         "json": False,
     }
@@ -127,7 +127,63 @@ def test_runtime_env_passes_health_file(tmp_path, monkeypatch):
     assert env["FAVA_TRAILS_TUNNEL_HEALTH_FILE"] == str(health_file)
 
 
-def test_run_starts_http_and_runs_tunnel_without_doctor_by_default(tmp_path, monkeypatch):
+def test_repo_revision_state_uses_jj_bookmarks_not_git_head(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            config = _load_gateway_config(_args(data_repo=str(data_repo)))
+
+    def fake_jj_output(_data_repo, *args):
+        rev = args[args.index("-r") + 1]
+        return {
+            "main": "local-main-commit",
+            "main@origin": "remote-main-commit",
+        }[rev]
+
+    with patch("fava_trails.tunnel_cli._jj_output", side_effect=fake_jj_output) as jj_output:
+        state = tunnel_cli._repo_revision_state(config)
+
+    assert state == {
+        "local_main": "local-main-commit",
+        "remote_main": "remote-main-commit",
+        "stale": True,
+    }
+    assert [call.args[1:] for call in jj_output.call_args_list] == [
+        ("log", "--no-graph", "-r", "main", "-T", 'commit_id ++ "\n"'),
+        ("log", "--no-graph", "-r", "main@origin", "-T", 'commit_id ++ "\n"'),
+    ]
+
+
+def test_disabled_sync_health_does_not_query_revision_state(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    health_file = tmp_path / "health.json"
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            config = _load_gateway_config(_args(data_repo=str(data_repo)))
+
+    with patch("fava_trails.tunnel_cli._repo_revision_state", side_effect=AssertionError):
+        worker = tunnel_cli._start_sync_worker(
+            config,
+            health_file,
+            interval=0.0,
+            timeout=30.0,
+            stop_event=MagicMock(),
+        )
+
+    assert worker is None
+    payload = json.loads(health_file.read_text())
+    assert payload["status"] == "disabled"
+    assert payload["message"] == "tunnel-managed sync disabled"
+    assert "stale" not in payload
+    assert "local_main" not in payload
+    assert "remote_main" not in payload
+
+
+def test_run_starts_http_and_runs_tunnel_without_doctor_or_autosync_by_default(tmp_path, monkeypatch):
     data_repo = _make_data_repo(tmp_path)
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     args = _args(data_repo=str(data_repo))
@@ -155,7 +211,36 @@ def test_run_starts_http_and_runs_tunnel_without_doctor_by_default(tmp_path, mon
     wait_health.assert_called_once()
     run.assert_not_called()
     start_tunnel.assert_called_once()
+    sync.assert_not_called()
+
+
+def test_run_autosyncs_when_interval_positive(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    args = _args(data_repo=str(data_repo), sync_interval_seconds=60.0)
+
+    http_process = MagicMock()
+    http_process.poll.return_value = None
+    http_process.pid = 111
+    tunnel_process = MagicMock()
+    tunnel_process.wait.return_value = 0
+    tunnel_process.poll.return_value = 0
+    tunnel_process.pid = 222
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with patch("fava_trails.tunnel_cli._check_port_available"):
+                with patch("fava_trails.tunnel_cli._start_http_runtime", return_value=http_process):
+                    with patch("fava_trails.tunnel_cli._wait_for_health"):
+                        with patch("fava_trails.tunnel_cli._sync_data_repo", return_value={"status": "ok"}) as sync:
+                            with patch("fava_trails.tunnel_cli._start_sync_worker", return_value=None) as start_worker:
+                                with patch("subprocess.run"):
+                                    with patch("fava_trails.tunnel_cli._start_tunnel_client", return_value=tunnel_process):
+                                        rc = cmd_run(args)
+
+    assert rc == 0
     sync.assert_called_once()
+    start_worker.assert_called_once()
 
 
 def test_run_checks_doctor_when_requested(tmp_path, monkeypatch):
@@ -257,7 +342,7 @@ def test_start_waits_for_startup_sync_before_ready_timeout(tmp_path, monkeypatch
     data_repo = _make_data_repo(tmp_path)
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
-    args = _args(data_repo=str(data_repo), ready_timeout=0.1, sync_timeout_seconds=0.5)
+    args = _args(data_repo=str(data_repo), ready_timeout=0.1, sync_interval_seconds=60.0, sync_timeout_seconds=0.5)
 
     process = MagicMock()
     process.pid = 4321


### PR DESCRIPTION
## Summary
- disable tunnel-managed autosync by default with sync interval 0
- make disabled sync mode bypass startup/background sync and omit stale/dirty autosync health fields
- compute tunnel revision freshness from JJ main vs main@origin instead of colocated Git HEAD

## Verification
- uv run pytest tests/test_tunnel_cli.py -q
- uv run pytest -q
- git diff --check