### PR TITLE
fix: constrain MCP to 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to FAVA Trails are documented here.
 
 ## Unreleased
 
+## [0.5.9] — 2026-07-29
+
+### Fixed
+- Constrain MCP to the supported 1.x line so a fresh dependency resolution cannot select MCP 2.0 and crash the MCP server before initialization.
+
 ## [0.5.8] — 2026-07-08
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,26 +16,26 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.0.0,<2.0",
-    "pydantic>=2.0.0",
-    "pyyaml>=6.0",
-    "python-ulid>=3.0.0",
-    "any-llm-sdk>=1.10.0",
-    "httpx>=0.27.0",
-    "starlette>=0.52.0",
-    "uvicorn>=0.41.0",
+    "pydantic>=2.0.0,<3.0",
+    "pyyaml>=6.0,<7.0",
+    "python-ulid>=3.0.0,<4.0",
+    "any-llm-sdk>=1.10.0,<2.0",
+    "httpx>=0.27.0,<1.0",
+    "starlette>=0.52.0,<1.0",
+    "uvicorn>=0.41.0,<1.0",
 ]
 
 [project.optional-dependencies]
-bedrock   = ["any-llm-sdk[bedrock]"]
-groq      = ["any-llm-sdk[groq]"]
-anthropic = ["any-llm-sdk[anthropic]"]
-gemini    = ["any-llm-sdk[gemini]"]
-mistral   = ["any-llm-sdk[mistral]"]
-ollama    = ["any-llm-sdk[ollama]"]
+bedrock   = ["any-llm-sdk[bedrock]>=1.10.0,<2.0"]
+groq      = ["any-llm-sdk[groq]>=1.10.0,<2.0"]
+anthropic = ["any-llm-sdk[anthropic]>=1.10.0,<2.0"]
+gemini    = ["any-llm-sdk[gemini]>=1.10.0,<2.0"]
+mistral   = ["any-llm-sdk[mistral]>=1.10.0,<2.0"]
+ollama    = ["any-llm-sdk[ollama]>=1.10.0,<2.0"]
 # Protocol extras: lightweight protocols (1-2 deps) live here as extras.
 # Protocols with heavy dependency trees must be UV workspace members instead.
-secom     = ["llmlingua>=0.2.0"]
-all       = ["any-llm-sdk[bedrock,groq,anthropic,gemini,mistral,ollama]", "llmlingua>=0.2.0"]
+secom     = ["llmlingua>=0.2.0,<1.0"]
+all       = ["any-llm-sdk[bedrock,groq,anthropic,gemini,mistral,ollama]>=1.10.0,<2.0", "llmlingua>=0.2.0,<1.0"]
 
 [project.urls]
 Homepage = "https://github.com/MachineWisdomAI/fava-trails"
@@ -48,7 +48,7 @@ fava-trails = "fava_trails.cli:main"
 fava-trails-tunnel = "fava_trails.tunnel_cli:main"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.0,<2.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
@@ -86,7 +86,7 @@ ignore = ["E501", "B008"]
 
 [dependency-groups]
 dev = [
-    "pytest>=9.0.2",
-    "pytest-asyncio>=1.3.0",
-    "ruff>=0.8.0",
+    "pytest>=9.0.2,<10.0",
+    "pytest-asyncio>=1.3.0,<2.0",
+    "ruff>=0.8.0,<1.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fava-trails"
-version = "0.5.8"
+version = "0.5.9"
 description = "FAVA Trails 🫛👣 — Federated Agents Versioned Audit Trail. VCS-backed memory for AI agents via MCP."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
 ]
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2.0",
     "pydantic>=2.0.0",
     "pyyaml>=6.0",
     "python-ulid>=3.0.0",

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1,0 +1,17 @@
+"""Regression tests for runtime dependency compatibility boundaries."""
+
+import tomllib
+from pathlib import Path
+
+
+def test_mcp_dependency_excludes_incompatible_major_version():
+    """FAVA's current server registration API requires MCP 1.x."""
+    pyproject = tomllib.loads((Path(__file__).parents[1] / "pyproject.toml").read_text())
+
+    mcp_requirement = next(
+        dependency
+        for dependency in pyproject["project"]["dependencies"]
+        if dependency.startswith("mcp")
+    )
+
+    assert "<2.0" in mcp_requirement

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -4,14 +4,17 @@ import tomllib
 from pathlib import Path
 
 
-def test_mcp_dependency_excludes_incompatible_major_version():
-    """FAVA's current server registration API requires MCP 1.x."""
+def test_all_direct_dependencies_exclude_their_next_major_version():
+    """Named dependencies must not silently cross a major compatibility boundary."""
     pyproject = tomllib.loads((Path(__file__).parents[1] / "pyproject.toml").read_text())
 
-    mcp_requirement = next(
-        dependency
-        for dependency in pyproject["project"]["dependencies"]
-        if dependency.startswith("mcp")
-    )
+    dependencies = [*pyproject["project"]["dependencies"]]
+    for group in pyproject["project"].get("optional-dependencies", {}).values():
+        dependencies.extend(group)
+    for group in pyproject.get("dependency-groups", {}).values():
+        dependencies.extend(group)
+    dependencies.extend(pyproject["build-system"]["requires"])
 
-    assert "<2.0" in mcp_requirement
+    unbounded = [dependency for dependency in dependencies if "<" not in dependency]
+
+    assert not unbounded, f"missing next-major bound: {', '.join(unbounded)}"

--- a/uv.lock
+++ b/uv.lock
@@ -477,7 +477,7 @@ wheels = [
 
 [[package]]
 name = "fava-trails"
-version = "0.5.8"
+version = "0.5.9"
 source = { editable = "." }
 dependencies = [
     { name = "any-llm-sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -537,7 +537,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "llmlingua", marker = "extra == 'all'", specifier = ">=0.2.0" },
     { name = "llmlingua", marker = "extra == 'secom'", specifier = ">=0.2.0" },
-    { name = "mcp", specifier = ">=1.0.0" },
+    { name = "mcp", specifier = ">=1.0.0,<2.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "python-ulid", specifier = ">=3.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -526,31 +526,31 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "any-llm-sdk", specifier = ">=1.10.0" },
-    { name = "any-llm-sdk", extras = ["anthropic"], marker = "extra == 'anthropic'" },
-    { name = "any-llm-sdk", extras = ["bedrock"], marker = "extra == 'bedrock'" },
-    { name = "any-llm-sdk", extras = ["bedrock", "groq", "anthropic", "gemini", "mistral", "ollama"], marker = "extra == 'all'" },
-    { name = "any-llm-sdk", extras = ["gemini"], marker = "extra == 'gemini'" },
-    { name = "any-llm-sdk", extras = ["groq"], marker = "extra == 'groq'" },
-    { name = "any-llm-sdk", extras = ["mistral"], marker = "extra == 'mistral'" },
-    { name = "any-llm-sdk", extras = ["ollama"], marker = "extra == 'ollama'" },
-    { name = "httpx", specifier = ">=0.27.0" },
-    { name = "llmlingua", marker = "extra == 'all'", specifier = ">=0.2.0" },
-    { name = "llmlingua", marker = "extra == 'secom'", specifier = ">=0.2.0" },
+    { name = "any-llm-sdk", specifier = ">=1.10.0,<2.0" },
+    { name = "any-llm-sdk", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.10.0,<2.0" },
+    { name = "any-llm-sdk", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.10.0,<2.0" },
+    { name = "any-llm-sdk", extras = ["bedrock", "groq", "anthropic", "gemini", "mistral", "ollama"], marker = "extra == 'all'", specifier = ">=1.10.0,<2.0" },
+    { name = "any-llm-sdk", extras = ["gemini"], marker = "extra == 'gemini'", specifier = ">=1.10.0,<2.0" },
+    { name = "any-llm-sdk", extras = ["groq"], marker = "extra == 'groq'", specifier = ">=1.10.0,<2.0" },
+    { name = "any-llm-sdk", extras = ["mistral"], marker = "extra == 'mistral'", specifier = ">=1.10.0,<2.0" },
+    { name = "any-llm-sdk", extras = ["ollama"], marker = "extra == 'ollama'", specifier = ">=1.10.0,<2.0" },
+    { name = "httpx", specifier = ">=0.27.0,<1.0" },
+    { name = "llmlingua", marker = "extra == 'all'", specifier = ">=0.2.0,<1.0" },
+    { name = "llmlingua", marker = "extra == 'secom'", specifier = ">=0.2.0,<1.0" },
     { name = "mcp", specifier = ">=1.0.0,<2.0" },
-    { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "python-ulid", specifier = ">=3.0.0" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "starlette", specifier = ">=0.52.0" },
-    { name = "uvicorn", specifier = ">=0.41.0" },
+    { name = "pydantic", specifier = ">=2.0.0,<3.0" },
+    { name = "python-ulid", specifier = ">=3.0.0,<4.0" },
+    { name = "pyyaml", specifier = ">=6.0,<7.0" },
+    { name = "starlette", specifier = ">=0.52.0,<1.0" },
+    { name = "uvicorn", specifier = ">=0.41.0,<1.0" },
 ]
 provides-extras = ["bedrock", "groq", "anthropic", "gemini", "mistral", "ollama", "secom", "all"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = ">=9.0.2" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "ruff", specifier = ">=0.8.0" },
+    { name = "pytest", specifier = ">=9.0.2,<10.0" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0" },
+    { name = "ruff", specifier = ">=0.8.0,<1.0" },
 ]
 
 [[package]]
@@ -2225,15 +2225,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.3.1"
+version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- constrain the runtime MCP dependency to the supported 1.x major line
- synchronize the uv lockfile requirement
- add a regression check that prevents removal of the MCP 2.x cap before the migration is implemented

## Validation

- `uv run ruff check .`
- `uv run pytest -q` (699 passed)
- direct stdio MCP `initialize` response under MCP 1.26.0

## Follow-up

MCP 2 migration is tracked in #83.
