### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to FAVA Trails are documented here.
 
 ## Unreleased
 
+## [0.6.0] — 2026-07-31
+
 ### Added
 - Standard per-machine Trust Gate configuration at `$XDG_CONFIG_HOME/fava-trails/config.yaml` (default `~/.config/fava-trails/config.yaml`), limited to runtime-specific fields and shared by the MCP server, doctor, readiness, and tunnel preflight.
 - Owner-only `trust_gate_api_key_file` credentials with per-promotion reads and one retry after a 401 only when the file value changed; `trust_gate_extra_body` supports provider-specific controls such as disabling local-model thinking.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fava-trails"
-version = "0.5.9"
+version = "0.6.0"
 description = "FAVA Trails 🫛👣 — Federated Agents Versioned Audit Trail. VCS-backed memory for AI agents via MCP."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,11 @@ if not Path(jj_bin).exists():
 
 
 @pytest.fixture(autouse=True)
-def reset_config_store():
-    """Reset ConfigStore singleton before and after every test for isolation."""
+def reset_config_store(monkeypatch, tmp_path):
+    """Isolate machine config and reset ConfigStore around every test."""
     from fava_trails.config import ConfigStore
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
     ConfigStore.reset()
     yield
     ConfigStore.reset()

--- a/uv.lock
+++ b/uv.lock
@@ -477,7 +477,7 @@ wheels = [
 
 [[package]]
 name = "fava-trails"
-version = "0.5.9"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "any-llm-sdk" },


### PR DESCRIPTION
## Summary
- release the standard per-machine Trust Gate provider configuration as v0.6.0
- move the accumulated Unreleased notes into the v0.6.0 changelog section
- isolate tests from the operator's real XDG machine config, discovered during post-merge dogfooding

## Validation
- `uv run pytest -q` — 755 passed
- `uv run ruff check .` — passed
- live local Unsloth dogfood — durable decision approved; adversarial instruction rejected
- `fava-trails doctor` — provider `openai`, model `unsloth/Qwen3.6-27B-GGUF`, credential file available