### PR TITLE
feat: add per-machine Trust Gate config

### DIFF
--- a/AGENTS_SETUP_INSTRUCTIONS.md
+++ b/AGENTS_SETUP_INSTRUCTIONS.md
@@ -36,25 +36,35 @@ The default model (`google/gemini-2.5-flash`) costs ~$0.001 per review.
 **Local OpenAI-compatible endpoint (e.g. Unsloth Studio):**
 
 Unsloth Studio (and similar local servers) expose authenticated OpenAI-compatible
-`/v1/chat/completions` endpoints. Point Trust Gate at them via `config.yaml`:
+`/v1/chat/completions` endpoints. Point Trust Gate at them on one machine via
+`$XDG_CONFIG_HOME/fava-trails/config.yaml` (default
+`~/.config/fava-trails/config.yaml`):
 
 ```yaml
 trust_gate: llm-oneshot
 trust_gate_provider: openai
 trust_gate_model: <exact-model-id-served-by-studio>
 trust_gate_api_base: http://127.0.0.1:<studio-api-port>/v1
-trust_gate_api_key_env: UNSLOTH_API_KEY
+trust_gate_api_key_file: /path/to/owner-only/runtime/api-key
 # Slow quantized local models may need more time; keep this below tool_timeout_secs.
 trust_gate_timeout_secs: 240
-tool_timeout_secs: 300
+trust_gate_extra_body:
+  enable_thinking: false
 ```
 
-Unsloth Studio generates local API keys (`sk-unsloth-…`) under **Settings → API**.
-`unsloth run` can also auto-create and print a key. Copy that value into the env
-var named by `trust_gate_api_key_env` (see [Unsloth API docs](https://unsloth.ai/docs/basics/api)).
+The key file must be a regular, non-symlink file owned by the current user with
+no group or other permissions (mode `0600`). It is read for every promotion. If
+the provider returns 401 and the file value changed, FAVA retries exactly once
+with the new value. `trust_gate_api_key_env` remains available as a fallback when
+no key file is configured (see [Unsloth API docs](https://unsloth.ai/docs/basics/api)).
 Do not hardcode host, port, model, or credentials in the engine. There is **no
 automatic fallback** to OpenRouter if the local provider fails — Trust Gate stays
 fail-closed.
+
+Per-machine config may contain only Trust Gate runtime fields. Effective
+precedence is machine config, then the data repo's `config.yaml`, then defaults;
+repository paths, remotes, push strategy, hooks, and trail definitions cannot be
+overridden per machine.
 
 FAVA Trails uses [any-llm-sdk](https://github.com/mozilla-ai/any-llm) for the provider seam.
 
@@ -155,6 +165,8 @@ trust_gate_model: google/gemini-2.5-flash # exact model id for LLM-based review
 trust_gate_api_base: null                 # optional; set for OpenAI-compatible local endpoints
 trust_gate_api_key_env: OPENROUTER_API_KEY # env var name holding the API key
 # openrouter_api_key_env: OPENROUTER_API_KEY  # deprecated alias for trust_gate_api_key_env
+# trust_gate_api_key_file: /path/to/key    # owner-only file; takes precedence over env
+# trust_gate_extra_body: {}               # provider-specific request body
 trust_gate_timeout_secs: 120              # LLM wait; raise for slow local models (< tool_timeout_secs)
 tool_timeout_secs: 300
 
@@ -184,6 +196,8 @@ trails:
 | `trust_gate_api_base` | string | `null` | Optional OpenAI-compatible API base (e.g. Unsloth Studio `http://127.0.0.1:<port>/v1`) |
 | `trust_gate_api_key_env` | string | `OPENROUTER_API_KEY` (via alias) | Env var name holding the API key |
 | `openrouter_api_key_env` | string | `OPENROUTER_API_KEY` | Deprecated alias for `trust_gate_api_key_env` |
+| `trust_gate_api_key_file` | string | `null` | Owner-only credential file; takes precedence over environment variables and is reread for each promotion |
+| `trust_gate_extra_body` | mapping | `{}` | Provider-specific request body passed through to the chat-completions request |
 | `trust_gate_timeout_secs` | int | `120` | Trust Gate LLM timeout; raise for slow local models, keep below `tool_timeout_secs` |
 | `tool_timeout_secs` | int | `300` | Outer MCP tool timeout |
 | `hooks` | list | `[]` | Lifecycle hook entries (see [Lifecycle Hooks](#lifecycle-hooks)) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to FAVA Trails are documented here.
 ## Unreleased
 
 ### Added
+- Standard per-machine Trust Gate configuration at `$XDG_CONFIG_HOME/fava-trails/config.yaml` (default `~/.config/fava-trails/config.yaml`), limited to runtime-specific fields and shared by the MCP server, doctor, readiness, and tunnel preflight.
+- Owner-only `trust_gate_api_key_file` credentials with per-promotion reads and one retry after a 401 only when the file value changed; `trust_gate_extra_body` supports provider-specific controls such as disabling local-model thinking.
 - Provider-neutral Trust Gate LLM configuration: `trust_gate_provider`, `trust_gate_api_base`, and `trust_gate_api_key_env` (with `openrouter_api_key_env` retained as a backward-compatible alias). OpenRouter remains the default; local OpenAI-compatible endpoints (e.g. Unsloth Studio) are supported via any-llm-sdk without product-specific transport. Implements #85.
 - Trust Gate provenance now records `provider` and returned `model` alongside the existing `reviewer` field.
 - `fava-trails doctor` reports the configured Trust Gate provider/model/api_base and validates the configured key env var (OpenRouter key URL only when provider is openrouter).

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ OPENROUTER_API_KEY = "sk-or-v1-..."
 }
 ```
 
-> **The Trust Gate uses LLM verification:** Thoughts are reviewed before promotion to ensure they're coherent and safe. By default, FAVA Trails uses [OpenRouter](https://openrouter.ai/) to access 300–500+ models from 60+ providers including Anthropic, OpenAI, Google, Qwen, and others. Get a free API key at [openrouter.ai/keys](https://openrouter.ai/keys). The default model (`google/gemini-2.5-flash`) costs ~$0.001 per review. You can instead point Trust Gate at a local OpenAI-compatible endpoint (e.g. [Unsloth Studio](https://unsloth.ai/docs/new/studio)) via `trust_gate_provider`, `trust_gate_api_base`, and `trust_gate_api_key_env` in `config.yaml` — see [AGENTS_SETUP_INSTRUCTIONS.md](AGENTS_SETUP_INSTRUCTIONS.md).
+> **The Trust Gate uses LLM verification:** Thoughts are reviewed before promotion to ensure they're coherent and safe. By default, FAVA Trails uses [OpenRouter](https://openrouter.ai/) to access 300–500+ models from 60+ providers including Anthropic, OpenAI, Google, Qwen, and others. Get a free API key at [openrouter.ai/keys](https://openrouter.ai/keys). The default model (`google/gemini-2.5-flash`) costs ~$0.001 per review. You can instead point Trust Gate at a local OpenAI-compatible endpoint (e.g. [Unsloth Studio](https://unsloth.ai/docs/new/studio)) through the standard per-machine config at `~/.config/fava-trails/config.yaml` — see [AGENTS_SETUP_INSTRUCTIONS.md](AGENTS_SETUP_INSTRUCTIONS.md).
 
 ### Use it
 
@@ -292,7 +292,7 @@ Environment variables:
 | `FAVA_TRAILS_SCOPE` | Agent | Project-specific scope from `.env` file | *(none)* |
 | `OPENROUTER_API_KEY` | Server | Default Trust Gate API key env (OpenRouter). Override the env var *name* via `trust_gate_api_key_env` / legacy `openrouter_api_key_env` in `config.yaml`. | *(none — required for `propose_truth` when using llm-oneshot)* |
 
-**LLM Provider:** FAVA Trails uses [any-llm-sdk](https://github.com/mozilla-ai/any-llm) for unified LLM access. OpenRouter is the default Trust Gate provider. To use a local OpenAI-compatible server (Unsloth Studio, vLLM, etc.), set `trust_gate_provider`, `trust_gate_model`, optional `trust_gate_api_base`, and `trust_gate_api_key_env` in `config.yaml`. Slow local quantized models may need a higher `trust_gate_timeout_secs` (still below `tool_timeout_secs`). There is no automatic fallback between providers.
+**LLM Provider:** FAVA Trails uses [any-llm-sdk](https://github.com/mozilla-ai/any-llm) for unified LLM access. OpenRouter is the default Trust Gate provider. To use a local OpenAI-compatible server (Unsloth Studio, vLLM, etc.) on one machine, put its Trust Gate runtime fields in `$XDG_CONFIG_HOME/fava-trails/config.yaml` (default `~/.config/fava-trails/config.yaml`). A credential file configured with `trust_gate_api_key_file` takes precedence over the environment and must be a regular, non-symlink, owner-only file. Slow local quantized models may need a higher `trust_gate_timeout_secs` (still below `tool_timeout_secs`). There is no automatic fallback between providers.
 
 The server reads `$FAVA_TRAILS_DATA_REPO/config.yaml` for global settings. Minimal `config.yaml`:
 
@@ -301,6 +301,8 @@ trails_dir: trails          # relative to FAVA_TRAILS_DATA_REPO
 remote_url: null            # git remote URL (optional)
 push_strategy: manual       # manual | immediate
 ```
+
+The standard per-machine config overrides only Trust Gate runtime fields. Repository settings such as `trails_dir`, `remote_url`, `push_strategy`, hooks, and trail definitions remain owned by the data repo. Effective precedence is machine config, then data-repo config, then defaults.
 
 When `push_strategy: immediate`, the server auto-pushes after every successful write. Push failures are non-fatal.
 

--- a/src/fava_trails/cli.py
+++ b/src/fava_trails/cli.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import yaml
 
 from .config import get_data_repo_root, get_trails_dir, load_global_config, sanitize_scope_path, save_global_config
+from .credentials import load_trust_gate_api_key, trust_gate_credential_description
 from .models import HookEntry, ThoughtRecord
 
 # ─── JJ binary helper ─────────────────────────────────────────────────────────
@@ -573,15 +574,22 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     # Check 3: Trust Gate provider + API key
     # Share validate_trust_gate_runtime() with tunnel/gateway preflight so doctor
     # and startup agree on provider/model/key-env (api_base stays optional).
-    env_var_name = "OPENROUTER_API_KEY"  # noqa: S105 — env var name, not a secret
+    credential_description = "OPENROUTER_API_KEY"  # noqa: S105 — env var name, not a secret
     provider = "openrouter"
     model = "google/gemini-2.5-flash"
     api_base = None
     trust_gate_policy = "llm-oneshot"
     trust_gate_config_ok = True
+    trust_gate_key_file: str | None = None
     try:
         global_config = load_global_config()
         env_var_name = global_config.validate_trust_gate_runtime()
+        configured_key_file = getattr(global_config, "trust_gate_api_key_file", None)
+        if isinstance(configured_key_file, str) and configured_key_file:
+            trust_gate_key_file = configured_key_file
+            credential_description = trust_gate_credential_description(global_config)
+        else:
+            credential_description = env_var_name
         provider = global_config.trust_gate_provider
         model = global_config.trust_gate_model
         api_base = global_config.trust_gate_api_base
@@ -599,17 +607,30 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         print(provider_line)
 
         if trust_gate_policy == "llm-oneshot":
-            if os.environ.get(env_var_name):
-                print(f"API key:      {env_var_name} is set")
+            credential_error: ValueError | None = None
+            if trust_gate_key_file:
+                try:
+                    load_trust_gate_api_key(global_config)
+                except ValueError as exc:
+                    credential_error = exc
+            elif not os.environ.get(env_var_name):
+                credential_error = ValueError(f"{env_var_name} is not set")
+
+            if credential_error is None:
+                availability = "is available" if trust_gate_key_file else "is set"
+                print(f"API key:      {credential_description} {availability}")
             else:
-                print(f"API key:      NOT SET ({env_var_name})")
-                print(f"  Fix: export {env_var_name}=...")
+                if trust_gate_key_file:
+                    print(f"API key:      INVALID ({credential_error})")
+                else:
+                    print(f"API key:      NOT SET ({env_var_name})")
+                    print(f"  Fix: export {env_var_name}=...")
                 if provider == "openrouter":
                     print("  Get a key: https://openrouter.ai/keys")
                 else:
                     print(
                         f"  Configure the API key for provider '{provider}' "
-                        f"(see trust_gate_api_key_env / optional trust_gate_api_base in config.yaml)."
+                        "(see trust_gate_api_key_file / trust_gate_api_key_env in config.yaml)."
                     )
                 any_failed = True
         else:

--- a/src/fava_trails/cli.py
+++ b/src/fava_trails/cli.py
@@ -580,16 +580,11 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     api_base = None
     trust_gate_policy = "llm-oneshot"
     trust_gate_config_ok = True
-    trust_gate_key_file: str | None = None
     try:
         global_config = load_global_config()
         env_var_name = global_config.validate_trust_gate_runtime()
-        configured_key_file = getattr(global_config, "trust_gate_api_key_file", None)
-        if isinstance(configured_key_file, str) and configured_key_file:
-            trust_gate_key_file = configured_key_file
-            credential_description = trust_gate_credential_description(global_config)
-        else:
-            credential_description = env_var_name
+        trust_gate_key_file = global_config.trust_gate_api_key_file
+        credential_description = trust_gate_credential_description(global_config)
         provider = global_config.trust_gate_provider
         model = global_config.trust_gate_model
         api_base = global_config.trust_gate_api_base
@@ -607,14 +602,11 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         print(provider_line)
 
         if trust_gate_policy == "llm-oneshot":
-            credential_error: ValueError | None = None
-            if trust_gate_key_file:
-                try:
-                    load_trust_gate_api_key(global_config)
-                except ValueError as exc:
-                    credential_error = exc
-            elif not os.environ.get(env_var_name):
-                credential_error = ValueError(f"{env_var_name} is not set")
+            try:
+                load_trust_gate_api_key(global_config)
+                credential_error: ValueError | None = None
+            except ValueError as exc:
+                credential_error = exc
 
             if credential_error is None:
                 availability = "is available" if trust_gate_key_file else "is set"

--- a/src/fava_trails/config.py
+++ b/src/fava_trails/config.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import yaml
 
@@ -15,6 +15,20 @@ from .models import GlobalConfig, TrailConfig
 logger = logging.getLogger(__name__)
 
 DEFAULT_FAVA_HOME = os.path.expanduser("~/.fava-trails")
+MAX_CONFIG_BYTES = 256 * 1024
+
+# Per-machine configuration is deliberately limited to Trust Gate runtime
+# selection. Durable trail/repository settings remain owned by the data repo.
+MACHINE_TRUST_GATE_KEYS = frozenset({
+    "trust_gate",
+    "trust_gate_provider",
+    "trust_gate_model",
+    "trust_gate_api_base",
+    "trust_gate_api_key_env",
+    "trust_gate_api_key_file",
+    "trust_gate_timeout_secs",
+    "trust_gate_extra_body",
+})
 
 # Scope path segment: alphanumeric + hyphens/dots/underscores, starts with alphanumeric
 _SCOPE_SEGMENT_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
@@ -66,6 +80,53 @@ def sanitize_namespace(namespace: str) -> str:
     return namespace
 
 
+def get_machine_config_path() -> Path:
+    """Return the standard per-machine FAVA Trails configuration path."""
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    root = Path(config_home).expanduser() if config_home else Path.home() / ".config"
+    return root / "fava-trails" / "config.yaml"
+
+
+def _read_config_mapping(path: Path, *, missing_ok: bool) -> dict[str, Any]:
+    if not path.exists():
+        if missing_ok:
+            return {}
+        raise ValueError("data repository config.yaml is missing")
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise ValueError("configuration file is not readable") from exc
+    if len(raw) > MAX_CONFIG_BYTES:
+        raise ValueError("configuration file exceeds the read limit")
+    try:
+        parsed = yaml.safe_load(raw.decode("utf-8"))
+    except (UnicodeDecodeError, yaml.YAMLError) as exc:
+        raise ValueError("configuration file is malformed") from exc
+    if parsed is None:
+        return {}
+    if not isinstance(parsed, dict):
+        raise ValueError("configuration must be a mapping")
+    return parsed
+
+
+def apply_machine_config(data_config: dict[str, Any]) -> dict[str, Any]:
+    """Overlay standard per-machine Trust Gate fields onto data-repo config."""
+    machine_path = get_machine_config_path()
+    machine_config = _read_config_mapping(machine_path, missing_ok=True)
+    unsupported = sorted(set(machine_config) - MACHINE_TRUST_GATE_KEYS)
+    if unsupported:
+        raise ValueError(
+            "unsupported per-machine configuration key(s): " + ", ".join(unsupported)
+        )
+    return {**data_config, **machine_config}
+
+
+def load_effective_global_config(data_repo_root: Path) -> GlobalConfig:
+    """Load data-repo configuration with standard per-machine Trust Gate overrides."""
+    data = _read_config_mapping(data_repo_root / "config.yaml", missing_ok=True)
+    return GlobalConfig(**apply_machine_config(data))
+
+
 class ConfigStore:
     """Singleton for cached global config access.
 
@@ -95,13 +156,7 @@ class ConfigStore:
         data_repo = os.environ.get("FAVA_TRAILS_DATA_REPO")
         data_repo_root = Path(data_repo) if data_repo else Path(DEFAULT_FAVA_HOME)
 
-        config_path = data_repo_root / "config.yaml"
-        if config_path.exists():
-            with open(config_path) as f:
-                data = yaml.safe_load(f) or {}
-            global_config = GlobalConfig(**data)
-        else:
-            global_config = GlobalConfig()
+        global_config = load_effective_global_config(data_repo_root)
 
         # Resolve trails_dir
         env_override = os.environ.get("FAVA_TRAILS_DIR")
@@ -147,16 +202,24 @@ def get_trails_dir() -> Path:
 
 
 def load_global_config() -> GlobalConfig:
-    """Load global configuration from config.yaml."""
+    """Load effective data-repo and per-machine configuration."""
     return ConfigStore.get().global_config
 
 
 def save_global_config(config: GlobalConfig) -> None:
-    """Save global configuration to config.yaml."""
+    """Save data-repo configuration without persisting machine overrides."""
     config_path = ConfigStore.get().data_repo_root / "config.yaml"
     config_path.parent.mkdir(parents=True, exist_ok=True)
+    persisted = config.model_dump()
+    data_config = _read_config_mapping(config_path, missing_ok=True)
+    machine_config = _read_config_mapping(get_machine_config_path(), missing_ok=True)
+    for key in MACHINE_TRUST_GATE_KEYS.intersection(machine_config):
+        if key in data_config:
+            persisted[key] = data_config[key]
+        else:
+            persisted.pop(key, None)
     with open(config_path, "w") as f:
-        yaml.dump(config.model_dump(), f, default_flow_style=False, sort_keys=False)
+        yaml.dump(persisted, f, default_flow_style=False, sort_keys=False)
     ConfigStore.reset()  # Invalidate cache after write
 
 

--- a/src/fava_trails/credentials.py
+++ b/src/fava_trails/credentials.py
@@ -1,0 +1,63 @@
+"""Trust Gate credential resolution without secret-bearing diagnostics."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+from .models import GlobalConfig
+
+
+def _load_owner_only_key_file(configured_path: str) -> str:
+    path = Path(configured_path).expanduser()
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise ValueError("Trust Gate credential file is not readable") from exc
+    if stat.S_ISLNK(metadata.st_mode):
+        raise ValueError("Trust Gate credential file must not be a symlink")
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    if nofollow is None or not hasattr(os, "getuid"):
+        raise ValueError("Trust Gate credential files require owner-checking platform support")
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, os.O_RDONLY | nofollow | getattr(os, "O_CLOEXEC", 0))
+        opened_metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(opened_metadata.st_mode):
+            raise ValueError("Trust Gate credential file must be a regular file")
+        if opened_metadata.st_uid != os.getuid():
+            raise ValueError("Trust Gate credential file must be owned by the current user")
+        if stat.S_IMODE(opened_metadata.st_mode) & 0o077:
+            raise ValueError("Trust Gate credential file must be owner-only")
+        with os.fdopen(descriptor, encoding="utf-8") as handle:
+            descriptor = None
+            value = handle.read().strip()
+    except ValueError:
+        raise
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValueError("Trust Gate credential file is not readable") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+    if not value:
+        raise ValueError("Trust Gate credential file is empty")
+    return value
+
+
+def load_trust_gate_api_key(config: GlobalConfig) -> str:
+    """Load the configured key, preferring a strict file over the legacy env source."""
+    if config.trust_gate_api_key_file:
+        return _load_owner_only_key_file(config.trust_gate_api_key_file)
+    env_name = config.resolve_trust_gate_api_key_env()
+    value = os.environ.get(env_name, "").strip()
+    if not value:
+        raise ValueError(f"No LLM API key found. Set {env_name} environment variable.")
+    return value
+
+
+def trust_gate_credential_description(config: GlobalConfig) -> str:
+    """Return a non-secret, path-free description for diagnostics."""
+    if config.trust_gate_api_key_file:
+        return "credential file"
+    return config.resolve_trust_gate_api_key_env()

--- a/src/fava_trails/credentials.py
+++ b/src/fava_trails/credentials.py
@@ -33,9 +33,11 @@ def _load_owner_only_key_file(configured_path: str) -> str:
         with os.fdopen(descriptor, encoding="utf-8") as handle:
             descriptor = None
             value = handle.read().strip()
+    except UnicodeDecodeError as exc:
+        raise ValueError("Trust Gate credential file is not readable") from exc
     except ValueError:
         raise
-    except (OSError, UnicodeDecodeError) as exc:
+    except OSError as exc:
         raise ValueError("Trust Gate credential file is not readable") from exc
     finally:
         if descriptor is not None:

--- a/src/fava_trails/llm/client.py
+++ b/src/fava_trails/llm/client.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import any_llm
 import httpx
+from any_llm.exceptions import AuthenticationError
 
 from ._retry import async_retry
 from .registry import get_registry
@@ -55,11 +57,15 @@ class LLMClient:
         provider: str = "openrouter",
         api_base: str | None = None,
         openrouter_api_key: str | None = None,
+        api_key_loader: Callable[[], str] | None = None,
+        extra_body: dict | None = None,
     ) -> None:
         # openrouter_api_key is retained as a backward-compatible alias.
         self._api_key = api_key if api_key is not None else openrouter_api_key
         self._provider = provider
         self._api_base = api_base
+        self._api_key_loader = api_key_loader
+        self._extra_body = dict(extra_body or {})
 
     @property
     def provider(self) -> str:
@@ -87,7 +93,7 @@ class LLMClient:
         forward the exact configured model identifier so local servers (e.g.
         Unsloth Studio) receive the ID they actually expose.
         """
-        if not self._api_key:
+        if not self._api_key and self._api_key_loader is None:
             raise LLMError("LLM API key required but not provided")
 
         # OpenRouter-oriented alias registry must not rewrite local/custom IDs
@@ -116,6 +122,17 @@ class LLMClient:
         if self._api_base is not None:
             kwargs["api_base"] = self._api_base
 
+        if self._extra_body:
+            kwargs["extra_body"] = dict(self._extra_body)
+
+        def _load_api_key() -> str | None:
+            if self._api_key_loader is None:
+                return self._api_key
+            try:
+                return self._api_key_loader()
+            except Exception as exc:
+                raise LLMError("LLM API credential unavailable") from exc
+
         async def _do_call() -> LLMResponse:
             # Use explicit httpx.Timeout phases to ensure all timeout types are set.
             # A scalar timeout only sets the total/read timeout; connect and pool
@@ -126,14 +143,27 @@ class LLMClient:
                 write=timeout,
                 pool=10.0,
             )
-            response = await any_llm.acompletion(
-                model=resolved_model,
-                provider=self._provider,
-                messages=messages,
-                api_key=self._api_key,
-                client_args={"timeout": httpx_timeout},
-                **kwargs,
-            )
+            api_key = _load_api_key()
+
+            async def _request(key: str | None):
+                return await any_llm.acompletion(
+                    model=resolved_model,
+                    provider=self._provider,
+                    messages=messages,
+                    api_key=key,
+                    client_args={"timeout": httpx_timeout},
+                    **kwargs,
+                )
+
+            try:
+                response = await _request(api_key)
+            except AuthenticationError:
+                if self._api_key_loader is None:
+                    raise
+                rotated_key = _load_api_key()
+                if rotated_key == api_key:
+                    raise
+                response = await _request(rotated_key)
             choice = response.choices[0] if response.choices else None
             content = choice.message.content if choice and choice.message else ""
 

--- a/src/fava_trails/models.py
+++ b/src/fava_trails/models.py
@@ -226,6 +226,13 @@ class GlobalConfig(BaseModel):
     trust_gate_api_key_env: str | None = None
     # Deprecated alias for trust_gate_api_key_env (OpenRouter default).
     openrouter_api_key_env: str = "OPENROUTER_API_KEY"
+    # Optional owner-only credential file. When set, it takes precedence over
+    # environment variables and is read for every Trust Gate request.
+    trust_gate_api_key_file: str | None = None
+    # Provider-specific request body passed through to any-llm. This is useful
+    # for OpenAI-compatible local servers whose generation controls are not
+    # part of the common chat-completions schema.
+    trust_gate_extra_body: dict[str, Any] = Field(default_factory=dict)
     # Timeout for the Trust Gate LLM call (asyncio.wait_for guard).
     # Should be well above a normal slow response (e.g. 60-90s) but short enough
     # to recover from a hung provider before the session times out. 0 = disabled.
@@ -262,6 +269,15 @@ class GlobalConfig(BaseModel):
             return None
         if not isinstance(v, str) or not v.strip():
             raise ValueError("trust_gate_api_key_env must be a non-empty string when set")
+        return v.strip()
+
+    @field_validator("trust_gate_api_key_file")
+    @classmethod
+    def normalize_trust_gate_api_key_file(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        if not isinstance(v, str) or not v.strip():
+            raise ValueError("trust_gate_api_key_file must be a non-empty path when set")
         return v.strip()
 
     @field_validator("trust_gate_api_base")

--- a/src/fava_trails/readiness.py
+++ b/src/fava_trails/readiness.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import yaml
 from pydantic import ValidationError
 
+from .config import apply_machine_config
 from .models import GlobalConfig, ThoughtRecord
 
 MAX_CONFIG_BYTES = 256 * 1024
@@ -80,7 +81,7 @@ def _validate_config(data_repo: Path, deadline: float) -> GlobalConfig:
         parsed = yaml.safe_load(raw.decode("utf-8"))
         if not isinstance(parsed, dict):
             raise ValueError("config must be a mapping")
-        config = GlobalConfig(**parsed)
+        config = GlobalConfig(**apply_machine_config(parsed))
     except (UnicodeDecodeError, ValueError, yaml.YAMLError, ValidationError) as exc:
         raise ReadinessFailure("config_malformed", "data repository config is malformed") from exc
     return config

--- a/src/fava_trails/readiness.py
+++ b/src/fava_trails/readiness.py
@@ -11,10 +11,9 @@ from pathlib import Path
 import yaml
 from pydantic import ValidationError
 
-from .config import apply_machine_config
+from .config import MAX_CONFIG_BYTES, apply_machine_config
 from .models import GlobalConfig, ThoughtRecord
 
-MAX_CONFIG_BYTES = 256 * 1024
 MAX_THOUGHT_BYTES = 512 * 1024
 MAX_TREE_ENTRIES = 100_000
 DEFAULT_READINESS_TIMEOUT_SECONDS = 2.0
@@ -83,7 +82,7 @@ def _validate_config(data_repo: Path, deadline: float) -> GlobalConfig:
             raise ValueError("config must be a mapping")
         config = GlobalConfig(**apply_machine_config(parsed))
     except (UnicodeDecodeError, ValueError, yaml.YAMLError, ValidationError) as exc:
-        raise ReadinessFailure("config_malformed", "data repository config is malformed") from exc
+        raise ReadinessFailure("config_malformed", "effective configuration is malformed") from exc
     return config
 
 

--- a/src/fava_trails/tools/navigation.py
+++ b/src/fava_trails/tools/navigation.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from typing import Any
 
 from ..config import ConfigStore, get_trails_dir, get_trust_gate_policy
@@ -134,20 +133,23 @@ async def handle_propose_truth(
                 return {"status": "error", "message": str(e)}
 
             global_config = ConfigStore.get().global_config
-            api_key_env = global_config.resolve_trust_gate_api_key_env()
-            api_key = os.environ.get(api_key_env, "")
-            if not api_key:
+            from ..credentials import load_trust_gate_api_key
+
+            try:
+                load_trust_gate_api_key(global_config)
+            except ValueError as exc:
                 return {
                     "status": "error",
-                    "message": (f"No LLM API key found. Set {api_key_env} environment variable."),
+                    "message": str(exc),
                 }
 
             from ..llm import LLMClient
 
             llm_client = LLMClient(
-                api_key=api_key,
+                api_key_loader=lambda: load_trust_gate_api_key(global_config),
                 provider=global_config.trust_gate_provider,
                 api_base=global_config.trust_gate_api_base,
+                extra_body=global_config.trust_gate_extra_body,
             )
 
             tg_timeout = global_config.trust_gate_timeout_secs

--- a/src/fava_trails/tunnel_cli.py
+++ b/src/fava_trails/tunnel_cli.py
@@ -48,9 +48,7 @@ class GatewayConfig:
     mcp_path: str
     profile: str
     tunnel_client: str
-    # Credential source description. Retains the historical attribute name for
-    # callers that display the configured environment variable.
-    trust_gate_env: str
+    trust_gate_credential: str
 
     @property
     def mcp_url(self) -> str:
@@ -198,7 +196,7 @@ def _load_gateway_config(args: argparse.Namespace, *, require_tunnel_client: boo
         mcp_path=mcp_path,
         profile=profile,
         tunnel_client=tunnel_client or tunnel_client_arg,
-        trust_gate_env=trust_gate_credential,
+        trust_gate_credential=trust_gate_credential,
     )
 
 

--- a/src/fava_trails/tunnel_cli.py
+++ b/src/fava_trails/tunnel_cli.py
@@ -21,12 +21,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import NoReturn
 
-import yaml
 from pydantic import ValidationError
 
 from .cli import _find_jj_bin
-from .config import ConfigStore
-from .models import GlobalConfig
+from .config import ConfigStore, load_effective_global_config
+from .credentials import load_trust_gate_api_key, trust_gate_credential_description
 from .readiness import DEFAULT_READINESS_TIMEOUT_SECONDS
 
 DEFAULT_HOST = "127.0.0.1"
@@ -49,6 +48,8 @@ class GatewayConfig:
     mcp_path: str
     profile: str
     tunnel_client: str
+    # Credential source description. Retains the historical attribute name for
+    # callers that display the configured environment variable.
     trust_gate_env: str
 
     @property
@@ -150,16 +151,15 @@ def _load_gateway_config(args: argparse.Namespace, *, require_tunnel_client: boo
     identity = _resolve_gateway_identity(args)
     data_repo = identity.data_repo
 
-    config_path = data_repo / "config.yaml"
-    if not config_path.is_file():
-        raise ValueError(f"missing data repo config.yaml: {config_path}")
+    if not (data_repo / "config.yaml").is_file():
+        raise ValueError(f"missing data repo config.yaml: {data_repo / 'config.yaml'}")
 
     try:
-        config_data = yaml.safe_load(config_path.read_text()) or {}
-    except yaml.YAMLError as exc:
-        raise ValueError(f"invalid data repo config.yaml: {exc}") from exc
+        global_config = load_effective_global_config(data_repo)
+    except (ValidationError, ValueError, TypeError) as exc:
+        raise ValueError(f"invalid Trust Gate configuration: {exc}") from exc
 
-    trails_value = config_data.get("trails_dir", "trails")
+    trails_value = global_config.trails_dir
     trails_dir = Path(trails_value)
     if not trails_dir.is_absolute():
         trails_dir = data_repo / trails_dir
@@ -169,27 +169,13 @@ def _load_gateway_config(args: argparse.Namespace, *, require_tunnel_client: boo
     if _find_jj_bin() is None:
         raise ValueError("jj not found. Install with: fava-trails install-jj")
 
-    # Reuse the typed GlobalConfig seam so provider/model/api_base/key-env are
-    # validated the same way as doctor and propose_truth (no duplicated alias logic).
     try:
-        if not isinstance(config_data, dict):
-            raise ValueError("config must be a mapping")
-        global_config = GlobalConfig(**config_data)
-        trust_gate_env = global_config.validate_trust_gate_runtime()
+        global_config.validate_trust_gate_runtime()
+        trust_gate_credential = trust_gate_credential_description(global_config)
+        if global_config.trust_gate == "llm-oneshot":
+            load_trust_gate_api_key(global_config)
     except (ValidationError, ValueError, TypeError) as exc:
         raise ValueError(f"invalid Trust Gate configuration: {exc}") from exc
-
-    if global_config.trust_gate == "llm-oneshot" and not os.environ.get(trust_gate_env):
-        raise ValueError(
-            f"Trust Gate provider config missing: set {trust_gate_env} "
-            f"(provider={global_config.trust_gate_provider}, model={global_config.trust_gate_model}"
-            + (
-                f", api_base={global_config.trust_gate_api_base}"
-                if global_config.trust_gate_api_base
-                else ""
-            )
-            + ")"
-        )
 
     host = getattr(args, "host", DEFAULT_HOST)
     port = getattr(args, "port", DEFAULT_PORT)
@@ -212,7 +198,7 @@ def _load_gateway_config(args: argparse.Namespace, *, require_tunnel_client: boo
         mcp_path=mcp_path,
         profile=profile,
         tunnel_client=tunnel_client or tunnel_client_arg,
-        trust_gate_env=trust_gate_env,
+        trust_gate_env=trust_gate_credential,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,6 +32,7 @@ from fava_trails.cli import (
     cmd_secom_warmup,
 )
 from fava_trails.config import ConfigStore
+from fava_trails.models import GlobalConfig
 
 
 def _cleanup_args(**overrides):
@@ -520,9 +521,11 @@ def test_doctor_all_green(tmp_path, monkeypatch, capsys):
         with patch("fava_trails.cli.load_global_config") as mock_config:
             cfg = mock_config.return_value
             cfg.validate_trust_gate_runtime.return_value = "OPENROUTER_API_KEY"
+            cfg.resolve_trust_gate_api_key_env.return_value = "OPENROUTER_API_KEY"
             cfg.trust_gate_provider = "openrouter"
             cfg.trust_gate_model = "google/gemini-2.5-flash"
             cfg.trust_gate_api_base = None
+            cfg.trust_gate_api_key_file = None
             cfg.trust_gate = "llm-oneshot"
             with patch("shutil.which", return_value="/usr/bin/jj"):
                 with patch("subprocess.run", return_value=_make_jj_mock(0)) as mock_run:
@@ -559,9 +562,11 @@ def test_doctor_missing_jj(tmp_path, monkeypatch, capsys):
         with patch("fava_trails.cli.load_global_config") as mock_config:
             cfg = mock_config.return_value
             cfg.validate_trust_gate_runtime.return_value = "OPENROUTER_API_KEY"
+            cfg.resolve_trust_gate_api_key_env.return_value = "OPENROUTER_API_KEY"
             cfg.trust_gate_provider = "openrouter"
             cfg.trust_gate_model = "google/gemini-2.5-flash"
             cfg.trust_gate_api_base = None
+            cfg.trust_gate_api_key_file = None
             cfg.trust_gate = "llm-oneshot"
             with patch("shutil.which", return_value=None):
                 with patch.object(Path, "exists", exists_side_effect):
@@ -584,9 +589,11 @@ def test_doctor_missing_data_repo(tmp_path, monkeypatch, capsys):
         with patch("fava_trails.cli.load_global_config") as mock_config:
             cfg = mock_config.return_value
             cfg.validate_trust_gate_runtime.return_value = "OPENROUTER_API_KEY"
+            cfg.resolve_trust_gate_api_key_env.return_value = "OPENROUTER_API_KEY"
             cfg.trust_gate_provider = "openrouter"
             cfg.trust_gate_model = "google/gemini-2.5-flash"
             cfg.trust_gate_api_base = None
+            cfg.trust_gate_api_key_file = None
             cfg.trust_gate = "llm-oneshot"
             with patch("shutil.which", return_value="/usr/bin/jj"):
                 with patch("subprocess.run", return_value=_make_jj_mock(0)) as mock_run:
@@ -609,9 +616,11 @@ def test_doctor_missing_scope(tmp_path, monkeypatch, capsys):
         with patch("fava_trails.cli.load_global_config") as mock_config:
             cfg = mock_config.return_value
             cfg.validate_trust_gate_runtime.return_value = "OPENROUTER_API_KEY"
+            cfg.resolve_trust_gate_api_key_env.return_value = "OPENROUTER_API_KEY"
             cfg.trust_gate_provider = "openrouter"
             cfg.trust_gate_model = "google/gemini-2.5-flash"
             cfg.trust_gate_api_base = None
+            cfg.trust_gate_api_key_file = None
             cfg.trust_gate = "llm-oneshot"
             with patch("shutil.which", return_value="/usr/bin/jj"):
                 with patch("subprocess.run", return_value=_make_jj_mock(0)) as mock_run:
@@ -635,9 +644,11 @@ def test_doctor_missing_openrouter_key(tmp_path, monkeypatch, capsys):
         with patch("fava_trails.cli.load_global_config") as mock_config:
             cfg = mock_config.return_value
             cfg.validate_trust_gate_runtime.return_value = "OPENROUTER_API_KEY"
+            cfg.resolve_trust_gate_api_key_env.return_value = "OPENROUTER_API_KEY"
             cfg.trust_gate_provider = "openrouter"
             cfg.trust_gate_model = "google/gemini-2.5-flash"
             cfg.trust_gate_api_base = None
+            cfg.trust_gate_api_key_file = None
             cfg.trust_gate = "llm-oneshot"
             with patch("shutil.which", return_value="/usr/bin/jj"):
                 with patch("subprocess.run", return_value=_make_jj_mock(0)) as mock_run:
@@ -648,6 +659,74 @@ def test_doctor_missing_openrouter_key(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "API key:      NOT SET" in out
     assert "openrouter.ai/keys" in out
+
+
+def test_doctor_rejects_whitespace_only_environment_key(tmp_path, monkeypatch, capsys):
+    """Doctor and propose_truth must agree that a whitespace key is missing."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "   ")
+    data_repo = _make_valid_data_repo(tmp_path)
+    (tmp_path / ".env").write_text("FAVA_TRAILS_SCOPE=mw/eng/test\n")
+
+    with patch("fava_trails.cli.get_data_repo_root", return_value=data_repo):
+        with patch("fava_trails.cli.load_global_config", return_value=GlobalConfig()):
+            with patch("shutil.which", return_value="/usr/bin/jj"):
+                with patch("subprocess.run", return_value=_make_jj_mock(0)):
+                    rc = cmd_doctor(_make_args())
+
+    assert rc == 1
+    assert "API key:      NOT SET (OPENROUTER_API_KEY)" in capsys.readouterr().out
+
+
+def test_doctor_accepts_owner_only_key_file_without_exposing_path(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    data_repo = _make_valid_data_repo(tmp_path)
+    (tmp_path / ".env").write_text("FAVA_TRAILS_SCOPE=mw/eng/test\n")
+    key_file = tmp_path / "runtime-api-key"
+    key_file.write_text("local-key\n")
+    key_file.chmod(0o600)
+    config = GlobalConfig(
+        trust_gate_provider="openai",
+        trust_gate_model="local-model",
+        trust_gate_api_base="http://127.0.0.1:8888/v1",
+        trust_gate_api_key_file=str(key_file),
+    )
+
+    with patch("fava_trails.cli.get_data_repo_root", return_value=data_repo):
+        with patch("fava_trails.cli.load_global_config", return_value=config):
+            with patch("shutil.which", return_value="/usr/bin/jj"):
+                with patch("subprocess.run", return_value=_make_jj_mock(0)):
+                    rc = cmd_doctor(_make_args())
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "API key:      credential file is available" in out
+    assert str(key_file) not in out
+
+
+def test_doctor_rejects_insecure_key_file_without_exposing_path(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    data_repo = _make_valid_data_repo(tmp_path)
+    (tmp_path / ".env").write_text("FAVA_TRAILS_SCOPE=mw/eng/test\n")
+    key_file = tmp_path / "runtime-api-key"
+    key_file.write_text("local-key\n")
+    key_file.chmod(0o644)
+    config = GlobalConfig(
+        trust_gate_provider="openai",
+        trust_gate_model="local-model",
+        trust_gate_api_key_file=str(key_file),
+    )
+
+    with patch("fava_trails.cli.get_data_repo_root", return_value=data_repo):
+        with patch("fava_trails.cli.load_global_config", return_value=config):
+            with patch("shutil.which", return_value="/usr/bin/jj"):
+                with patch("subprocess.run", return_value=_make_jj_mock(0)):
+                    rc = cmd_doctor(_make_args())
+
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "must be owner-only" in out
+    assert str(key_file) not in out
 
 
 def test_doctor_local_provider_missing_key_no_openrouter_url(tmp_path, monkeypatch, capsys):
@@ -662,9 +741,11 @@ def test_doctor_local_provider_missing_key_no_openrouter_url(tmp_path, monkeypat
         with patch("fava_trails.cli.load_global_config") as mock_config:
             cfg = mock_config.return_value
             cfg.validate_trust_gate_runtime.return_value = "UNSLOTH_API_KEY"
+            cfg.resolve_trust_gate_api_key_env.return_value = "UNSLOTH_API_KEY"
             cfg.trust_gate_provider = "openai"
             cfg.trust_gate_model = "local-gguf"
             cfg.trust_gate_api_base = "http://127.0.0.1:8000/v1"
+            cfg.trust_gate_api_key_file = None
             cfg.trust_gate = "llm-oneshot"
             with patch("shutil.which", return_value="/usr/bin/jj"):
                 with patch("subprocess.run", return_value=_make_jj_mock(0)) as mock_run:
@@ -716,9 +797,11 @@ def test_doctor_hosted_openai_without_api_base_ok(tmp_path, monkeypatch, capsys)
         with patch("fava_trails.cli.load_global_config") as mock_config:
             cfg = mock_config.return_value
             cfg.validate_trust_gate_runtime.return_value = "OPENAI_API_KEY"
+            cfg.resolve_trust_gate_api_key_env.return_value = "OPENAI_API_KEY"
             cfg.trust_gate_provider = "openai"
             cfg.trust_gate_model = "gpt-4.1-mini"
             cfg.trust_gate_api_base = None
+            cfg.trust_gate_api_key_file = None
             cfg.trust_gate = "llm-oneshot"
             with patch("shutil.which", return_value="/usr/bin/jj"):
                 with patch("subprocess.run", return_value=_make_jj_mock(0)) as mock_run:

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -212,6 +212,68 @@ async def test_custom_provider_and_api_base_forwarded():
 
 
 @pytest.mark.asyncio
+async def test_extra_body_forwarded_to_openai_compatible_provider():
+    """Provider-specific request controls reach the OpenAI-compatible API."""
+    client = LLMClient(
+        api_key="local-key",
+        provider="openai",
+        api_base="http://127.0.0.1:9999/v1",
+        extra_body={"enable_thinking": False},
+    )
+    mock_resp = _mock_completion("ok", model="local-gguf")
+
+    with patch("fava_trails.llm.client.any_llm.acompletion", new_callable=AsyncMock) as call:
+        call.return_value = mock_resp
+        await client.chat(messages=[{"role": "user", "content": "hi"}], model="local-gguf")
+
+    assert call.call_args.kwargs["extra_body"] == {"enable_thinking": False}
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_retries_once_only_when_file_key_changed():
+    """A 401 caused by rotation gets one retry with the newly read key."""
+    keys = iter(("old-key", "new-key"))
+    client = LLMClient(
+        api_key_loader=lambda: next(keys),
+        provider="openai",
+        api_base="http://127.0.0.1:9999/v1",
+    )
+    mock_resp = _mock_completion("ok", model="local-gguf")
+
+    with patch("fava_trails.llm.client.any_llm.acompletion", new_callable=AsyncMock) as call:
+        call.side_effect = [AuthenticationError("expired"), mock_resp]
+        result = await client.chat(messages=[{"role": "user", "content": "hi"}], model="local-gguf")
+
+    assert result.content == "ok"
+    assert [item.kwargs["api_key"] for item in call.call_args_list] == ["old-key", "new-key"]
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_does_not_retry_when_file_key_is_unchanged():
+    client = LLMClient(api_key_loader=lambda: "same-key")
+
+    with patch("fava_trails.llm.client.any_llm.acompletion", new_callable=AsyncMock) as call:
+        call.side_effect = AuthenticationError("bad key")
+        with pytest.raises(AuthenticationError):
+            await client.chat(messages=[{"role": "user", "content": "hi"}], model="model")
+
+    assert call.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_key_loader_failure_does_not_enter_request_retry_loop():
+    loader = MagicMock(side_effect=ValueError("credential unavailable"))
+    client = LLMClient(api_key_loader=loader)
+
+    with patch("fava_trails.llm.client.any_llm.acompletion", new_callable=AsyncMock) as call:
+        with pytest.raises(LLMError, match="credential unavailable"):
+            await client.chat(messages=[{"role": "user", "content": "hi"}], model="model")
+
+    assert loader.call_count == 1
+    call.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_local_provider_preserves_registry_colliding_model_id():
     """Local/custom endpoints must not rewrite IDs that collide with OpenRouter aliases.
 

--- a/tests/test_machine_trust_gate_config.py
+++ b/tests/test_machine_trust_gate_config.py
@@ -184,6 +184,19 @@ def test_key_file_is_read_each_time_for_safe_rotation(tmp_path):
     assert load_trust_gate_api_key(config) == "new-key"
 
 
+def test_key_file_invalid_utf8_uses_safe_generic_error(tmp_path):
+    key_file = tmp_path / "api-key"
+    key_file.write_bytes(b"\xff\xfe")
+    key_file.chmod(0o600)
+    config = GlobalConfig(trust_gate_api_key_file=str(key_file))
+
+    with pytest.raises(ValueError, match="credential file is not readable") as exc_info:
+        load_trust_gate_api_key(config)
+
+    assert str(key_file) not in str(exc_info.value)
+    assert "codec" not in str(exc_info.value)
+
+
 def test_env_key_remains_backward_compatible(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-key")
     assert load_trust_gate_api_key(GlobalConfig()) == "openrouter-key"

--- a/tests/test_machine_trust_gate_config.py
+++ b/tests/test_machine_trust_gate_config.py
@@ -1,0 +1,189 @@
+"""Per-machine Trust Gate configuration and credential contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from fava_trails.config import ConfigStore, load_effective_global_config, save_global_config
+from fava_trails.credentials import load_trust_gate_api_key
+from fava_trails.models import GlobalConfig
+from fava_trails.readiness import ReadinessFailure, probe_data_repository
+
+
+def _write_data_config(data_repo: Path) -> None:
+    data_repo.mkdir()
+    (data_repo / "config.yaml").write_text(
+        "\n".join(
+            (
+                "trails_dir: trails",
+                "remote_url: git@github.com:MachineWisdomAI/fava-trails-data.git",
+                "trust_gate: llm-oneshot",
+                "trust_gate_provider: openrouter",
+                "trust_gate_model: google/gemini-2.5-flash",
+                "openrouter_api_key_env: OPENROUTER_API_KEY",
+                "trust_gate_timeout_secs: 120",
+                "tool_timeout_secs: 300",
+            )
+        )
+        + "\n"
+    )
+
+
+def test_machine_config_overrides_only_trust_gate_runtime_fields(tmp_path, monkeypatch):
+    data_repo = tmp_path / "data"
+    _write_data_config(data_repo)
+    config_home = tmp_path / "config"
+    machine_dir = config_home / "fava-trails"
+    machine_dir.mkdir(parents=True)
+    key_file = tmp_path / "local-api-key"
+    (machine_dir / "config.yaml").write_text(
+        "\n".join(
+            (
+                "trust_gate_provider: openai",
+                "trust_gate_model: unsloth/Qwen3.6-27B-GGUF",
+                "trust_gate_api_base: http://127.0.0.1:8888/v1",
+                f'trust_gate_api_key_file: "{key_file}"',
+                "trust_gate_timeout_secs: 240",
+                "trust_gate_extra_body:",
+                "  enable_thinking: false",
+            )
+        )
+        + "\n"
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
+
+    config = load_effective_global_config(data_repo)
+
+    assert config.trails_dir == "trails"
+    assert config.remote_url == "git@github.com:MachineWisdomAI/fava-trails-data.git"
+    assert config.tool_timeout_secs == 300
+    assert config.trust_gate_provider == "openai"
+    assert config.trust_gate_model == "unsloth/Qwen3.6-27B-GGUF"
+    assert config.trust_gate_api_base == "http://127.0.0.1:8888/v1"
+    assert config.trust_gate_api_key_file == str(key_file)
+    assert config.trust_gate_timeout_secs == 240
+    assert config.trust_gate_extra_body == {"enable_thinking": False}
+
+
+def test_absent_machine_config_preserves_data_repo_behavior(tmp_path, monkeypatch):
+    data_repo = tmp_path / "data"
+    _write_data_config(data_repo)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "missing-config-home"))
+
+    config = load_effective_global_config(data_repo)
+
+    assert config.trust_gate_provider == "openrouter"
+    assert config.trust_gate_model == "google/gemini-2.5-flash"
+    assert config.resolve_trust_gate_api_key_env() == "OPENROUTER_API_KEY"
+    assert config.trust_gate_api_key_file is None
+    assert config.trust_gate_extra_body == {}
+
+
+def test_machine_config_rejects_non_runtime_keys(tmp_path, monkeypatch):
+    data_repo = tmp_path / "data"
+    _write_data_config(data_repo)
+    machine_dir = tmp_path / "config" / "fava-trails"
+    machine_dir.mkdir(parents=True)
+    (machine_dir / "config.yaml").write_text("trails_dir: private-trails\n")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+    with pytest.raises(ValueError, match="unsupported per-machine configuration key"):
+        load_effective_global_config(data_repo)
+
+
+def test_readiness_validates_effective_machine_config(tmp_path, monkeypatch):
+    """Readiness cannot report healthy when the effective machine overlay is invalid."""
+    data_repo = tmp_path / "data"
+    _write_data_config(data_repo)
+    (data_repo / "trails").mkdir()
+    machine_dir = tmp_path / "config" / "fava-trails"
+    machine_dir.mkdir(parents=True)
+    (machine_dir / "config.yaml").write_text("trust_gate_timeout_secs: 300\n")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+    with pytest.raises(ReadinessFailure, match="data repository config is malformed"):
+        probe_data_repository(data_repo)
+
+
+def test_saving_global_config_does_not_persist_machine_overrides(tmp_path, monkeypatch):
+    """Protocol setup must never leak machine model or credential paths into shared config."""
+    data_repo = tmp_path / "data"
+    _write_data_config(data_repo)
+    config_home = tmp_path / "config"
+    machine_dir = config_home / "fava-trails"
+    machine_dir.mkdir(parents=True)
+    (machine_dir / "config.yaml").write_text(
+        "\n".join(
+            (
+                "trust_gate_provider: openai",
+                "trust_gate_model: local-model",
+                "trust_gate_api_key_file: /private/runtime/api-key",
+                "trust_gate_extra_body:",
+                "  enable_thinking: false",
+            )
+        )
+        + "\n"
+    )
+    monkeypatch.setenv("FAVA_TRAILS_DATA_REPO", str(data_repo))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
+    ConfigStore.reset()
+
+    save_global_config(ConfigStore.get().global_config)
+
+    persisted = yaml.safe_load((data_repo / "config.yaml").read_text())
+    assert persisted["trust_gate_provider"] == "openrouter"
+    assert persisted["trust_gate_model"] == "google/gemini-2.5-flash"
+    assert "trust_gate_api_key_file" not in persisted
+    assert "trust_gate_extra_body" not in persisted
+
+
+def test_key_file_takes_precedence_and_requires_owner_only_regular_file(tmp_path, monkeypatch):
+    key_file = tmp_path / "api-key"
+    key_file.write_text("file-key\n")
+    key_file.chmod(0o600)
+    monkeypatch.setenv("FALLBACK_API_KEY", "env-key")
+    config = GlobalConfig(
+        trust_gate_api_key_file=str(key_file),
+        trust_gate_api_key_env="FALLBACK_API_KEY",
+    )
+
+    assert load_trust_gate_api_key(config) == "file-key"
+
+    key_file.chmod(0o640)
+    with pytest.raises(ValueError, match="owner-only"):
+        load_trust_gate_api_key(config)
+
+
+def test_key_file_rejects_symlink_and_does_not_expose_path(tmp_path):
+    target = tmp_path / "actual-secret"
+    target.write_text("secret\n")
+    target.chmod(0o600)
+    link = tmp_path / "linked-secret"
+    link.symlink_to(target)
+    config = GlobalConfig(trust_gate_api_key_file=str(link))
+
+    with pytest.raises(ValueError) as exc_info:
+        load_trust_gate_api_key(config)
+
+    assert "symlink" in str(exc_info.value).lower()
+    assert str(link) not in str(exc_info.value)
+    assert str(target) not in str(exc_info.value)
+
+
+def test_key_file_is_read_each_time_for_safe_rotation(tmp_path):
+    key_file = tmp_path / "api-key"
+    key_file.write_text("old-key\n")
+    key_file.chmod(0o600)
+    config = GlobalConfig(trust_gate_api_key_file=str(key_file))
+
+    assert load_trust_gate_api_key(config) == "old-key"
+    key_file.write_text("new-key\n")
+    assert load_trust_gate_api_key(config) == "new-key"
+
+
+def test_env_key_remains_backward_compatible(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-key")
+    assert load_trust_gate_api_key(GlobalConfig()) == "openrouter-key"

--- a/tests/test_machine_trust_gate_config.py
+++ b/tests/test_machine_trust_gate_config.py
@@ -104,7 +104,7 @@ def test_readiness_validates_effective_machine_config(tmp_path, monkeypatch):
     (machine_dir / "config.yaml").write_text("trust_gate_timeout_secs: 300\n")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
 
-    with pytest.raises(ReadinessFailure, match="data repository config is malformed"):
+    with pytest.raises(ReadinessFailure, match="effective configuration is malformed"):
         probe_data_repository(data_repo)
 
 

--- a/tests/test_trust_gate_local_provider.py
+++ b/tests/test_trust_gate_local_provider.py
@@ -370,6 +370,53 @@ async def test_propose_truth_local_reject(trail_manager, tmp_fava_home, openai_s
 
 
 @pytest.mark.asyncio
+async def test_propose_truth_uses_key_file_and_provider_extra_body(
+    trail_manager,
+    tmp_fava_home,
+    tmp_path,
+    openai_server,
+):
+    """The production promotion path reads the file and disables Qwen thinking."""
+    base_url, handler = openai_server
+    key_file = tmp_path / "runtime-api-key"
+    key_file.write_text("test-local-key\n")
+    key_file.chmod(0o600)
+    record = await trail_manager.save_thought(
+        content="A concrete local-provider observation.",
+        agent_id="test-agent",
+        source_type=SourceType.OBSERVATION,
+    )
+    cache = MagicMock(spec=TrustGatePromptCache)
+    cache.resolve_prompt.return_value = "You are a reviewer."
+    cfg = ConfigStore.__new__(ConfigStore)
+    cfg.global_config = GlobalConfig(
+        trust_gate="llm-oneshot",
+        trust_gate_provider="openai",
+        trust_gate_model="fixture-local-model",
+        trust_gate_api_base=base_url,
+        trust_gate_api_key_file=str(key_file),
+        trust_gate_extra_body={"enable_thinking": False},
+        trust_gate_timeout_secs=30,
+        tool_timeout_secs=60,
+    )
+    cfg.data_repo_root = tmp_fava_home
+    cfg.trails_dir = tmp_fava_home / "trails"
+    ConfigStore.override(cfg)
+
+    result = await handle_propose_truth(
+        trail_manager,
+        {"thought_id": record.thought_id},
+        prompt_cache=cache,
+    )
+
+    assert result["status"] == "ok"
+    assert handler.last_auth == "Bearer test-local-key"
+    assert handler.last_body is not None
+    assert handler.last_body["enable_thinking"] is False
+    assert str(key_file) not in json.dumps(result)
+
+
+@pytest.mark.asyncio
 async def test_propose_truth_missing_configured_key(trail_manager, tmp_fava_home, openai_server):
     base_url, _ = openai_server
 

--- a/tests/test_tunnel_cli.py
+++ b/tests/test_tunnel_cli.py
@@ -130,7 +130,7 @@ def test_load_gateway_config_uses_trust_gate_api_key_env(tmp_path, monkeypatch):
     with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
         with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
             config = _load_gateway_config(_args(data_repo=str(data_repo)))
-    assert config.trust_gate_env == "UNSLOTH_API_KEY"
+    assert config.trust_gate_credential == "UNSLOTH_API_KEY"
 
 
 def test_load_gateway_config_uses_standard_machine_config_and_key_file(tmp_path, monkeypatch):
@@ -163,7 +163,7 @@ def test_load_gateway_config_uses_standard_machine_config_and_key_file(tmp_path,
         with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
             config = _load_gateway_config(_args(data_repo=str(data_repo)))
 
-    assert config.trust_gate_env == "credential file"
+    assert config.trust_gate_credential == "credential file"
 
 
 def test_load_gateway_config_rejects_blank_provider(tmp_path, monkeypatch):
@@ -190,7 +190,7 @@ def test_load_gateway_config_allows_hosted_provider_without_api_base(tmp_path, m
     with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
         with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
             config = _load_gateway_config(_args(data_repo=str(data_repo)))
-    assert config.trust_gate_env == "OPENAI_API_KEY"
+    assert config.trust_gate_credential == "OPENAI_API_KEY"
 
 
 def test_load_gateway_config_rejects_invalid_api_base(tmp_path, monkeypatch):

--- a/tests/test_tunnel_cli.py
+++ b/tests/test_tunnel_cli.py
@@ -133,6 +133,39 @@ def test_load_gateway_config_uses_trust_gate_api_key_env(tmp_path, monkeypatch):
     assert config.trust_gate_env == "UNSLOTH_API_KEY"
 
 
+def test_load_gateway_config_uses_standard_machine_config_and_key_file(tmp_path, monkeypatch):
+    """Tunnel preflight resolves the same XDG Trust Gate config as the MCP server."""
+    data_repo = _make_data_repo(tmp_path)
+    config_home = tmp_path / "config"
+    machine_dir = config_home / "fava-trails"
+    machine_dir.mkdir(parents=True)
+    key_file = tmp_path / "runtime-api-key"
+    key_file.write_text("local-key\n")
+    key_file.chmod(0o600)
+    (machine_dir / "config.yaml").write_text(
+        "\n".join(
+            (
+                "trust_gate_provider: openai",
+                "trust_gate_model: unsloth/Qwen3.6-27B-GGUF",
+                "trust_gate_api_base: http://127.0.0.1:8888/v1",
+                f'trust_gate_api_key_file: "{key_file}"',
+                "trust_gate_timeout_secs: 240",
+                "trust_gate_extra_body:",
+                "  enable_thinking: false",
+            )
+        )
+        + "\n"
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    with patch("fava_trails.tunnel_cli._find_jj_bin", return_value="/usr/bin/jj"):
+        with patch("shutil.which", return_value="/usr/bin/tunnel-client"):
+            config = _load_gateway_config(_args(data_repo=str(data_repo)))
+
+    assert config.trust_gate_env == "credential file"
+
+
 def test_load_gateway_config_rejects_blank_provider(tmp_path, monkeypatch):
     """Blank trust_gate_provider fails tunnel preflight via GlobalConfig validation."""
     data_repo = _make_data_repo(tmp_path, extra_lines=["trust_gate_provider: ''"])


### PR DESCRIPTION
## Summary
- load Trust Gate runtime overrides from the standard XDG config path while keeping data-repo settings authoritative
- add strict owner-only key-file credentials with bounded changed-key rotation retry
- pass provider-specific request body controls through to OpenAI-compatible endpoints
- unify effective config across MCP promotion, doctor, readiness, and tunnel preflight
- document the local-provider configuration and protect shared config writes from machine-value leakage

## Verification
- full pytest suite
- ruff check src/ tests/
- git diff --check
- in-process OpenAI-compatible approve/reject and key-file request tests

Implements the local-machine cutover foundation for #85.