### PR TITLE
fix: prove tunnel data readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,24 @@ normal `sync` MCP tool when you want to fetch/rebase shared trail data.
 fava-trails-tunnel start --data-repo /path/to/fava-trails-data --profile fava-trails
 ```
 
-Pass `--sync-interval-seconds N` only if you intentionally want the tunnel to
-sync on startup and every `N` seconds; `0` fully disables the autosync code path.
-Use `--sync-timeout-seconds N` to bound each opt-in sync attempt. The health
-endpoint and status command report the tunnel runtime and any opt-in sync state:
+The `/healthz` readiness probe is bounded and non-mutating. It validates the
+data repository config and required `trails` directory, traverses at most
+100,000 scope-tree entries within two seconds, and parses one representative
+thought (up to 512 KiB) when records exist. A structurally valid empty repository
+is ready. Missing, unreadable, over-limit, timed-out, or malformed data returns
+HTTP 503 with a stable reason code. The response contains counts and status only;
+it never includes filesystem paths, credentials, thought bodies, or repository
+content.
+
+Readiness proves local data readability by the runtime identity. It does **not**
+prove remote freshness, perform a sync, contact the network, or validate that a
+write would succeed. A production deployment that requires fresh startup data
+must perform exactly one separately bounded `sync` before it exposes the tunnel,
+then rely on readiness. Keep `--sync-interval-seconds` at its default `0` for
+that deployment; later synchronization is an explicit MCP operation.
+
+The tunnel startup wait and `status` command consume `/healthz`; `status` exits
+non-zero when the supervisor is running but its data is not ready:
 
 ```bash
 curl http://127.0.0.1:8765/healthz

--- a/README.md
+++ b/README.md
@@ -208,10 +208,17 @@ content.
 
 Readiness proves local data readability by the runtime identity. It does **not**
 prove remote freshness, perform a sync, contact the network, or validate that a
-write would succeed. A production deployment that requires fresh startup data
-must perform exactly one separately bounded `sync` before it exposes the tunnel,
-then rely on readiness. Keep `--sync-interval-seconds` at its default `0` for
-that deployment; later synchronization is an explicit MCP operation.
+write would succeed. A deployment that requires fresh startup data can request
+one bounded, fail-closed sync inside the gateway before it exposes the tunnel:
+
+```bash
+fava-trails-tunnel start --data-repo /path/to/fava-trails-data --profile fava-trails --sync-on-start
+```
+
+With `--sync-on-start`, a non-ok result, timeout, or exception prevents HTTP and
+tunnel exposure. Keep `--sync-interval-seconds` at its default `0` when no
+later autosync is wanted; a positive interval additionally starts the recurring
+worker without repeating the initial sync.
 
 The tunnel startup wait and `status` command consume `/healthz`; `status` exits
 non-zero when the supervisor is running but its data is not ready:

--- a/src/fava_trails/http_runtime.py
+++ b/src/fava_trails/http_runtime.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json
+import asyncio
 import os
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -13,7 +13,8 @@ from starlette.applications import Starlette
 from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
 
-from .config import ConfigStore, get_data_repo_root, get_trails_dir
+from .config import DEFAULT_FAVA_HOME, ConfigStore
+from .readiness import DEFAULT_READINESS_TIMEOUT_SECONDS, ReadinessFailure, probe_data_repository
 
 
 class _McpASGIApp:
@@ -41,28 +42,51 @@ def create_streamable_http_app() -> Starlette:
             yield
 
     async def healthz(request) -> JSONResponse:
-        data_repo = get_data_repo_root()
-        trails_dir = get_trails_dir()
-        sync_state = {}
-        health_file = os.environ.get("FAVA_TRAILS_TUNNEL_HEALTH_FILE")
-        if health_file:
-            try:
-                payload = json.loads(Path(health_file).read_text())
-                if isinstance(payload, dict):
-                    sync_state = payload
-            except (OSError, json.JSONDecodeError):
-                sync_state = {"status": "unknown", "message": "health file unreadable"}
-        sync_status = sync_state.get("status")
-        degraded = sync_status not in (None, "ok", "disabled")
-        return JSONResponse(
-            {
-                "status": "degraded" if degraded else "ok",
-                "runtime": "fava-trails-tunnel",
-                "data_repo": str(data_repo),
-                "trails_dir": str(trails_dir),
-                "sync": sync_state,
-            }
-        )
+        data_repo = Path(os.environ.get("FAVA_TRAILS_DATA_REPO", DEFAULT_FAVA_HOME)).expanduser()
+        try:
+            data_state = await asyncio.wait_for(
+                asyncio.to_thread(
+                    probe_data_repository,
+                    data_repo,
+                    timeout_seconds=DEFAULT_READINESS_TIMEOUT_SECONDS,
+                ),
+                timeout=DEFAULT_READINESS_TIMEOUT_SECONDS + 0.1,
+            )
+        except ReadinessFailure as exc:
+            return JSONResponse(
+                {
+                    "status": "not_ready",
+                    "runtime": "fava-trails-tunnel",
+                    "reason": exc.reason,
+                    "message": exc.message,
+                },
+                status_code=503,
+            )
+        except TimeoutError:
+            return JSONResponse(
+                {
+                    "status": "not_ready",
+                    "runtime": "fava-trails-tunnel",
+                    "reason": "probe_timeout",
+                    "message": "data readiness probe exceeded its time limit",
+                },
+                status_code=503,
+            )
+        except Exception:  # noqa: BLE001 - readiness must fail closed without leaking internals
+            return JSONResponse(
+                {
+                    "status": "not_ready",
+                    "runtime": "fava-trails-tunnel",
+                    "reason": "readiness_probe_failed",
+                    "message": "data readiness probe failed",
+                },
+                status_code=503,
+            )
+        return JSONResponse({
+            "status": "ok",
+            "runtime": "fava-trails-tunnel",
+            "data": data_state,
+        })
 
     return Starlette(
         lifespan=lifespan,

--- a/src/fava_trails/readiness.py
+++ b/src/fava_trails/readiness.py
@@ -1,0 +1,272 @@
+"""Bounded, non-mutating readiness checks for a FAVA Trails data repository."""
+
+from __future__ import annotations
+
+import os
+import stat
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from .models import GlobalConfig, ThoughtRecord
+
+MAX_CONFIG_BYTES = 256 * 1024
+MAX_THOUGHT_BYTES = 512 * 1024
+MAX_TREE_ENTRIES = 100_000
+DEFAULT_READINESS_TIMEOUT_SECONDS = 2.0
+
+
+class ReadinessFailure(Exception):
+    """A safe, bounded readiness failure suitable for an HTTP response."""
+
+    def __init__(self, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.message = message
+
+
+@dataclass
+class _TreeProbe:
+    entries: int = 0
+    scopes: int = 0
+    records: int = 0
+    representative: Path | None = None
+    representative_key: str | None = None
+
+
+def _check_deadline(deadline: float) -> None:
+    if time.monotonic() >= deadline:
+        raise ReadinessFailure("probe_timeout", "data readiness probe exceeded its time limit")
+
+
+def _read_bounded(
+    path: Path,
+    *,
+    limit: int,
+    missing_reason: str,
+    unreadable_reason: str,
+    too_large_reason: str,
+    label: str,
+    deadline: float,
+) -> bytes:
+    _check_deadline(deadline)
+    try:
+        with path.open("rb") as handle:
+            payload = handle.read(limit + 1)
+    except FileNotFoundError as exc:
+        raise ReadinessFailure(missing_reason, f"{label} is missing") from exc
+    except OSError as exc:
+        raise ReadinessFailure(unreadable_reason, f"{label} is not readable") from exc
+    if len(payload) > limit:
+        raise ReadinessFailure(too_large_reason, f"{label} exceeds the readiness read limit")
+    _check_deadline(deadline)
+    return payload
+
+
+def _validate_config(data_repo: Path, deadline: float) -> GlobalConfig:
+    raw = _read_bounded(
+        data_repo / "config.yaml",
+        limit=MAX_CONFIG_BYTES,
+        missing_reason="config_missing",
+        unreadable_reason="config_unreadable",
+        too_large_reason="config_too_large",
+        label="data repository config",
+        deadline=deadline,
+    )
+    try:
+        parsed = yaml.safe_load(raw.decode("utf-8"))
+        if not isinstance(parsed, dict):
+            raise ValueError("config must be a mapping")
+        config = GlobalConfig(**parsed)
+    except (UnicodeDecodeError, ValueError, yaml.YAMLError, ValidationError) as exc:
+        raise ReadinessFailure("config_malformed", "data repository config is malformed") from exc
+    return config
+
+
+def _configured_trails_dir(data_repo: Path, config: GlobalConfig) -> Path:
+    override = os.environ.get("FAVA_TRAILS_DIR")
+    if override:
+        return Path(os.path.expanduser(override))
+    configured = Path(config.trails_dir)
+    return configured if configured.is_absolute() else data_repo / configured
+
+
+def _directory(
+    path: Path,
+    *,
+    missing_reason: str,
+    unreadable_reason: str,
+    label: str,
+    deadline: float,
+) -> Path:
+    _check_deadline(deadline)
+    try:
+        resolved = path.resolve(strict=True)
+        mode = resolved.stat().st_mode
+    except FileNotFoundError as exc:
+        raise ReadinessFailure(missing_reason, f"{label} is missing") from exc
+    except OSError as exc:
+        raise ReadinessFailure(unreadable_reason, f"{label} is not accessible") from exc
+    if not stat.S_ISDIR(mode):
+        raise ReadinessFailure(missing_reason, f"{label} is missing")
+    _check_deadline(deadline)
+    return resolved
+
+
+def _entries(path: Path, probe: _TreeProbe, deadline: float) -> list[os.DirEntry[str]]:
+    entries: list[os.DirEntry[str]] = []
+    _check_deadline(deadline)
+    try:
+        with os.scandir(path) as iterator:
+            for entry in iterator:
+                _check_deadline(deadline)
+                probe.entries += 1
+                if probe.entries > MAX_TREE_ENTRIES:
+                    raise ReadinessFailure(
+                        "scope_tree_too_large",
+                        "scope tree exceeds the readiness traversal limit",
+                    )
+                entries.append(entry)
+    except ReadinessFailure:
+        raise
+    except OSError as exc:
+        raise ReadinessFailure(
+            "scope_tree_unreadable",
+            "scope tree cannot be traversed by the runtime identity",
+        ) from exc
+    return sorted(entries, key=lambda entry: entry.name)
+
+
+def _is_dir(entry: os.DirEntry[str]) -> bool:
+    try:
+        return entry.is_dir(follow_symlinks=False)
+    except OSError as exc:
+        raise ReadinessFailure(
+            "scope_tree_unreadable",
+            "scope tree cannot be traversed by the runtime identity",
+        ) from exc
+
+
+def _is_file(entry: os.DirEntry[str]) -> bool:
+    try:
+        return entry.is_file(follow_symlinks=False)
+    except OSError as exc:
+        raise ReadinessFailure(
+            "scope_tree_unreadable",
+            "scope tree cannot be traversed by the runtime identity",
+        ) from exc
+
+
+def _scan_thoughts(
+    thoughts_dir: Path,
+    trails_dir: Path,
+    probe: _TreeProbe,
+    deadline: float,
+) -> None:
+    stack = [thoughts_dir]
+    while stack:
+        current = stack.pop()
+        entries = _entries(current, probe, deadline)
+        for entry in reversed(entries):
+            path = Path(entry.path)
+            if _is_dir(entry):
+                stack.append(path)
+                continue
+            if not _is_file(entry) or path.suffix != ".md":
+                continue
+            probe.records += 1
+            key = path.relative_to(trails_dir).as_posix()
+            if probe.representative_key is None or key < probe.representative_key:
+                probe.representative = path
+                probe.representative_key = key
+
+
+def _scan_scope_tree(trails_dir: Path, deadline: float) -> _TreeProbe:
+    probe = _TreeProbe()
+    stack = [trails_dir]
+    while stack:
+        current = stack.pop()
+        entries = _entries(current, probe, deadline)
+        for entry in reversed(entries):
+            if not _is_dir(entry):
+                continue
+            path = Path(entry.path)
+            if entry.name == "thoughts":
+                probe.scopes += 1
+                _scan_thoughts(path, trails_dir, probe, deadline)
+            else:
+                stack.append(path)
+    return probe
+
+
+def _read_representative(path: Path, deadline: float) -> None:
+    raw = _read_bounded(
+        path,
+        limit=MAX_THOUGHT_BYTES,
+        missing_reason="thought_unreadable",
+        unreadable_reason="thought_unreadable",
+        too_large_reason="thought_too_large",
+        label="representative thought",
+        deadline=deadline,
+    )
+    try:
+        text = raw.decode("utf-8")
+        if not text.startswith("---") or len(text.split("---", 2)) < 3:
+            raise ValueError("frontmatter is missing")
+        record = ThoughtRecord.from_markdown(text)
+        if record.thought_id != path.stem:
+            raise ValueError("thought id does not match filename")
+    except (UnicodeDecodeError, ValueError, yaml.YAMLError, ValidationError) as exc:
+        raise ReadinessFailure("thought_malformed", "representative thought is malformed") from exc
+
+
+def probe_data_repository(
+    data_repo: Path,
+    *,
+    timeout_seconds: float = DEFAULT_READINESS_TIMEOUT_SECONDS,
+) -> dict[str, object]:
+    """Prove that configured trail data is traversable and representative data parses.
+
+    The probe never creates directories, initializes repositories, syncs, or writes files.
+    Returned diagnostics contain counts and stable reason codes, never filesystem paths or
+    thought content.
+    """
+    deadline = time.monotonic() + max(timeout_seconds, 0.0)
+    repo_root = _directory(
+        data_repo,
+        missing_reason="data_repo_missing",
+        unreadable_reason="data_repo_unreadable",
+        label="data repository",
+        deadline=deadline,
+    )
+    config = _validate_config(repo_root, deadline)
+    trails_dir = _configured_trails_dir(repo_root, config)
+    configured_trails = _directory(
+        trails_dir,
+        missing_reason="trails_missing",
+        unreadable_reason="trails_unreadable",
+        label="trails directory",
+        deadline=deadline,
+    )
+    try:
+        configured_trails.relative_to(repo_root)
+    except ValueError as exc:
+        raise ReadinessFailure(
+            "trails_outside_data_repo",
+            "trails directory must be inside the data repository",
+        ) from exc
+
+    probe = _scan_scope_tree(configured_trails, deadline)
+    if probe.representative is not None:
+        _read_representative(probe.representative, deadline)
+
+    return {
+        "status": "ok",
+        "scopes": probe.scopes,
+        "records": probe.records,
+        "empty": probe.records == 0,
+        "representative_read": probe.representative is not None,
+    }

--- a/src/fava_trails/tunnel_cli.py
+++ b/src/fava_trails/tunnel_cli.py
@@ -15,6 +15,7 @@ import sys
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
@@ -24,6 +25,7 @@ import yaml
 
 from .cli import _find_jj_bin
 from .config import ConfigStore
+from .readiness import DEFAULT_READINESS_TIMEOUT_SECONDS
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
@@ -32,6 +34,8 @@ DEFAULT_MCP_PATH = "/mcp/"
 DEFAULT_SYNC_INTERVAL_SECONDS = 0.0
 DEFAULT_SYNC_TIMEOUT_SECONDS = 30.0
 DETACHED_STARTUP_GRACE_SECONDS = 5.0
+MAX_HEALTH_RESPONSE_BYTES = 64 * 1024
+HEALTH_REQUEST_TIMEOUT_SECONDS = DEFAULT_READINESS_TIMEOUT_SECONDS + 0.5
 
 
 @dataclass(frozen=True)
@@ -203,6 +207,74 @@ def _runtime_env(config: GatewayConfig, *, health_file: Path | None = None) -> d
     return env
 
 
+def _request_health(url: str, *, timeout: float) -> tuple[int, dict]:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            status = response.status
+            raw = response.read(MAX_HEALTH_RESPONSE_BYTES + 1)
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        raw = exc.read(MAX_HEALTH_RESPONSE_BYTES + 1)
+    if len(raw) > MAX_HEALTH_RESPONSE_BYTES:
+        return status, {}
+    try:
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return status, {}
+    return status, payload if isinstance(payload, dict) else {}
+
+
+def _health_diagnostic(payload: dict) -> str:
+    reason = payload.get("reason")
+    message = payload.get("message")
+    if isinstance(reason, str) and isinstance(message, str):
+        return f"{reason}: {message}"[:240]
+    if isinstance(reason, str):
+        return reason[:120]
+    return "readiness endpoint returned a non-ready response"
+
+
+def _safe_readiness_payload(status: int, payload: dict) -> dict:
+    if status == 200 and payload.get("status") == "ok":
+        data = payload.get("data")
+        safe_data = {}
+        if isinstance(data, dict):
+            for key in ("status", "scopes", "records", "empty", "representative_read"):
+                value = data.get(key)
+                if isinstance(value, (str, int, bool)):
+                    safe_data[key] = value
+        return {"status": "ok", "data": safe_data}
+    reason = payload.get("reason")
+    message = payload.get("message")
+    return {
+        "status": "not_ready",
+        "reason": reason[:120] if isinstance(reason, str) else "readiness_failed",
+        "message": message[:240] if isinstance(message, str) else "runtime readiness check failed",
+    }
+
+
+def _status_readiness(args: argparse.Namespace, metadata: dict) -> dict:
+    health_url = metadata.get("health_url")
+    if not isinstance(health_url, str):
+        health_url = f"http://{args.host}:{args.port}/healthz"
+    parsed = urllib.parse.urlparse(health_url)
+    if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
+        return {
+            "status": "not_ready",
+            "reason": "invalid_health_url",
+            "message": "runtime health URL is not loopback-only",
+        }
+    try:
+        status, payload = _request_health(health_url, timeout=HEALTH_REQUEST_TIMEOUT_SECONDS)
+    except (OSError, urllib.error.URLError):
+        return {
+            "status": "not_ready",
+            "reason": "health_unreachable",
+            "message": "runtime readiness endpoint is unreachable",
+        }
+    return _safe_readiness_payload(status, payload)
+
+
 def _wait_for_health(url: str, process: subprocess.Popen, *, timeout: float) -> None:
     deadline = time.monotonic() + timeout
     last_error: Exception | None = None
@@ -210,9 +282,11 @@ def _wait_for_health(url: str, process: subprocess.Popen, *, timeout: float) -> 
         if process.poll() is not None:
             raise subprocess.SubprocessError("private MCP runtime exited before becoming ready")
         try:
-            with urllib.request.urlopen(url, timeout=0.5) as response:
-                if response.status == 200:
-                    return
+            request_timeout = min(HEALTH_REQUEST_TIMEOUT_SECONDS, deadline - time.monotonic())
+            status, payload = _request_health(url, timeout=max(request_timeout, 0.05))
+            if status == 200 and payload.get("status") == "ok":
+                return
+            last_error = RuntimeError(_health_diagnostic(payload))
         except (OSError, urllib.error.URLError) as exc:
             last_error = exc
         time.sleep(0.1)
@@ -727,24 +801,30 @@ def cmd_status(args: argparse.Namespace) -> int:
         running = bool(pid and _is_pid_running(pid))
         metadata = _read_json_file(_metadata_file(state_dir))
         health = _read_json_file(_health_file(state_dir))
+        readiness = _status_readiness(args, metadata) if running else {}
+        ready = bool(running and readiness.get("status") == "ok")
         if getattr(args, "json", False):
             print(json.dumps({
-                "status": "running" if running else "not_running",
+                "status": "ready" if ready else ("not_ready" if running else "not_running"),
                 "running": running,
+                "ready": ready,
                 "pid": pid if running else None,
                 "state_dir": str(state_dir),
                 "log_file": str(_log_file(state_dir)),
                 "metadata": metadata,
                 "health": health,
+                "readiness": readiness,
             }, indent=2))
-            return 0 if running else 1
-        if pid and _is_pid_running(pid):
-            print(f"Gateway running (pid {pid})")
+            return 0 if ready else 1
+        if running:
+            print(f"Gateway {'ready' if ready else 'running but not ready'} (pid {pid})")
             print(f"  State: {state_dir}")
             print(f"  Log:   {_log_file(state_dir)}")
             if health:
                 print(f"  Sync:  {health.get('status', 'unknown')} ({health.get('message', '')})")
-            return 0
+            if not ready:
+                print(f"  Readiness: {readiness.get('reason', 'failed')} ({readiness.get('message', '')})")
+            return 0 if ready else 1
         print("Gateway not running")
         print(f"  State: {state_dir}")
         return 1

--- a/src/fava_trails/tunnel_cli.py
+++ b/src/fava_trails/tunnel_cli.py
@@ -584,7 +584,7 @@ def _detached_startup_timeout(args: argparse.Namespace) -> float:
     ready_timeout = max(float(getattr(args, "ready_timeout", 0.0)), 0.0)
     sync_interval = float(getattr(args, "sync_interval_seconds", DEFAULT_SYNC_INTERVAL_SECONDS))
     sync_timeout = max(float(getattr(args, "sync_timeout_seconds", DEFAULT_SYNC_TIMEOUT_SECONDS)), 0.0)
-    if sync_interval > 0:
+    if getattr(args, "sync_on_start", False) or sync_interval > 0:
         return ready_timeout + sync_timeout + DETACHED_STARTUP_GRACE_SECONDS
     return ready_timeout + DETACHED_STARTUP_GRACE_SECONDS
 
@@ -645,9 +645,14 @@ def cmd_run(args: argparse.Namespace) -> int:
 
         sync_interval = float(getattr(args, "sync_interval_seconds", DEFAULT_SYNC_INTERVAL_SECONDS))
         sync_timeout = float(getattr(args, "sync_timeout_seconds", DEFAULT_SYNC_TIMEOUT_SECONDS))
-        if sync_interval > 0:
+        initial_sync_requested = bool(getattr(args, "sync_on_start", False)) or sync_interval > 0
+        if initial_sync_requested:
             sync_state = _sync_data_repo(config, health_path, timeout=sync_timeout)
             print(f"  Data repo sync: {sync_state['status']}")
+            if sync_state["status"] != "ok":
+                raise ValueError(f"initial data repo sync failed: {sync_state.get('message', '')}")
+
+        if sync_interval > 0:
             sync_thread = _start_sync_worker(
                 config,
                 health_path,
@@ -753,6 +758,8 @@ def cmd_start(args: argparse.Namespace) -> int:
         ]
         if getattr(args, "tunnel_doctor", False):
             command.append("--tunnel-doctor")
+        if getattr(args, "sync_on_start", False):
+            command.append("--sync-on-start")
         command.extend([
             "--sync-interval-seconds",
             str(args.sync_interval_seconds),
@@ -909,6 +916,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_run.add_argument("--tunnel-client", default="tunnel-client", help="Path to tunnel-client binary")
     p_run.add_argument("--ready-timeout", type=float, default=20.0, help="Seconds to wait for local MCP readiness")
     p_run.add_argument("--tunnel-doctor", action="store_true", help="Run tunnel-client doctor before starting the tunnel")
+    p_run.add_argument("--sync-on-start", action="store_true", help="Require one successful data repo sync before exposing the gateway")
     p_run.add_argument("--sync-interval-seconds", type=float, default=DEFAULT_SYNC_INTERVAL_SECONDS, help=f"Seconds between data repo syncs; 0 disables tunnel-managed sync (default: {DEFAULT_SYNC_INTERVAL_SECONDS:g})")
     p_run.add_argument("--sync-timeout-seconds", type=float, default=DEFAULT_SYNC_TIMEOUT_SECONDS, help=f"Seconds before a data repo sync is marked failed (default: {DEFAULT_SYNC_TIMEOUT_SECONDS:g})")
     p_run.add_argument("--state-dir", default=None, help=argparse.SUPPRESS)
@@ -919,6 +927,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_start.add_argument("--tunnel-client", default="tunnel-client", help="Path to tunnel-client binary")
     p_start.add_argument("--ready-timeout", type=float, default=20.0, help="Seconds to wait for local MCP readiness")
     p_start.add_argument("--tunnel-doctor", action="store_true", help="Run tunnel-client doctor before starting the tunnel")
+    p_start.add_argument("--sync-on-start", action="store_true", help="Require one successful data repo sync before exposing the gateway")
     p_start.add_argument("--sync-interval-seconds", type=float, default=DEFAULT_SYNC_INTERVAL_SECONDS, help=f"Seconds between data repo syncs; 0 disables tunnel-managed sync (default: {DEFAULT_SYNC_INTERVAL_SECONDS:g})")
     p_start.add_argument("--sync-timeout-seconds", type=float, default=DEFAULT_SYNC_TIMEOUT_SECONDS, help=f"Seconds before a data repo sync is marked failed (default: {DEFAULT_SYNC_TIMEOUT_SECONDS:g})")
     p_start.set_defaults(func=cmd_start)

--- a/tests/test_tunnel_cli.py
+++ b/tests/test_tunnel_cli.py
@@ -13,6 +13,8 @@ from starlette.testclient import TestClient
 from fava_trails import tunnel_cli
 from fava_trails.config import ConfigStore
 from fava_trails.http_runtime import create_streamable_http_app
+from fava_trails.models import ThoughtFrontmatter, ThoughtRecord
+from fava_trails.readiness import ReadinessFailure, probe_data_repository
 from fava_trails.tunnel_cli import (
     DEFAULT_HOST,
     DEFAULT_MCP_PATH,
@@ -54,6 +56,18 @@ def _make_data_repo(tmp_path: Path, *, openrouter_env: str = "OPENROUTER_API_KEY
         f"trails_dir: trails\nopenrouter_api_key_env: {openrouter_env}\n"
     )
     return data_repo
+
+
+def _write_thought(data_repo: Path, *, thought_id: str = "01KXREADINESS00000000000000") -> Path:
+    thought_path = data_repo / "trails" / "mwai" / "eng" / "thoughts" / "drafts" / f"{thought_id}.md"
+    thought_path.parent.mkdir(parents=True)
+    thought_path.write_text(
+        ThoughtRecord(
+            frontmatter=ThoughtFrontmatter(thought_id=thought_id),
+            content="private representative content",
+        ).to_markdown()
+    )
+    return thought_path
 
 
 def test_load_gateway_config_requires_explicit_data_repo(monkeypatch):
@@ -125,6 +139,23 @@ def test_runtime_env_passes_health_file(tmp_path, monkeypatch):
     env = _runtime_env(config, health_file=health_file)
 
     assert env["FAVA_TRAILS_TUNNEL_HEALTH_FILE"] == str(health_file)
+
+
+def test_startup_wait_requires_strengthened_readiness_result():
+    process = MagicMock()
+    process.poll.return_value = None
+
+    with patch(
+        "fava_trails.tunnel_cli._request_health",
+        side_effect=[
+            (503, {"status": "not_ready", "reason": "trails_unreadable"}),
+            (200, {"status": "ok", "data": {"empty": True}}),
+        ],
+    ) as request_health:
+        with patch("fava_trails.tunnel_cli.time.sleep"):
+            tunnel_cli._wait_for_health("http://127.0.0.1:8765/healthz", process, timeout=1.0)
+
+    assert request_health.call_count == 2
 
 
 def test_repo_revision_state_uses_jj_bookmarks_not_git_head(tmp_path, monkeypatch):
@@ -491,12 +522,44 @@ def test_status_json_reports_health(tmp_path, monkeypatch, capsys):
     tunnel_cli._health_file(state_dir).write_text('{"status":"blocked","message":"dirty working copy"}\n')
 
     with patch("fava_trails.tunnel_cli._is_pid_running", return_value=True):
-        rc = cmd_status(_args(data_repo=str(data_repo), json=True))
+        with patch(
+            "fava_trails.tunnel_cli._status_readiness",
+            return_value={"status": "ok", "data": {"empty": True}},
+        ):
+            rc = cmd_status(_args(data_repo=str(data_repo), json=True))
 
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["running"] is True
+    assert payload["ready"] is True
     assert payload["health"]["status"] == "blocked"
+    assert payload["readiness"]["status"] == "ok"
+
+
+def test_status_returns_failure_when_runtime_is_running_but_data_is_not_ready(tmp_path, monkeypatch, capsys):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    state_dir = tunnel_cli._state_dir(data_repo.resolve(), DEFAULT_PROFILE)
+    state_dir.mkdir(parents=True)
+    tunnel_cli._pid_file(state_dir).write_text("4321\n")
+
+    with patch("fava_trails.tunnel_cli._is_pid_running", return_value=True):
+        with patch(
+            "fava_trails.tunnel_cli._status_readiness",
+            return_value={
+                "status": "not_ready",
+                "reason": "trails_unreadable",
+                "message": "trails directory is not accessible",
+            },
+        ):
+            rc = cmd_status(_args(data_repo=str(data_repo), json=True))
+
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "not_ready"
+    assert payload["running"] is True
+    assert payload["ready"] is False
+    assert payload["readiness"]["reason"] == "trails_unreadable"
 
 
 def test_stop_does_not_require_startup_only_environment(tmp_path, monkeypatch, capsys):
@@ -574,8 +637,7 @@ def test_tunnel_cli_help_mentions_start():
     assert "run" in help_text
 
 
-def test_http_runtime_healthz_reports_data_repo(tmp_path, monkeypatch):
-    data_repo = _make_data_repo(tmp_path)
+def _health_response(data_repo: Path, monkeypatch):
     monkeypatch.setenv("FAVA_TRAILS_DATA_REPO", str(data_repo))
     ConfigStore.reset()
 
@@ -585,34 +647,126 @@ def test_http_runtime_healthz_reports_data_repo(tmp_path, monkeypatch):
     with patch("fava_trails.server._init_server", new=noop_init_server):
         app = create_streamable_http_app()
         with TestClient(app) as client:
-            response = client.get("/healthz")
+            return client.get("/healthz")
+
+
+def test_http_runtime_healthz_reports_valid_empty_repository_ready(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    response = _health_response(data_repo, monkeypatch)
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["status"] == "ok"
     assert payload["runtime"] == "fava-trails-tunnel"
-    assert payload["data_repo"] == str(data_repo)
-    assert payload["trails_dir"] == str(data_repo / "trails")
-    assert payload["sync"] == {}
+    assert payload["data"] == {
+        "status": "ok",
+        "scopes": 0,
+        "records": 0,
+        "empty": True,
+        "representative_read": False,
+    }
+    assert str(data_repo) not in response.text
 
 
-def test_http_runtime_healthz_reports_sync_degraded(tmp_path, monkeypatch):
+def test_http_runtime_healthz_traverses_scopes_and_parses_representative_record(tmp_path, monkeypatch):
     data_repo = _make_data_repo(tmp_path)
-    health_file = tmp_path / "health.json"
-    health_file.write_text('{"status":"blocked","message":"dirty working copy"}\n')
-    monkeypatch.setenv("FAVA_TRAILS_DATA_REPO", str(data_repo))
-    monkeypatch.setenv("FAVA_TRAILS_TUNNEL_HEALTH_FILE", str(health_file))
-    ConfigStore.reset()
-
-    async def noop_init_server():
-        return None
-
-    with patch("fava_trails.server._init_server", new=noop_init_server):
-        app = create_streamable_http_app()
-        with TestClient(app) as client:
-            response = client.get("/healthz")
+    _write_thought(data_repo)
+    response = _health_response(data_repo, monkeypatch)
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["status"] == "degraded"
-    assert payload["sync"]["status"] == "blocked"
+    assert payload["data"]["scopes"] == 1
+    assert payload["data"]["records"] == 1
+    assert payload["data"]["empty"] is False
+    assert payload["data"]["representative_read"] is True
+    assert "private representative content" not in response.text
+    assert str(data_repo) not in response.text
+
+
+def test_http_runtime_healthz_does_not_treat_prior_sync_state_as_readiness(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    health_file = tmp_path / "health.json"
+    health_file.write_text('{"status":"blocked","message":"dirty working copy"}\n')
+    monkeypatch.setenv("FAVA_TRAILS_TUNNEL_HEALTH_FILE", str(health_file))
+    response = _health_response(data_repo, monkeypatch)
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    assert "dirty working copy" not in response.text
+    assert "sync" not in response.json()
+
+
+def test_http_runtime_healthz_reports_missing_structure_without_path(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    (data_repo / "trails").rmdir()
+    response = _health_response(data_repo, monkeypatch)
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "status": "not_ready",
+        "runtime": "fava-trails-tunnel",
+        "reason": "trails_missing",
+        "message": "trails directory is missing",
+    }
+    assert str(data_repo) not in response.text
+
+
+def test_http_runtime_healthz_reports_malformed_config_without_loading_cached_config(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    (data_repo / "config.yaml").write_text("trails_dir: [not-a-path]\n")
+    response = _health_response(data_repo, monkeypatch)
+
+    assert response.status_code == 503
+    assert response.json()["reason"] == "config_malformed"
+    assert str(data_repo) not in response.text
+
+
+def test_http_runtime_healthz_probes_the_trails_directory_named_by_config(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    (data_repo / "config.yaml").write_text("trails_dir: missing-trails\n")
+    response = _health_response(data_repo, monkeypatch)
+
+    assert response.status_code == 503
+    assert response.json()["reason"] == "trails_missing"
+
+
+def test_http_runtime_healthz_reports_inaccessible_scope_tree(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    with patch("fava_trails.readiness.os.scandir", side_effect=PermissionError("private path")):
+        response = _health_response(data_repo, monkeypatch)
+
+    assert response.status_code == 503
+    assert response.json()["reason"] == "scope_tree_unreadable"
+    assert "private path" not in response.text
+    assert str(data_repo) not in response.text
+
+
+def test_http_runtime_healthz_reports_malformed_representative_without_content(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    thought_path = _write_thought(data_repo)
+    thought_path.write_text("---\nvalidation_status: definitely-invalid\n---\nsecret body")
+    response = _health_response(data_repo, monkeypatch)
+
+    assert response.status_code == 503
+    assert response.json()["reason"] == "thought_malformed"
+    assert "secret body" not in response.text
+    assert str(thought_path) not in response.text
+
+
+def test_data_readiness_probe_has_explicit_time_bound(tmp_path):
+    data_repo = _make_data_repo(tmp_path)
+
+    with pytest.raises(ReadinessFailure, match="time limit") as exc_info:
+        probe_data_repository(data_repo, timeout_seconds=0)
+
+    assert exc_info.value.reason == "probe_timeout"
+
+
+def test_http_runtime_healthz_reports_tree_bound(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    (data_repo / "trails" / "scope").mkdir()
+    monkeypatch.setattr("fava_trails.readiness.MAX_TREE_ENTRIES", 0)
+    response = _health_response(data_repo, monkeypatch)
+
+    assert response.status_code == 503
+    assert response.json()["reason"] == "scope_tree_too_large"

--- a/tests/test_tunnel_cli.py
+++ b/tests/test_tunnel_cli.py
@@ -39,6 +39,7 @@ def _args(**overrides):
         "tunnel_client": "tunnel-client",
         "ready_timeout": 0.1,
         "tunnel_doctor": False,
+        "sync_on_start": False,
         "state_dir": None,
         "sync_interval_seconds": 0.0,
         "sync_timeout_seconds": 30.0,
@@ -245,10 +246,10 @@ def test_run_starts_http_and_runs_tunnel_without_doctor_or_autosync_by_default(t
     sync.assert_not_called()
 
 
-def test_run_autosyncs_when_interval_positive(tmp_path, monkeypatch):
+def test_run_syncs_once_when_start_flag_and_interval_both_request_it(tmp_path, monkeypatch):
     data_repo = _make_data_repo(tmp_path)
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-    args = _args(data_repo=str(data_repo), sync_interval_seconds=60.0)
+    args = _args(data_repo=str(data_repo), sync_on_start=True, sync_interval_seconds=60.0)
 
     http_process = MagicMock()
     http_process.poll.return_value = None
@@ -272,6 +273,75 @@ def test_run_autosyncs_when_interval_positive(tmp_path, monkeypatch):
     assert rc == 0
     sync.assert_called_once()
     start_worker.assert_called_once()
+
+
+def test_run_syncs_once_on_start_without_recurring_worker(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    args = _args(data_repo=str(data_repo), sync_on_start=True, sync_interval_seconds=0.0)
+
+    http_process = MagicMock(pid=111)
+    http_process.poll.return_value = None
+    tunnel_process = MagicMock(pid=222)
+    tunnel_process.wait.return_value = 0
+    tunnel_process.poll.return_value = 0
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with patch("fava_trails.tunnel_cli._check_port_available"):
+                with patch("fava_trails.tunnel_cli._sync_data_repo", return_value={"status": "ok"}) as sync:
+                    with patch("fava_trails.tunnel_cli._start_sync_worker") as start_worker:
+                        with patch("fava_trails.tunnel_cli._start_http_runtime", return_value=http_process) as start_http:
+                            with patch("fava_trails.tunnel_cli._wait_for_health"):
+                                with patch("fava_trails.tunnel_cli._start_tunnel_client", return_value=tunnel_process) as start_tunnel:
+                                    assert cmd_run(args) == 0
+
+    sync.assert_called_once()
+    start_worker.assert_not_called()
+    start_http.assert_called_once()
+    start_tunnel.assert_called_once()
+
+
+@pytest.mark.parametrize("sync_state", [
+    {"status": "blocked", "message": "dirty working copy"},
+    {"status": "conflict", "message": "merge conflict"},
+    {"status": "error", "message": "sync timed out after 30s"},
+])
+def test_run_does_not_expose_after_initial_sync_failure(tmp_path, monkeypatch, sync_state):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    args = _args(data_repo=str(data_repo), sync_on_start=True)
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with patch("fava_trails.tunnel_cli._check_port_available"):
+                with patch("fava_trails.tunnel_cli._sync_data_repo", return_value=sync_state) as sync:
+                    with patch("fava_trails.tunnel_cli._start_sync_worker") as start_worker:
+                        with patch("fava_trails.tunnel_cli._start_http_runtime") as start_http:
+                            with patch("fava_trails.tunnel_cli._start_tunnel_client") as start_tunnel:
+                                assert cmd_run(args) == 1
+
+    sync.assert_called_once()
+    start_worker.assert_not_called()
+    start_http.assert_not_called()
+    start_tunnel.assert_not_called()
+
+
+def test_run_does_not_expose_when_startup_sync_times_out(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    args = _args(data_repo=str(data_repo), sync_on_start=True)
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with patch("fava_trails.tunnel_cli._check_port_available"):
+                with patch("fava_trails.tunnel_cli._sync_data_repo", side_effect=TimeoutError):
+                    with patch("fava_trails.tunnel_cli._start_http_runtime") as start_http:
+                        with patch("fava_trails.tunnel_cli._start_tunnel_client") as start_tunnel:
+                            assert cmd_run(args) == 1
+
+    start_http.assert_not_called()
+    start_tunnel.assert_not_called()
 
 
 def test_run_checks_doctor_when_requested(tmp_path, monkeypatch):
@@ -361,11 +431,36 @@ def test_start_passes_tunnel_doctor_to_supervisor_when_requested(tmp_path, monke
     assert rc == 0
 
 
+def test_start_forwards_sync_on_start_to_supervisor(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    args = _args(data_repo=str(data_repo), sync_on_start=True)
+
+    process = MagicMock(pid=4321)
+    process.poll.return_value = None
+    state_dir = tunnel_cli._state_dir(data_repo.resolve(), DEFAULT_PROFILE)
+
+    def fake_popen(command, *args, **kwargs):
+        state_dir.mkdir(parents=True, exist_ok=True)
+        tunnel_cli._ready_file(state_dir).write_text('{"status":"ready"}\n')
+        assert "--sync-on-start" in command
+        return process
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with patch("fava_trails.tunnel_cli._check_port_available"):
+                with patch("subprocess.Popen", side_effect=fake_popen):
+                    assert cmd_start(args) == 0
+
+
 def test_detached_startup_timeout_includes_sync_budget_and_grace():
     enabled = _args(ready_timeout=2.0, sync_interval_seconds=60.0, sync_timeout_seconds=3.0)
+    flagged = _args(ready_timeout=2.0, sync_on_start=True, sync_interval_seconds=0.0, sync_timeout_seconds=3.0)
     disabled = _args(ready_timeout=2.0, sync_interval_seconds=0.0, sync_timeout_seconds=3.0)
 
     assert tunnel_cli._detached_startup_timeout(enabled) == 2.0 + 3.0 + tunnel_cli.DETACHED_STARTUP_GRACE_SECONDS
+    assert tunnel_cli._detached_startup_timeout(flagged) == 2.0 + 3.0 + tunnel_cli.DETACHED_STARTUP_GRACE_SECONDS
     assert tunnel_cli._detached_startup_timeout(disabled) == 2.0 + tunnel_cli.DETACHED_STARTUP_GRACE_SECONDS
 
 


### PR DESCRIPTION
## Summary

- replace path-string and prior-sync health with a bounded, non-mutating data-readiness probe
- traverse the configured scope tree and parse one deterministic representative thought when records exist
- return 200 for a valid empty repository and safe 503 reason codes for missing, unreadable, over-limit, timed-out, or malformed data
- make detached startup and fava-trails-tunnel status consume the strengthened readiness result
- add fava-trails-tunnel run/start --sync-on-start: one bounded, fail-closed initial sync before HTTP or tunnel exposure

## Sync contract

Default false preserves existing behavior. A positive --sync-interval-seconds still starts the recurring worker. When either it or --sync-on-start requests initial sync, the gateway executes it exactly once; interval zero with --sync-on-start performs no later autosync. Detached start forwards the flag and includes the sync timeout in its startup budget.

## Verification

- uv run ruff check
- PYTHONPATH=src uv run pytest tests/test_tunnel_cli.py -q — 42 passed
- PYTHONPATH=src uv run pytest -q
- git diff --check

## Review

- native mw-review found no blocking findings
- the single external Claude review pass was policy-blocked because it would transmit private source; native fallback completed

Closes #73