### PR TITLE
feat: gate tunnel exposure on initial sync

### DIFF
--- a/src/fava_trails/tunnel_cli.py
+++ b/src/fava_trails/tunnel_cli.py
@@ -510,7 +510,7 @@ def _detached_startup_timeout(args: argparse.Namespace) -> float:
     ready_timeout = max(float(getattr(args, "ready_timeout", 0.0)), 0.0)
     sync_interval = float(getattr(args, "sync_interval_seconds", DEFAULT_SYNC_INTERVAL_SECONDS))
     sync_timeout = max(float(getattr(args, "sync_timeout_seconds", DEFAULT_SYNC_TIMEOUT_SECONDS)), 0.0)
-    if sync_interval > 0:
+    if getattr(args, "sync_on_start", False) or sync_interval > 0:
         return ready_timeout + sync_timeout + DETACHED_STARTUP_GRACE_SECONDS
     return ready_timeout + DETACHED_STARTUP_GRACE_SECONDS
 
@@ -571,9 +571,14 @@ def cmd_run(args: argparse.Namespace) -> int:
 
         sync_interval = float(getattr(args, "sync_interval_seconds", DEFAULT_SYNC_INTERVAL_SECONDS))
         sync_timeout = float(getattr(args, "sync_timeout_seconds", DEFAULT_SYNC_TIMEOUT_SECONDS))
-        if sync_interval > 0:
+        initial_sync_requested = bool(getattr(args, "sync_on_start", False)) or sync_interval > 0
+        if initial_sync_requested:
             sync_state = _sync_data_repo(config, health_path, timeout=sync_timeout)
             print(f"  Data repo sync: {sync_state['status']}")
+            if sync_state["status"] != "ok":
+                raise ValueError(f"initial data repo sync failed: {sync_state.get('message', '')}")
+
+        if sync_interval > 0:
             sync_thread = _start_sync_worker(
                 config,
                 health_path,
@@ -679,6 +684,8 @@ def cmd_start(args: argparse.Namespace) -> int:
         ]
         if getattr(args, "tunnel_doctor", False):
             command.append("--tunnel-doctor")
+        if getattr(args, "sync_on_start", False):
+            command.append("--sync-on-start")
         command.extend([
             "--sync-interval-seconds",
             str(args.sync_interval_seconds),
@@ -829,6 +836,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_run.add_argument("--tunnel-client", default="tunnel-client", help="Path to tunnel-client binary")
     p_run.add_argument("--ready-timeout", type=float, default=20.0, help="Seconds to wait for local MCP readiness")
     p_run.add_argument("--tunnel-doctor", action="store_true", help="Run tunnel-client doctor before starting the tunnel")
+    p_run.add_argument("--sync-on-start", action="store_true", help="Require one successful data repo sync before exposing the gateway")
     p_run.add_argument("--sync-interval-seconds", type=float, default=DEFAULT_SYNC_INTERVAL_SECONDS, help=f"Seconds between data repo syncs; 0 disables tunnel-managed sync (default: {DEFAULT_SYNC_INTERVAL_SECONDS:g})")
     p_run.add_argument("--sync-timeout-seconds", type=float, default=DEFAULT_SYNC_TIMEOUT_SECONDS, help=f"Seconds before a data repo sync is marked failed (default: {DEFAULT_SYNC_TIMEOUT_SECONDS:g})")
     p_run.add_argument("--state-dir", default=None, help=argparse.SUPPRESS)
@@ -839,6 +847,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_start.add_argument("--tunnel-client", default="tunnel-client", help="Path to tunnel-client binary")
     p_start.add_argument("--ready-timeout", type=float, default=20.0, help="Seconds to wait for local MCP readiness")
     p_start.add_argument("--tunnel-doctor", action="store_true", help="Run tunnel-client doctor before starting the tunnel")
+    p_start.add_argument("--sync-on-start", action="store_true", help="Require one successful data repo sync before exposing the gateway")
     p_start.add_argument("--sync-interval-seconds", type=float, default=DEFAULT_SYNC_INTERVAL_SECONDS, help=f"Seconds between data repo syncs; 0 disables tunnel-managed sync (default: {DEFAULT_SYNC_INTERVAL_SECONDS:g})")
     p_start.add_argument("--sync-timeout-seconds", type=float, default=DEFAULT_SYNC_TIMEOUT_SECONDS, help=f"Seconds before a data repo sync is marked failed (default: {DEFAULT_SYNC_TIMEOUT_SECONDS:g})")
     p_start.set_defaults(func=cmd_start)

--- a/tests/test_tunnel_cli.py
+++ b/tests/test_tunnel_cli.py
@@ -37,6 +37,7 @@ def _args(**overrides):
         "tunnel_client": "tunnel-client",
         "ready_timeout": 0.1,
         "tunnel_doctor": False,
+        "sync_on_start": False,
         "state_dir": None,
         "sync_interval_seconds": 0.0,
         "sync_timeout_seconds": 30.0,
@@ -214,10 +215,10 @@ def test_run_starts_http_and_runs_tunnel_without_doctor_or_autosync_by_default(t
     sync.assert_not_called()
 
 
-def test_run_autosyncs_when_interval_positive(tmp_path, monkeypatch):
+def test_run_syncs_once_when_start_flag_and_interval_both_request_it(tmp_path, monkeypatch):
     data_repo = _make_data_repo(tmp_path)
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-    args = _args(data_repo=str(data_repo), sync_interval_seconds=60.0)
+    args = _args(data_repo=str(data_repo), sync_on_start=True, sync_interval_seconds=60.0)
 
     http_process = MagicMock()
     http_process.poll.return_value = None
@@ -241,6 +242,75 @@ def test_run_autosyncs_when_interval_positive(tmp_path, monkeypatch):
     assert rc == 0
     sync.assert_called_once()
     start_worker.assert_called_once()
+
+
+def test_run_syncs_once_on_start_without_recurring_worker(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    args = _args(data_repo=str(data_repo), sync_on_start=True, sync_interval_seconds=0.0)
+
+    http_process = MagicMock(pid=111)
+    http_process.poll.return_value = None
+    tunnel_process = MagicMock(pid=222)
+    tunnel_process.wait.return_value = 0
+    tunnel_process.poll.return_value = 0
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with patch("fava_trails.tunnel_cli._check_port_available"):
+                with patch("fava_trails.tunnel_cli._sync_data_repo", return_value={"status": "ok"}) as sync:
+                    with patch("fava_trails.tunnel_cli._start_sync_worker") as start_worker:
+                        with patch("fava_trails.tunnel_cli._start_http_runtime", return_value=http_process) as start_http:
+                            with patch("fava_trails.tunnel_cli._wait_for_health"):
+                                with patch("fava_trails.tunnel_cli._start_tunnel_client", return_value=tunnel_process) as start_tunnel:
+                                    assert cmd_run(args) == 0
+
+    sync.assert_called_once()
+    start_worker.assert_not_called()
+    start_http.assert_called_once()
+    start_tunnel.assert_called_once()
+
+
+@pytest.mark.parametrize("sync_state", [
+    {"status": "blocked", "message": "dirty working copy"},
+    {"status": "conflict", "message": "merge conflict"},
+    {"status": "error", "message": "sync timed out after 30s"},
+])
+def test_run_does_not_expose_after_initial_sync_failure(tmp_path, monkeypatch, sync_state):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    args = _args(data_repo=str(data_repo), sync_on_start=True)
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with patch("fava_trails.tunnel_cli._check_port_available"):
+                with patch("fava_trails.tunnel_cli._sync_data_repo", return_value=sync_state) as sync:
+                    with patch("fava_trails.tunnel_cli._start_sync_worker") as start_worker:
+                        with patch("fava_trails.tunnel_cli._start_http_runtime") as start_http:
+                            with patch("fava_trails.tunnel_cli._start_tunnel_client") as start_tunnel:
+                                assert cmd_run(args) == 1
+
+    sync.assert_called_once()
+    start_worker.assert_not_called()
+    start_http.assert_not_called()
+    start_tunnel.assert_not_called()
+
+
+def test_run_does_not_expose_when_startup_sync_times_out(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    args = _args(data_repo=str(data_repo), sync_on_start=True)
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with patch("fava_trails.tunnel_cli._check_port_available"):
+                with patch("fava_trails.tunnel_cli._sync_data_repo", side_effect=TimeoutError):
+                    with patch("fava_trails.tunnel_cli._start_http_runtime") as start_http:
+                        with patch("fava_trails.tunnel_cli._start_tunnel_client") as start_tunnel:
+                            assert cmd_run(args) == 1
+
+    start_http.assert_not_called()
+    start_tunnel.assert_not_called()
 
 
 def test_run_checks_doctor_when_requested(tmp_path, monkeypatch):
@@ -330,11 +400,36 @@ def test_start_passes_tunnel_doctor_to_supervisor_when_requested(tmp_path, monke
     assert rc == 0
 
 
+def test_start_forwards_sync_on_start_to_supervisor(tmp_path, monkeypatch):
+    data_repo = _make_data_repo(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    args = _args(data_repo=str(data_repo), sync_on_start=True)
+
+    process = MagicMock(pid=4321)
+    process.poll.return_value = None
+    state_dir = tunnel_cli._state_dir(data_repo.resolve(), DEFAULT_PROFILE)
+
+    def fake_popen(command, *args, **kwargs):
+        state_dir.mkdir(parents=True, exist_ok=True)
+        tunnel_cli._ready_file(state_dir).write_text('{"status":"ready"}\n')
+        assert "--sync-on-start" in command
+        return process
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            with patch("fava_trails.tunnel_cli._check_port_available"):
+                with patch("subprocess.Popen", side_effect=fake_popen):
+                    assert cmd_start(args) == 0
+
+
 def test_detached_startup_timeout_includes_sync_budget_and_grace():
     enabled = _args(ready_timeout=2.0, sync_interval_seconds=60.0, sync_timeout_seconds=3.0)
+    flagged = _args(ready_timeout=2.0, sync_on_start=True, sync_interval_seconds=0.0, sync_timeout_seconds=3.0)
     disabled = _args(ready_timeout=2.0, sync_interval_seconds=0.0, sync_timeout_seconds=3.0)
 
     assert tunnel_cli._detached_startup_timeout(enabled) == 2.0 + 3.0 + tunnel_cli.DETACHED_STARTUP_GRACE_SECONDS
+    assert tunnel_cli._detached_startup_timeout(flagged) == 2.0 + 3.0 + tunnel_cli.DETACHED_STARTUP_GRACE_SECONDS
     assert tunnel_cli._detached_startup_timeout(disabled) == 2.0 + tunnel_cli.DETACHED_STARTUP_GRACE_SECONDS
 
 


### PR DESCRIPTION
Summary:
- Adds the bounded fava-trails-tunnel run/start --sync-on-start interface.
- Requires exactly one successful bounded sync before starting HTTP or exposing the tunnel when the flag or a positive interval requests initial sync.
- Retains recurring sync only for positive intervals, and forwards the flag plus sync budget through detached start.

Validation:
- uv run ruff check
- PYTHONPATH=src uv run pytest tests/test_tunnel_cli.py -q (32 passed)
- PYTHONPATH=src uv run pytest -q
- git diff --check

Review:
- Native mw-review found no blocking findings.
- The external Claude pass was policy-blocked because it would transmit private source; the native fallback completed.