### PR TITLE
docs: draft FAVA Trails v0.6.0 release article

### DIFF
--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-amplification-kit.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-amplification-kit.md
@@ -25,30 +25,26 @@ Tracked article links are for social posts:
 ### Primary
 
 ```text
-I maintain FAVA Trails, an open-source, Git-native memory system for AI agents.
+Most agent memory systems fail by remembering too much. Agents narrate everything they do, and when all of it becomes "memory," recall turns into a bigger context window full of noise and contradictions that steer later agents wrong.
 
-Version 0.6.0 lets the model that decides which drafts become permanent run locally through an OpenAI-compatible endpoint. I tested that path with a quantized Qwen3.6 27B model and the exact prompt FAVA uses in production.
+FAVA Trails, the open-source Git-native memory system I maintain, treats memory as a lifecycle instead of an archive. Every thought starts as a draft. A trust gate asks whether a future agent, with no context about this conversation, would find it useful. Only what passes becomes permanent, versioned memory, and superseded beliefs stay in the audit history but drop out of recall.
 
-Across 49 historical cases and canaries, the model returned 49 valid verdicts. It matched all 13 historical rejections, 17 of 26 historical approvals, and 9 of 10 canaries.
+Until now that review ran through a hosted model, so every candidate memory crossed an external inference boundary before it could be promoted. With v0.6.0, the gate can run on your own machine through any OpenAI-compatible endpoint. Promotion candidates stay local, per-thought hosted API fees disappear, and a hosted provider leaves the critical path.
 
-The direction of the errors mattered more to me than the aggregate agreement rate. Every disagreement was an additional rejection. A rejected thought stays visible as a draft and can be revised. A bad approval quietly enters institutional memory and can steer later agents.
+Before trusting a quantized model with that job, I benchmarked an Unsloth-served Qwen 3.6 27B against 49 historical promotion decisions with prior Google Gemini verdicts. It proved on par with Gemini for this task, and its errors leaned in the safe direction. Every mistake was an extra rejection, which stays visible as a draft and can be resubmitted. It never quietly approved weak material into institutional memory, where it would steer later agents. For a memory gate, a conservative critic beats a permissive one.
 
-I asked OpenAI Codex running GPT 5.6 to review the nine historical disagreements against the same prompt. It favored Gemini in six cases and the local model in three. That is not independent ground truth, but it made the tradeoff concrete: the local model was stricter, sometimes too strict, and never crossed a historical rejection boundary in this corpus.
-
-For this task, that is an error profile I am willing to operate. Promotion candidates can stay on the local machine, per-thought hosted inference fees disappear, and a hosted provider leaves the critical path.
-
-The benchmark, limitations, and implementation details are here:
+The benchmark, the disagreement audit, and the limitations:
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=linkedin&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=personal-post
 ```
 
 ### Short
 
 ```text
-FAVA Trails v0.6.0 can use a local model to decide what deserves permanent agent memory.
+The hard part of agent memory is deciding what deserves to be remembered.
 
-I tested a quantized Qwen3.6 27B model on 49 historical cases and canaries: 49/49 valid verdicts, 13/13 historical rejections preserved, 17/26 approvals matched, and 9/10 canaries matched.
+FAVA Trails v0.6.0 can make that decision on your own machine: a local model reviews every draft thought before it becomes permanent, versioned memory. Promotion candidates stay local, and no hosted provider sits in the critical path.
 
-A second-model review favored Gemini on six historical disagreements and the local model on three. The local model was stricter, but its errors were conservative and recoverable. For the memory gate I maintain, that tradeoff works.
+I benchmarked an Unsloth quantized Qwen 3.6 model as the gatekeeper against the gate's historical Google Gemini verdicts. It proved on par with Gemini for this job, and every error it made was an extra rejection, recoverable as a draft. It never quietly approved weak material into permanent memory.
 
 Results and limitations:
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=linkedin&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=personal-post
@@ -61,11 +57,9 @@ Reshare the personal post from the company page on the following day. Use one in
 ### Primary
 
 ```text
-FAVA Trails v0.6.0 adds provider-neutral local-model gating for permanent agent memory.
+Agent memory is only as good as the gate that guards it. FAVA Trails, our open-source Git-native memory system, reviews every draft thought before it becomes permanent memory, and with v0.6.0 that review can run entirely on the operator's machine.
 
-The release is backed by a 49-case test of the production promotion prompt: 49 valid verdicts, all 13 historical rejection boundaries preserved, and a conservative error profile that keeps questionable material in drafts instead of quietly promoting it.
-
-Younes explains the benchmark, the six-versus-three disagreement review, and the limits of the evidence in the post below.
+Younes benchmarked an Unsloth quantized Qwen 3.6 model against the gate's historical Google Gemini verdicts, audited every disagreement with a second model, and found it on par with Gemini for this job, with errors that lean conservative. He explains below why that is the right kind of reviewer for a memory gate.
 
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=linkedin&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=company-reshare
 ```
@@ -73,9 +67,7 @@ https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm
 ### Short
 
 ```text
-FAVA Trails v0.6.0 can keep agent-memory promotion review on the operator's machine.
-
-The 49-case benchmark produced valid verdicts every time and preserved all 13 historical rejection boundaries. Read the results, disagreements, and limitations below.
+FAVA Trails v0.6.0 moves agent-memory review onto the operator's machine. Draft thoughts still pass the Trust Gate before becoming permanent memory; the gate can now be a local model, with no hosted provider in the critical path. Benchmark and limitations below.
 
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=linkedin&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=company-reshare
 ```
@@ -85,11 +77,11 @@ https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm
 ### Primary
 
 ```text
-I tested a quantized Qwen3.6 27B model as the local promotion gate for FAVA Trails.
+Agents produce endless text, and almost none of it deserves to be remembered.
 
-The model returned valid verdicts in all 49 cases, preserved all 13 historical rejections, matched 17 of 26 historical approvals, and matched 9 of 10 canaries.
+FAVA Trails, the memory system I maintain, makes every thought earn permanence. It starts as a draft, a trust gate asks whether a future agent with no context would find it useful, and only what passes becomes permanent, versioned memory.
 
-A second-model review of the nine historical disagreements favored Gemini in six cases and the local model in three. The local model was stricter, but every observed error was an additional rejection, which leaves the thought visible and recoverable as a draft.
+As of v0.6.0 that gate can run on a local model. I benchmarked an Unsloth quantized Qwen 3.6 model on 49 historical promotion decisions to see whether it could be trusted with the job. It proved on par with the Google Gemini verdicts it replaced, and every error it made was an extra rejection, which stays recoverable as a draft. It never quietly approved weak material. For a memory gate, that is the right kind of imperfect.
 
 The benchmark and its limits:
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=substack&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=note
@@ -98,7 +90,7 @@ https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm
 ### Short
 
 ```text
-Local-model memory gating in FAVA Trails: 49/49 valid verdicts, all 13 historical rejections preserved, and a six-versus-three disagreement review that showed where the local model was too strict and where it caught weak promotions.
+The model that decides what our agents remember now runs locally. In FAVA Trails' 49-case benchmark, every error the local gatekeeper made was a recoverable rejection, never a quiet bad approval. That error direction is what makes a quantized model acceptable for this job.
 
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=substack&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=note
 ```
@@ -110,7 +102,7 @@ Check https://www.reddit.com/r/LocalLLaMA/about/rules/ immediately before postin
 ### Primary title
 
 ```text
-I tested a quantized Qwen3.6 27B model as a local gate for agent memory: 49 cases, all 13 historical rejections preserved
+I tested quantized Qwen3.6 27B as the gatekeeper for agent memory: 49 cases, every error was a conservative rejection
 ```
 
 ### Primary body
@@ -118,11 +110,11 @@ I tested a quantized Qwen3.6 27B model as a local gate for agent memory: 49 case
 ```markdown
 Disclosure: I maintain FAVA Trails, the open-source project I tested here.
 
-FAVA Trails stores agent memory as versioned Markdown in Git. Draft thoughts go through a promotion gate before they become permanent memory. Version 0.6.0 lets that gate use a local model through an OpenAI-compatible endpoint, so I wanted to know whether a quantized model was reliable enough for this specific job.
+FAVA Trails stores agent memory as versioned Markdown in Git. Draft thoughts pass a promotion gate before they become permanent memory, so the gate decides what future agents will recall. Version 0.6.0 lets that gate use a local model through an OpenAI-compatible endpoint, which keeps promotion candidates on the operator's machine and removes hosted inference from the critical path.
 
-I tested `unsloth/Qwen3.6-27B-GGUF` through Unsloth Studio with the exact production promotion prompt. The corpus contained 39 historical thoughts with prior Gemini verdicts, including 26 approvals and 13 rejections, plus 10 synthetic canaries.
+On paper the gate is a good fit for a local model: stable policy prompt, structured JSON output, auditable historical cases, and asymmetric failure costs. I wanted to know whether a quantized model actually holds up on it.
 
-The historical Gemini verdicts were references from earlier operation, not a fresh Gemini rerun.
+I ran `unsloth/Qwen3.6-27B-GGUF` through Unsloth Studio with the exact production promotion prompt, against 39 historical thoughts with prior Gemini verdicts (26 approvals, 13 rejections) plus 10 synthetic canaries. The Gemini verdicts were references from earlier operation, not a fresh rerun.
 
 | Measure | Result |
 |---|---:|
@@ -137,17 +129,11 @@ The historical Gemini verdicts were references from earlier operation, not a fre
 | p95 latency | 122.9 seconds |
 | Maximum latency | 172.5 seconds |
 
-Every disagreement was an additional rejection by the local model. It did not reverse any of the 13 historical Gemini rejections in this corpus.
+The aggregate agreement rate is the least interesting row. Every disagreement was an additional rejection by the local model, and it did not reverse any of the 13 historical rejections. That direction fits a promotion gate. A false rejection leaves the thought in drafts, where it can be revised and resubmitted. A false approval quietly adds weak material to future agent context.
 
-That error direction fits a promotion gate. A false rejection leaves the thought in drafts, where it can be revised and resubmitted. A false approval quietly adds weak material to future agent context.
+For the nine historical thoughts the local model rejected against Gemini's approval, I asked OpenAI Codex running GPT 5.6 to judge each one against the same prompt. It favored Gemini in six cases and the local model in three: a transient handoff stored as a permanent review, a misclassified implementation artifact, and an imperative task instruction presented as durable knowledge. That review is an interpretive challenge to the old verdicts, not independent ground truth. A separate positive canary accounted for the tenth disagreement.
 
-The local model rejected nine historical thoughts Gemini had approved. I asked OpenAI Codex running GPT 5.6 to judge those nine against the same production prompt. It favored Gemini in six cases and the local model in three. In those three, the local model caught a transient handoff, a misclassified implementation artifact, and an imperative task instruction that lacked durable rationale. A separate positive canary accounted for the tenth disagreement.
-
-That second-model review is an interpretive challenge to the old verdicts, not independent ground truth. The test covers one model, one prompt, and one corpus. It does not show general parity with Gemini or frontier models.
-
-Long inputs were the weak spot. Inputs over 40,000 characters reached only 2/6 raw agreement and had a median latency of 122.9 seconds. The model was also confident when wrong, so confidence is not a useful escalation trigger by itself.
-
-My conclusion is narrow: this quantized model had an acceptable, conservative error profile for this promotion policy. The released integration remains provider-neutral and fails closed if the local endpoint is unavailable or returns malformed output.
+Limitations: one model, one prompt, one corpus. Inputs over 40,000 characters dropped to 2/6 raw agreement with a 122.9-second median latency. The model was confident when wrong (average 0.93 on disagreements), so confidence alone is not a useful escalation trigger. The released integration is provider-neutral and fails closed if the endpoint is unavailable or returns malformed output.
 
 Full write-up:
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=reddit&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=rlocalllama
@@ -159,7 +145,7 @@ https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500
 ### Short title
 
 ```text
-Local Qwen3.6 27B as an agent-memory gate: 49/49 valid verdicts and 13/13 historical rejections preserved
+Local Qwen3.6 27B as an agent-memory gate: valid verdicts in all 49 cases, no reversed rejections
 ```
 
 ### Short body
@@ -167,9 +153,7 @@ Local Qwen3.6 27B as an agent-memory gate: 49/49 valid verdicts and 13/13 histor
 ```markdown
 Disclosure: I maintain FAVA Trails, the open-source project I tested here.
 
-FAVA Trails v0.6.0 can use a local OpenAI-compatible model to review drafts before they enter permanent agent memory. I tested `unsloth/Qwen3.6-27B-GGUF` through Unsloth Studio with the exact production prompt.
-
-The corpus contained 39 historical thoughts with prior Gemini verdicts and 10 synthetic canaries. The Gemini verdicts were historical references, not a fresh rerun.
+FAVA Trails v0.6.0 can use a local OpenAI-compatible model to review drafts before they enter permanent agent memory. I tested `unsloth/Qwen3.6-27B-GGUF` through Unsloth Studio with the exact production prompt, against 39 historical thoughts with prior Gemini verdicts and 10 synthetic canaries. The Gemini verdicts were historical references, not a fresh rerun.
 
 | Measure | Result |
 |---|---:|
@@ -180,9 +164,9 @@ The corpus contained 39 historical thoughts with prior Gemini verdicts and 10 sy
 | Canaries matched | 9/10 |
 | Repeat consistency | 8/8 cases stable across three runs |
 
-Every disagreement was an additional rejection. A second-model review of the nine historical disagreements favored Gemini in six cases and the local model in three. The tenth disagreement was a positive canary. That review is not independent ground truth, but it shows the error direction clearly: the local model was conservative, sometimes too conservative, and did not cross a historical rejection boundary in this corpus.
+Every disagreement was an additional rejection, and the model never reversed a historical rejection. That error direction fits this gate: a false rejection stays recoverable as a draft, while a false approval quietly pollutes permanent memory. A second-model review (OpenAI Codex running GPT 5.6) of the nine historical disagreements favored Gemini in six cases and the local model in three.
 
-The result is limited to one model, prompt, and corpus. Inputs over 40,000 characters were weak at 2/6 raw agreement with 122.9-second median latency, and confidence did not identify bad verdicts.
+Limits: one model, one prompt, one corpus. Inputs over 40,000 characters dropped to 2/6 raw agreement with a 122.9-second median latency, and confidence did not identify bad verdicts.
 
 Full method and limitations:
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=reddit&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=rlocalllama

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-amplification-kit.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-amplification-kit.md
@@ -25,28 +25,26 @@ Tracked article links are for social posts:
 ### Primary
 
 ```text
-Most agent memory systems fail by remembering too much. Agents narrate everything they do, and when all of it becomes "memory," recall turns into a bigger context window full of noise and contradictions that steer later agents wrong.
+Agents generate a lot of text, and most of it should not become durable context. A useful observation, a decision with its rationale, or a hard-won negative result may help the next agent, but process narration and transient runtime state usually will not. When everything is saved indiscriminately, "memory" becomes a larger context window full of noise and contradictions that steer later agents wrong.
 
-FAVA Trails, the open-source Git-native memory system I maintain, treats memory as a lifecycle instead of an archive. Every thought starts as a draft. A trust gate asks whether a future agent, with no context about this conversation, would find it useful. Only what passes becomes permanent, versioned memory, and superseded beliefs stay in the audit history but drop out of recall.
+FAVA Trails, the open-source Git-native memory system I maintain, treats memory as curated, versioned knowledge rather than a transcript archive. Every thought begins as a draft, and a trust gate reviews it by asking whether a future agent, with no context about this conversation, would find it useful. Only the thoughts that pass become permanent memory, while superseded beliefs remain in the audit history but disappear from normal recall.
 
-Until now that review ran through a hosted model, so every candidate memory crossed an external inference boundary before it could be promoted. With v0.6.0, the gate can run on your own machine through any OpenAI-compatible endpoint. Promotion candidates stay local, per-thought hosted API fees disappear, and a hosted provider leaves the critical path.
+Until v0.6.0, that review had to travel through a hosted model, so every candidate memory crossed an external inference boundary before it could be promoted. The gate can now run on the operator's own machine through any OpenAI-compatible endpoint, which keeps promotion candidates local, eliminates per-thought hosted API fees, and removes a hosted provider from the critical path.
 
-Before trusting a quantized model with that job, I benchmarked an Unsloth-served Qwen 3.6 27B against 49 historical promotion decisions with prior Google Gemini verdicts. It proved on par with Gemini for this task, and its errors leaned in the safe direction. Every mistake was an extra rejection, which stays visible as a draft and can be resubmitted. It never quietly approved weak material into institutional memory, where it would steer later agents. For a memory gate, a conservative critic beats a permissive one.
+Before trusting a quantized model with that job, I benchmarked an Unsloth-served Qwen 3.6 27B against 49 historical promotion decisions that carried prior Google Gemini verdicts. It proved on par with Gemini for this task, and its mistakes leaned in the safe direction: every disagreement was an additional rejection, which leaves the thought visible as a draft where it can be revised and resubmitted, rather than a quiet approval that lets weak material into institutional memory. It approved somewhat fewer historical candidates in exchange for keeping promotion review local, and for this job that is a trade I am willing to make.
 
-The benchmark, the disagreement audit, and the limitations:
+The full benchmark, the disagreement audit, and the limitations are in the write-up:
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=linkedin&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=personal-post
 ```
 
 ### Short
 
 ```text
-The hard part of agent memory is deciding what deserves to be remembered.
+The hard part of agent memory is deciding what deserves to be remembered, and FAVA Trails v0.6.0 lets that decision happen on your own machine. A local model can now review every draft thought before it becomes permanent, versioned memory, so promotion candidates stay local and no hosted provider sits in the critical path.
 
-FAVA Trails v0.6.0 can make that decision on your own machine: a local model reviews every draft thought before it becomes permanent, versioned memory. Promotion candidates stay local, and no hosted provider sits in the critical path.
+I benchmarked an Unsloth quantized Qwen 3.6 model against the gate's historical Google Gemini verdicts, and it proved on par with Gemini for this job. Its errors were conservative and recoverable: every mistake was an extra rejection that leaves the thought editable as a draft, rather than a quiet approval that pollutes permanent memory.
 
-I benchmarked an Unsloth quantized Qwen 3.6 model as the gatekeeper against the gate's historical Google Gemini verdicts. It proved on par with Gemini for this job, and every error it made was an extra rejection, recoverable as a draft. It never quietly approved weak material into permanent memory.
-
-Results and limitations:
+The results and their limitations:
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=linkedin&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=personal-post
 ```
 
@@ -57,9 +55,9 @@ Reshare the personal post from the company page on the following day. Use one in
 ### Primary
 
 ```text
-Agent memory is only as good as the gate that guards it. FAVA Trails, our open-source Git-native memory system, reviews every draft thought before it becomes permanent memory, and with v0.6.0 that review can run entirely on the operator's machine.
+FAVA Trails, our open-source Git-native memory system, reviews every draft thought before it becomes permanent agent memory, and with v0.6.0 that review can run entirely on the operator's machine.
 
-Younes benchmarked an Unsloth quantized Qwen 3.6 model against the gate's historical Google Gemini verdicts, audited every disagreement with a second model, and found it on par with Gemini for this job, with errors that lean conservative. He explains below why that is the right kind of reviewer for a memory gate.
+Younes benchmarked an Unsloth quantized Qwen 3.6 model against the gate's historical Google Gemini verdicts and found it on par with Gemini for this job, with mistakes that lean toward rejecting too much rather than approving too much. He explains below why that is the right failure profile for a memory gate.
 
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=linkedin&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=company-reshare
 ```
@@ -67,7 +65,7 @@ https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm
 ### Short
 
 ```text
-FAVA Trails v0.6.0 moves agent-memory review onto the operator's machine. Draft thoughts still pass the Trust Gate before becoming permanent memory; the gate can now be a local model, with no hosted provider in the critical path. Benchmark and limitations below.
+FAVA Trails v0.6.0 moves agent-memory review onto the operator's machine. Draft thoughts still pass the Trust Gate before becoming permanent memory, but the gate can now be a local model, so no hosted provider sits in the critical path. The benchmark and its limitations are below.
 
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=linkedin&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=company-reshare
 ```
@@ -77,11 +75,9 @@ https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm
 ### Primary
 
 ```text
-Agents produce endless text, and almost none of it deserves to be remembered.
+Agents produce endless text, and almost none of it deserves to be remembered. FAVA Trails, the memory system I maintain, makes every thought earn its permanence: a thought begins as a draft, a trust gate asks whether a future agent with no context about the conversation would find it useful, and only the thoughts that pass become permanent, versioned memory.
 
-FAVA Trails, the memory system I maintain, makes every thought earn permanence. It starts as a draft, a trust gate asks whether a future agent with no context would find it useful, and only what passes becomes permanent, versioned memory.
-
-As of v0.6.0 that gate can run on a local model. I benchmarked an Unsloth quantized Qwen 3.6 model on 49 historical promotion decisions to see whether it could be trusted with the job. It proved on par with the Google Gemini verdicts it replaced, and every error it made was an extra rejection, which stays recoverable as a draft. It never quietly approved weak material. For a memory gate, that is the right kind of imperfect.
+As of v0.6.0 that gate can run on a local model. I benchmarked an Unsloth quantized Qwen 3.6 model on 49 historical promotion decisions to see whether it could be trusted with the job, and it proved on par with the Google Gemini verdicts it replaced. Its mistakes were conservative ones: every error was an extra rejection that stays recoverable as a draft, and it never quietly approved weak material into permanent memory.
 
 The benchmark and its limits:
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=substack&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=note
@@ -90,7 +86,7 @@ https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm
 ### Short
 
 ```text
-The model that decides what our agents remember now runs locally. In FAVA Trails' 49-case benchmark, every error the local gatekeeper made was a recoverable rejection, never a quiet bad approval. That error direction is what makes a quantized model acceptable for this job.
+The model that decides what our agents remember now runs locally. In FAVA Trails' 49-case benchmark, an Unsloth quantized Qwen 3.6 model proved on par with Google Gemini, and every mistake it made was a recoverable rejection rather than a quiet approval of weak material.
 
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=substack&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=note
 ```
@@ -102,7 +98,7 @@ Check https://www.reddit.com/r/LocalLLaMA/about/rules/ immediately before postin
 ### Primary title
 
 ```text
-I tested quantized Qwen3.6 27B as the gatekeeper for agent memory: 49 cases, every error was a conservative rejection
+I tested quantized Qwen3.6 27B as a local gate for agent memory across 49 historical cases: every error was an extra rejection, and none reversed a historical rejection
 ```
 
 ### Primary body
@@ -112,7 +108,7 @@ Disclosure: I maintain FAVA Trails, the open-source project I tested here.
 
 FAVA Trails stores agent memory as versioned Markdown in Git. Draft thoughts pass a promotion gate before they become permanent memory, so the gate decides what future agents will recall. Version 0.6.0 lets that gate use a local model through an OpenAI-compatible endpoint, which keeps promotion candidates on the operator's machine and removes hosted inference from the critical path.
 
-On paper the gate is a good fit for a local model: stable policy prompt, structured JSON output, auditable historical cases, and asymmetric failure costs. I wanted to know whether a quantized model actually holds up on it.
+The gate looked like a good fit for a local model on paper, since the task has a stable policy prompt, structured JSON output, auditable historical cases, and asymmetric failure costs. I wanted to know whether a quantized model actually holds up on it.
 
 I ran `unsloth/Qwen3.6-27B-GGUF` through Unsloth Studio with the exact production promotion prompt, against 39 historical thoughts with prior Gemini verdicts (26 approvals, 13 rejections) plus 10 synthetic canaries. The Gemini verdicts were references from earlier operation, not a fresh rerun.
 
@@ -129,11 +125,11 @@ I ran `unsloth/Qwen3.6-27B-GGUF` through Unsloth Studio with the exact productio
 | p95 latency | 122.9 seconds |
 | Maximum latency | 172.5 seconds |
 
-The aggregate agreement rate is the least interesting row. Every disagreement was an additional rejection by the local model, and it did not reverse any of the 13 historical rejections. That direction fits a promotion gate. A false rejection leaves the thought in drafts, where it can be revised and resubmitted. A false approval quietly adds weak material to future agent context.
+Raw agreement was 79.6%, which sounds merely adequate until you look at the direction of the errors. Every disagreement was an additional rejection by the local model, and it did not reverse any of the 13 historical rejections. That direction fits a promotion gate, because a false rejection leaves the thought in drafts where it can be revised and resubmitted, while a false approval quietly adds weak material to future agent context.
 
-For the nine historical thoughts the local model rejected against Gemini's approval, I asked OpenAI Codex running GPT 5.6 to judge each one against the same prompt. It favored Gemini in six cases and the local model in three: a transient handoff stored as a permanent review, a misclassified implementation artifact, and an imperative task instruction presented as durable knowledge. That review is an interpretive challenge to the old verdicts, not independent ground truth. A separate positive canary accounted for the tenth disagreement.
+For the nine historical thoughts the local model rejected against Gemini's approval, I asked OpenAI Codex running GPT 5.6 to judge each one against the same prompt. It favored Gemini in six cases and the local model in three, where the local model had caught a transient handoff stored as a permanent review, an implementation artifact misclassified as a specification, and an imperative task instruction presented as durable knowledge. That review is an interpretive challenge to the old verdicts rather than independent ground truth, and a separate positive canary accounted for the tenth disagreement.
 
-Limitations: one model, one prompt, one corpus. Inputs over 40,000 characters dropped to 2/6 raw agreement with a 122.9-second median latency. The model was confident when wrong (average 0.93 on disagreements), so confidence alone is not a useful escalation trigger. The released integration is provider-neutral and fails closed if the endpoint is unavailable or returns malformed output.
+The result is limited to one model on one prompt and corpus, so it does not establish general parity with Gemini or frontier models. Inputs over 40,000 characters were the weak spot, dropping to 2/6 raw agreement with a 122.9-second median latency. The model was also confident when it was wrong, averaging 0.93 confidence on disagreements, so confidence alone is not a useful escalation trigger. The released integration is provider-neutral and fails closed if the endpoint is unavailable or returns malformed output.
 
 Full write-up:
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=reddit&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=rlocalllama
@@ -145,7 +141,7 @@ https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500
 ### Short title
 
 ```text
-Local Qwen3.6 27B as an agent-memory gate: valid verdicts in all 49 cases, no reversed rejections
+Local Qwen3.6 27B as an agent-memory gate: valid verdicts in all 49 cases, and no reversed rejections
 ```
 
 ### Short body
@@ -164,9 +160,9 @@ FAVA Trails v0.6.0 can use a local OpenAI-compatible model to review drafts befo
 | Canaries matched | 9/10 |
 | Repeat consistency | 8/8 cases stable across three runs |
 
-Every disagreement was an additional rejection, and the model never reversed a historical rejection. That error direction fits this gate: a false rejection stays recoverable as a draft, while a false approval quietly pollutes permanent memory. A second-model review (OpenAI Codex running GPT 5.6) of the nine historical disagreements favored Gemini in six cases and the local model in three.
+Every disagreement was an additional rejection, and the model never reversed a historical rejection. That error direction fits this gate, because a false rejection stays recoverable as a draft while a false approval quietly pollutes permanent memory. A second-model review by OpenAI Codex running GPT 5.6 examined the nine historical disagreements and favored Gemini in six cases and the local model in three.
 
-Limits: one model, one prompt, one corpus. Inputs over 40,000 characters dropped to 2/6 raw agreement with a 122.9-second median latency, and confidence did not identify bad verdicts.
+The result is limited to one model on one prompt and corpus. Inputs over 40,000 characters dropped to 2/6 raw agreement with a 122.9-second median latency, and confidence did not identify bad verdicts.
 
 Full method and limitations:
 https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=reddit&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=rlocalllama

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-amplification-kit.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-amplification-kit.md
@@ -1,0 +1,215 @@
+# Amplification kit: FAVA Trails v0.6.0 local Trust Gate
+
+This file contains copy for manual publishing. Copy only the text inside the relevant block. Younes publishes each item and makes the final platform-specific formatting choice.
+
+## Links
+
+Clean links are for durable owned surfaces:
+
+- Article: https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides
+- FAVA Trails v0.6.0: https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.6.0
+- Benchmark evidence: https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500
+- PyPI: https://pypi.org/project/fava-trails/0.6.0/
+
+Tracked article links are for social posts:
+
+| Destination | URL |
+|---|---|
+| Personal LinkedIn | https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=linkedin&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=personal-post |
+| Company LinkedIn | https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=linkedin&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=company-reshare |
+| Substack Note | https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=substack&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=note |
+| r/LocalLLaMA | https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=reddit&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=rlocalllama |
+
+## Personal LinkedIn
+
+### Primary
+
+```text
+I maintain FAVA Trails, an open-source, Git-native memory system for AI agents.
+
+Version 0.6.0 lets the model that decides which drafts become permanent run locally through an OpenAI-compatible endpoint. I tested that path with a quantized Qwen3.6 27B model and the exact prompt FAVA uses in production.
+
+Across 49 historical cases and canaries, the model returned 49 valid verdicts. It matched all 13 historical rejections, 17 of 26 historical approvals, and 9 of 10 canaries.
+
+The direction of the errors mattered more to me than the aggregate agreement rate. Every disagreement was an additional rejection. A rejected thought stays visible as a draft and can be revised. A bad approval quietly enters institutional memory and can steer later agents.
+
+I asked OpenAI Codex running GPT 5.6 to review the nine historical disagreements against the same prompt. It favored Gemini in six cases and the local model in three. That is not independent ground truth, but it made the tradeoff concrete: the local model was stricter, sometimes too strict, and never crossed a historical rejection boundary in this corpus.
+
+For this task, that is an error profile I am willing to operate. Promotion candidates can stay on the local machine, per-thought hosted inference fees disappear, and a hosted provider leaves the critical path.
+
+The benchmark, limitations, and implementation details are here:
+https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=linkedin&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=personal-post
+```
+
+### Short
+
+```text
+FAVA Trails v0.6.0 can use a local model to decide what deserves permanent agent memory.
+
+I tested a quantized Qwen3.6 27B model on 49 historical cases and canaries: 49/49 valid verdicts, 13/13 historical rejections preserved, 17/26 approvals matched, and 9/10 canaries matched.
+
+A second-model review favored Gemini on six historical disagreements and the local model on three. The local model was stricter, but its errors were conservative and recoverable. For the memory gate I maintain, that tradeoff works.
+
+Results and limitations:
+https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=linkedin&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=personal-post
+```
+
+## Machine Wisdom AI LinkedIn reshare
+
+Reshare the personal post from the company page on the following day. Use one introduction above the reshare.
+
+### Primary
+
+```text
+FAVA Trails v0.6.0 adds provider-neutral local-model gating for permanent agent memory.
+
+The release is backed by a 49-case test of the production promotion prompt: 49 valid verdicts, all 13 historical rejection boundaries preserved, and a conservative error profile that keeps questionable material in drafts instead of quietly promoting it.
+
+Younes explains the benchmark, the six-versus-three disagreement review, and the limits of the evidence in the post below.
+
+https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=linkedin&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=company-reshare
+```
+
+### Short
+
+```text
+FAVA Trails v0.6.0 can keep agent-memory promotion review on the operator's machine.
+
+The 49-case benchmark produced valid verdicts every time and preserved all 13 historical rejection boundaries. Read the results, disagreements, and limitations below.
+
+https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=linkedin&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=company-reshare
+```
+
+## Substack Note
+
+### Primary
+
+```text
+I tested a quantized Qwen3.6 27B model as the local promotion gate for FAVA Trails.
+
+49/49 valid verdicts.
+13/13 historical rejections preserved.
+17/26 historical approvals matched.
+9/10 canaries matched.
+
+A second-model review of the nine historical disagreements favored Gemini in six cases and the local model in three. The local model was stricter, but every observed error was an additional rejection, which leaves the thought visible and recoverable as a draft.
+
+The benchmark and its limits:
+https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=substack&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=note
+```
+
+### Short
+
+```text
+Local-model memory gating in FAVA Trails: 49/49 valid verdicts, all 13 historical rejections preserved, and a six-versus-three disagreement review that showed where the local model was too strict and where it caught weak promotions.
+
+https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=substack&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=note
+```
+
+## r/LocalLLaMA
+
+Check https://www.reddit.com/r/LocalLLaMA/about/rules/ immediately before posting. If a benchmark post with a maintainer disclosure and links would violate the current rules, skip it. Do not remove the disclosure or disguise the links.
+
+### Primary title
+
+```text
+I tested a quantized Qwen3.6 27B model as a local gate for agent memory: 49 cases, all 13 historical rejections preserved
+```
+
+### Primary body
+
+```markdown
+Disclosure: I maintain FAVA Trails, the open-source project I tested here.
+
+FAVA Trails stores agent memory as versioned Markdown in Git. Draft thoughts go through a promotion gate before they become permanent memory. Version 0.6.0 lets that gate use a local model through an OpenAI-compatible endpoint, so I wanted to know whether a quantized model was reliable enough for this specific job.
+
+I tested `unsloth/Qwen3.6-27B-GGUF` through Unsloth Studio with the exact production promotion prompt. The corpus contained 39 historical thoughts with prior Gemini verdicts, including 26 approvals and 13 rejections, plus 10 synthetic canaries.
+
+The historical Gemini verdicts were references from earlier operation, not a fresh Gemini rerun.
+
+| Measure | Result |
+|---|---:|
+| Valid structured verdicts | 49/49 |
+| Parse, CLI, or retry failures | 0 |
+| Raw agreement with historical references and canaries | 39/49 (79.6%) |
+| Historical rejections matched | 13/13 |
+| Historical approvals matched | 17/26 |
+| Canaries matched | 9/10 |
+| Repeat consistency | 8/8 cases stable across three runs |
+| Median latency | 14.0 seconds |
+| p95 latency | 122.9 seconds |
+| Maximum latency | 172.5 seconds |
+
+The raw agreement number hides the important part: every disagreement was an additional rejection by the local model. It did not reverse any of the 13 historical Gemini rejections in this corpus.
+
+That error direction fits a promotion gate. A false rejection leaves the thought in drafts, where it can be revised and resubmitted. A false approval quietly adds weak material to future agent context.
+
+The local model rejected nine historical thoughts Gemini had approved. I asked OpenAI Codex running GPT 5.6 to judge those nine against the same production prompt. It favored Gemini in six cases and the local model in three. In those three, the local model caught a transient handoff, a misclassified implementation artifact, and an imperative task instruction that lacked durable rationale. A separate positive canary accounted for the tenth disagreement.
+
+That second-model review is an interpretive challenge to the old verdicts, not independent ground truth. The test covers one model, one prompt, and one corpus. It does not show general parity with Gemini or frontier models.
+
+Long inputs were the weak spot. Inputs over 40,000 characters reached only 2/6 raw agreement and had a median latency of 122.9 seconds. The model was also confident when wrong, so confidence is not a useful escalation trigger by itself.
+
+My conclusion is narrow: this quantized model had an acceptable, conservative error profile for this promotion policy. The released integration remains provider-neutral and fails closed if the local endpoint is unavailable or returns malformed output.
+
+Full write-up:
+https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=reddit&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=rlocalllama
+
+Benchmark evidence and disagreement audit:
+https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500
+```
+
+### Short title
+
+```text
+Local Qwen3.6 27B as an agent-memory gate: 49/49 valid verdicts and 13/13 historical rejections preserved
+```
+
+### Short body
+
+```markdown
+Disclosure: I maintain FAVA Trails, the open-source project I tested here.
+
+FAVA Trails v0.6.0 can use a local OpenAI-compatible model to review drafts before they enter permanent agent memory. I tested `unsloth/Qwen3.6-27B-GGUF` through Unsloth Studio with the exact production prompt.
+
+The corpus contained 39 historical thoughts with prior Gemini verdicts and 10 synthetic canaries. The Gemini verdicts were historical references, not a fresh rerun.
+
+| Measure | Result |
+|---|---:|
+| Valid verdicts | 49/49 |
+| Raw agreement | 39/49 |
+| Historical rejections matched | 13/13 |
+| Historical approvals matched | 17/26 |
+| Canaries matched | 9/10 |
+| Repeat consistency | 8/8 cases stable across three runs |
+
+Every disagreement was an additional rejection. A second-model review of the nine historical disagreements favored Gemini in six cases and the local model in three. The tenth disagreement was a positive canary. That review is not independent ground truth, but it shows the error direction clearly: the local model was conservative, sometimes too conservative, and did not cross a historical rejection boundary in this corpus.
+
+The result is limited to one model, prompt, and corpus. Inputs over 40,000 characters were weak at 2/6 raw agreement with 122.9-second median latency, and confidence did not identify bad verdicts.
+
+Full method and limitations:
+https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm_source=reddit&utm_medium=social&utm_campaign=fava-trails-v0-6-0&utm_content=rlocalllama
+
+Evidence:
+https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500
+```
+
+## GitHub v0.6.0 release addition
+
+Append this to the existing release body using the clean canonical URL:
+
+```markdown
+### Benchmark write-up
+
+[FAVA Trails v0.6.0: The Model That Decides What Our Agents Remember Now Runs Locally](https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides) covers the 49-case evaluation, disagreement review, and limits of the local-model promotion gate.
+```
+
+## Manual publishing order
+
+1. Add the benchmark write-up to the GitHub v0.6.0 release.
+2. Publish the personal LinkedIn post.
+3. Publish the Substack Note.
+4. Review and merge the separate machine-wisdom.ai indexing PR.
+5. On the following day, reshare the personal LinkedIn post from the Machine Wisdom AI page.
+6. Recheck the live r/LocalLLaMA rules, then publish or skip the Reddit post.
+7. Record each public URL and the first measurement checkpoint in the measurement ledger.

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-amplification-kit.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-amplification-kit.md
@@ -87,10 +87,7 @@ https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides?utm
 ```text
 I tested a quantized Qwen3.6 27B model as the local promotion gate for FAVA Trails.
 
-49/49 valid verdicts.
-13/13 historical rejections preserved.
-17/26 historical approvals matched.
-9/10 canaries matched.
+The model returned valid verdicts in all 49 cases, preserved all 13 historical rejections, matched 17 of 26 historical approvals, and matched 9 of 10 canaries.
 
 A second-model review of the nine historical disagreements favored Gemini in six cases and the local model in three. The local model was stricter, but every observed error was an additional rejection, which leaves the thought visible and recoverable as a draft.
 
@@ -140,7 +137,7 @@ The historical Gemini verdicts were references from earlier operation, not a fre
 | p95 latency | 122.9 seconds |
 | Maximum latency | 172.5 seconds |
 
-The raw agreement number hides the important part: every disagreement was an additional rejection by the local model. It did not reverse any of the 13 historical Gemini rejections in this corpus.
+Every disagreement was an additional rejection by the local model. It did not reverse any of the 13 historical Gemini rejections in this corpus.
 
 That error direction fits a promotion gate. A false rejection leaves the thought in drafts, where it can be revised and resubmitted. A false approval quietly adds weak material to future agent context.
 

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-measurement.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-measurement.md
@@ -1,0 +1,90 @@
+# Measurement ledger: FAVA Trails v0.6.0 publication
+
+Canonical article: https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides
+
+Published: July 31, 2026 at 17:51:04 UTC
+
+## Adoption baseline
+
+These publication-time values were supplied during launch planning.
+
+| Metric | Publication baseline | 24 hours | 7 days | 30 days |
+|---|---:|---:|---:|---:|
+| GitHub stars | 22 |  |  |  |
+| GitHub forks | 3 |  |  |  |
+| Repository views | 49 |  |  |  |
+| Unique repository visitors | 20 |  |  |  |
+| PyPI downloads without mirrors, trailing 7 days | 91 |  |  |  |
+| Genuine installation questions | 0 |  |  |  |
+| Genuine contribution questions | 0 |  |  |  |
+
+Treat clone counts as secondary because CI and automation distort them.
+
+## Content and referral results
+
+| Metric | Publication | 24 hours | 7 days | 30 days |
+|---|---:|---:|---:|---:|
+| Substack views |  |  |  |  |
+| Substack email opens |  |  |  |  |
+| New Substack subscriptions |  |  |  |  |
+| Personal LinkedIn impressions |  |  |  |  |
+| Personal LinkedIn link clicks |  |  |  |  |
+| Company LinkedIn impressions |  |  |  |  |
+| Company LinkedIn link clicks |  |  |  |  |
+| Substack Note views |  |  |  |  |
+| Substack Note reactions or replies |  |  |  |  |
+| Reddit score |  |  |  |  |
+| Reddit comments |  |  |  |  |
+| Article referrals to GitHub |  |  |  |  |
+
+### Discussion quality
+
+At each checkpoint, record concrete questions, attempted installations, bug reports, disagreement with the method, or contribution interest. Do not reduce discussion quality to reaction counts.
+
+| Checkpoint | Questions or evidence |
+|---|---|
+| Publication |  |
+| 24 hours |  |
+| 7 days |  |
+| 30 days |  |
+
+## Public URLs
+
+| Surface | URL | Published at | Verified |
+|---|---|---|---|
+| Substack article | https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides | 2026-07-31 17:51:04 UTC | Yes |
+| GitHub v0.6.0 release | https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.6.0 |  |  |
+| Personal LinkedIn |  |  |  |
+| Company LinkedIn reshare |  |  |  |
+| Substack Note |  |  |  |
+| r/LocalLLaMA |  |  |  |
+| machine-wisdom.ai writing index | https://machine-wisdom.ai/writing/ |  |  |
+
+## Model-discovery checks
+
+Run these at publication and after 30 days in one browsing model and one non-browsing model. Start a fresh conversation for each test condition.
+
+1. What open-source MCP tools provide governed or versioned memory for AI agents?
+2. Can FAVA Trails use a local LLM for memory promotion?
+3. What evidence exists for local LLM promotion gating in FAVA Trails?
+
+| Date | Model and mode | Prompt | Names FAVA Trails | Accurate | Cites Substack | Cites GitHub | Cites machine-wisdom.ai | Notes |
+|---|---|---|---|---|---|---|---|---|
+| 2026-07-31 |  | 1 |  |  |  |  |  |  |
+| 2026-07-31 |  | 2 |  |  |  |  |  |  |
+| 2026-07-31 |  | 3 |  |  |  |  |  |  |
+| 2026-08-30 |  | 1 |  |  |  |  |  |  |
+| 2026-08-30 |  | 2 |  |  |  |  |  |  |
+| 2026-08-30 |  | 3 |  |  |  |  |  |  |
+
+## Link and claim QA
+
+- [x] The article returns HTTP 200 at the clean canonical URL.
+- [x] The page declares the clean canonical URL in HTML metadata.
+- [x] The benchmark screenshot has the required alt text.
+- [x] Every social URL resolves and retains its source-specific UTM parameters.
+- [ ] The GitHub release contains the clean benchmark write-up link.
+- [ ] The machine-wisdom.ai writing index contains the clean article link.
+- [ ] The machine-wisdom.ai `llms.txt` contains the clean article link.
+- [ ] The website PR checks and human review pass before merge.
+- [ ] Every derivative preserves the article's bounded claims and limitations.

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-measurement.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-measurement.md
@@ -68,14 +68,20 @@ Run these at publication and after 30 days in one browsing model and one non-bro
 2. Can FAVA Trails use a local LLM for memory promotion?
 3. What evidence exists for local LLM promotion gating in FAVA Trails?
 
-| Date | Model and mode | Prompt | Names FAVA Trails | Accurate | Cites Substack | Cites GitHub | Cites machine-wisdom.ai | Notes |
-|---|---|---|---|---|---|---|---|---|
-| 2026-07-31 |  | 1 |  |  |  |  |  |  |
-| 2026-07-31 |  | 2 |  |  |  |  |  |  |
-| 2026-07-31 |  | 3 |  |  |  |  |  |  |
-| 2026-08-30 |  | 1 |  |  |  |  |  |  |
-| 2026-08-30 |  | 2 |  |  |  |  |  |  |
-| 2026-08-30 |  | 3 |  |  |  |  |  |  |
+| Date | Mode | Model | Prompt | Names FAVA Trails | Accurate | Cites Substack | Cites GitHub | Cites machine-wisdom.ai | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| 2026-07-31 | Browsing |  | 1 |  |  |  |  |  |  |
+| 2026-07-31 | Non-browsing |  | 1 |  |  |  |  |  |  |
+| 2026-07-31 | Browsing |  | 2 |  |  |  |  |  |  |
+| 2026-07-31 | Non-browsing |  | 2 |  |  |  |  |  |  |
+| 2026-07-31 | Browsing |  | 3 |  |  |  |  |  |  |
+| 2026-07-31 | Non-browsing |  | 3 |  |  |  |  |  |  |
+| 2026-08-30 | Browsing |  | 1 |  |  |  |  |  |  |
+| 2026-08-30 | Non-browsing |  | 1 |  |  |  |  |  |  |
+| 2026-08-30 | Browsing |  | 2 |  |  |  |  |  |  |
+| 2026-08-30 | Non-browsing |  | 2 |  |  |  |  |  |  |
+| 2026-08-30 | Browsing |  | 3 |  |  |  |  |  |  |
+| 2026-08-30 | Non-browsing |  | 3 |  |  |  |  |  |  |
 
 ## Link and claim QA
 

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-publishing-brief.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-publishing-brief.md
@@ -20,7 +20,7 @@ This file contains publication metadata and should not be pasted into the Substa
 
 ## Suggested Substack preview text
 
-A quantized local Qwen model preserved every historical rejection in FAVA Trails' 49-case promotion benchmark, and its observed mistakes were conservative and recoverable. Here is what we learned while moving institutional-memory review off hosted inference.
+A quantized local Qwen model preserved all 13 historical rejection boundaries in FAVA Trails' 49-case promotion benchmark, and its observed mistakes were conservative and recoverable. Here is what we learned while moving institutional-memory review off hosted inference.
 
 ## Suggested social text
 

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-publishing-brief.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-publishing-brief.md
@@ -2,6 +2,17 @@
 
 This file contains publication metadata and should not be pasted into the Substack article body.
 
+## Published record
+
+- **Status:** Published
+- **Published:** July 31, 2026 at 17:51:04 UTC
+- **Canonical URL:** https://machinewisdom.substack.com/p/fava-trails-v060-the-model-that-decides
+- **Live title:** FAVA Trails v0.6.0: The Model That Decides What Our Agents Remember Now Runs Locally
+- **Live description:** FAVA Trails v0.6.0 brings local-model promotion gating. Our benchmark found that a quantized Qwen model was conservative, consistent, and a good fit for the job
+- **Screenshot alt text:** “Benchmark results: 49 of 49 valid verdicts, 39 of 49 raw agreement, all 13 historical rejections matched, 17 of 26 approvals matched, and 9 of 10 canaries matched.”
+
+Use the clean canonical URL on GitHub and machine-wisdom.ai. Use the source-specific links in the amplification kit for social posts.
+
 ## Page job
 
 - **Audience:** AI-agent builders, technical leaders, and local-model practitioners evaluating durable agent memory.
@@ -42,7 +53,9 @@ Suggested alt text: "Agent thoughts passing through a local quality gate before 
 
 ## Publication checks
 
-- Add the author's byline and publication date in Substack.
-- Add the exact workstation hardware used for the benchmark if reproducibility is a publication goal; do not infer or invent it.
-- Verify Substack's canonical URL, Article metadata, social card, and hero-image alt text after publishing.
-- Confirm the article does not include this publishing brief.
+- [x] The article is publicly available at the canonical URL.
+- [x] The title and description match the publication-ready article.
+- [x] The benchmark screenshot exposes the exact results as alt text.
+- [x] Substack emits canonical and NewsArticle metadata.
+- [x] The article does not include this publishing brief.
+- [ ] Add the exact workstation hardware in a future revision only if reproducibility requires it; do not infer or invent it.

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-publishing-brief.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-publishing-brief.md
@@ -2,6 +2,22 @@
 
 This file contains publication metadata and should not be pasted into the Substack article body.
 
+## Page job
+
+- **Audience:** AI-agent builders, technical leaders, and local-model practitioners evaluating durable agent memory.
+- **Search intent:** Understand local LLM promotion gating, the FAVA Trails v0.6.0 release, and the evidence from its Unsloth/Qwen benchmark.
+- **Primary entity:** FAVA Trails v0.6.0.
+- **Supporting entities:** FAVA Trust Gate, Unsloth Studio, Qwen3.6 27B GGUF, Gemini, OpenAI Codex, Model Context Protocol, OpenRouter, and Jujutsu.
+- **Desired action:** Understand the bounded result, then inspect the open-source release or install it from PyPI.
+- **Proof:** The production prompt, issue #85 benchmark record, release and implementation PRs, release workflow, and PyPI artifact.
+
+## Search and social metadata
+
+- **SEO title:** FAVA Trails v0.6.0: Local LLM Gating for Agent Memory
+- **Meta description:** FAVA Trails v0.6.0 adds local LLM promotion gating. See the 49-case Unsloth/Qwen benchmark, disagreement audit, limitations, and release details.
+- **Suggested slug:** `fava-trails-v06-local-llm-agent-memory`
+- **Schema candidate:** Article. Let Substack generate it from visible title, byline, date, image, and article content; do not inject separate JSON-LD unless the publishing surface supports and requires it.
+
 ## Suggested Substack preview text
 
 A quantized local Qwen model preserved every historical rejection in FAVA Trails' 49-case promotion benchmark, and its observed mistakes were conservative and recoverable. Here is what we learned while moving institutional-memory review off hosted inference.

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-publishing-brief.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-publishing-brief.md
@@ -1,0 +1,32 @@
+# Publishing brief: FAVA Trails v0.6.0 local Trust Gate article
+
+This file contains publication metadata and should not be pasted into the Substack article body.
+
+## Suggested Substack preview text
+
+A quantized local Qwen model preserved every historical rejection in FAVA Trails' 49-case promotion benchmark, and its observed mistakes were conservative and recoverable. Here is what we learned while moving institutional-memory review off hosted inference.
+
+## Suggested social text
+
+FAVA Trails v0.6.0 can use a local model to decide what deserves permanent agent memory. In a 49-case benchmark: 49/49 valid verdicts, all 13 historical rejection boundaries preserved, and an interpretive net difference of three historical judgments after second-model adjudication.
+
+## Suggested tags
+
+- AI agents
+- Agent memory
+- Local LLMs
+- Model Context Protocol
+- Open source
+
+## Suggested hero image
+
+A split scene showing noisy streams of agent thoughts approaching a small local gate, with only a few versioned memory cards continuing into a private archive. Avoid humanoid robots and generic glowing brains.
+
+Suggested alt text: "Agent thoughts passing through a local quality gate before entering a private versioned memory archive."
+
+## Publication checks
+
+- Add the author's byline and publication date in Substack.
+- Add the exact workstation hardware used for the benchmark if reproducibility is a publication goal; do not infer or invent it.
+- Verify Substack's canonical URL, Article metadata, social card, and hero-image alt text after publishing.
+- Confirm the article does not include this publishing brief.

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-publishing-brief.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory-publishing-brief.md
@@ -35,7 +35,7 @@ A quantized local Qwen model preserved all 13 historical rejection boundaries in
 
 ## Suggested social text
 
-FAVA Trails v0.6.0 can use a local model to decide what deserves permanent agent memory. In a 49-case benchmark: 49/49 valid verdicts, all 13 historical rejection boundaries preserved, and an interpretive net difference of three historical judgments after second-model adjudication.
+FAVA Trails v0.6.0 can use a local model to decide what deserves permanent agent memory. An Unsloth quantized Qwen 3.6 model proved on par with Google Gemini on the gate's historical verdicts, and every error it made was a recoverable rejection rather than a quiet bad approval.
 
 ## Suggested tags
 

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory.md
@@ -104,4 +104,6 @@ The v0.5.8 ChatGPT tunnel gateway made FAVA reachable from an authorized ChatGPT
 
 Tunnel startup was hardened over several releases. Readiness checks validate that the runtime identity can actually traverse the configured trail tree and parse representative data. Optional startup sync is bounded and fail-closed. Recurring autosync is disabled by default rather than quietly mutating shared state.
 
+--- 
+
 [FAVA Trails v0.6.0](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.6.0) is available now on [PyPI](https://pypi.org/project/fava-trails/0.6.0/). The project is open source under Apache 2.0.

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory.md
@@ -10,7 +10,7 @@ A quantized local model still has to be trustworthy enough to act as the gatekee
 
 We ran [49 historical cases and canaries](https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500) through an Unsloth-served Qwen3.6 27B GGUF model. It returned valid structured verdicts in all 49 cases, preserved all 13 historical rejection boundaries in the corpus, and was stable across every repeated case. Every observed disagreement was conservative: the local model rejected additional material, but it did not reverse any of the 13 historical Gemini rejections.
 
-I then asked OpenAI Codex to re-audit the disagreements as a second-model adjudicator. The local model's interpretive net difference against the historical Gemini references was only three judgments. In exchange, promotion candidates in the Mac-local deployment stay local, per-thought hosted API fees disappear, and a hosted provider is removed from the critical path.
+I then asked OpenAI Codex to re-audit the disagreements as a second-model adjudicator. It favored Gemini in six cases and the local model in three, leaving an interpretive net difference of three historical judgments. In exchange, promotion candidates in the Mac-local deployment stay local, per-thought hosted API fees disappear, and a hosted provider is removed from the critical path.
 
 For this job, that is a trade I am willing to make.
 
@@ -36,7 +36,9 @@ The benchmark used 39 historical thoughts with prior Gemini verdicts (26 approva
 
 We tested one model on one operationally important task, using the exact prompt that governs FAVA Trails promotion.
 
-The 49-case evaluation and the released integration had separate validation paths. The benchmark used WisdomHelm's provider-neutral `local-llm` CLI to send FAVA's exact production messages and parse the results with FAVA's production verdict parser; it did not change the production provider configuration or exercise the new v0.6 provider path end to end. After the release was integrated, [a separate live dogfood](https://github.com/MachineWisdomAI/fava-trails/pull/88) exercised that provider path directly: it approved a durable architectural decision and rejected an adversarial instruction.
+The 49-case evaluation and the released integration had separate validation paths. The benchmark used WisdomHelm's provider-neutral `local-llm` CLI to send FAVA's exact production messages and parse the results with FAVA's production verdict parser. It did not change the production provider configuration or exercise the new v0.6 provider path end to end.
+
+After the release was integrated, [a separate live dogfood](https://github.com/MachineWisdomAI/fava-trails/pull/88) exercised that provider path directly. It approved a durable architectural decision and rejected an adversarial instruction.
 
 The results were:
 
@@ -100,7 +102,7 @@ Credentials follow the same fail-closed rules. File-backed API keys must be owne
 
 Failures remain fail-closed. If the local endpoint is unavailable, times out, rejects authentication, or returns malformed output, FAVA Trails does not silently fall back to a hosted provider and promote the thought anyway.
 
-Failing closed reduces external dependency without creating an invisible alternate decision path.
+Local execution reduces external provider dependency. Failing closed prevents an invisible alternate decision path.
 
 ## FAVA Trails changed substantially in the last few months
 

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory.md
@@ -82,7 +82,7 @@ The full evidence and caveats are recorded in [FAVA Trails issue #85](https://gi
 
 ## What the benchmark did not prove
 
-The result is encouraging, but it has boundaries.
+The benchmark supports one bounded conclusion: this local model had an acceptable error profile for FAVA's promotion prompt on this corpus. It does not establish general parity with Gemini, frontier models, or unrelated agent tasks.
 
 The Gemini verdicts were historical references, not a fresh Gemini rerun. The benchmark covered a specific corpus and prompt, not arbitrary reasoning tasks. Long inputs were a weak spot: inputs over 40,000 characters achieved only 2/6 raw agreement and had a median latency of 122.9 seconds. The largest successful request contained 29,397 prompt tokens.
 
@@ -94,7 +94,7 @@ For FAVA Trails, the answer was yes.
 
 ## The implementation stays provider-neutral
 
-Although Unsloth Studio was the first live target, FAVA Trails v0.6.0 does not contain an Unsloth-specific transport. It uses the OpenAI-compatible interface already exposed by many local and hosted runtimes.
+[FAVA Trails v0.6.0](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.6.0) supports local promotion gating through a provider-neutral OpenAI-compatible interface. Although Unsloth Studio was the first live target, the release does not contain an Unsloth-specific SDK or transport.
 
 Each machine can select its provider, exact model identifier, API base, timeout, credentials, and provider-specific request controls through the standard per-machine configuration at `~/.config/fava-trails/config.yaml`. Shared trail configuration does not need to change, so one workstation can use a local model while another machine or a ChatGPT gateway continues using OpenRouter.
 
@@ -106,21 +106,21 @@ That boundary is important: local execution should reduce external dependency, n
 
 ## FAVA Trails changed substantially in the last few months
 
-The local Trust Gate is the headline for v0.6.0, but it sits on top of a broader push to make agent memory inspectable, portable, and operationally safe.
+From May through July, FAVA Trails added four operational layers around its memory core: safer synchronization, human-readable views, authenticated ChatGPT access, and local promotion gating. The local Trust Gate is the v0.6.0 headline, but it rests on that broader push to make agent memory inspectable, portable, and operationally safe.
 
 Between [v0.5.6 and v0.6.0](https://github.com/MachineWisdomAI/fava-trails/compare/v0.5.6...v0.6.0)—May 5 through July 31—the repository accumulated 66 commits. The public milestones also included [v0.5.7](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.7), [v0.5.8](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.8), and [v0.5.9](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.9). The more meaningful story is how the system's boundaries became explicit.
 
 ### Data integrity became fail-closed
 
-FAVA sync now blocks when the data repository has a dirty working copy or case-colliding tracked paths. Commit operations fail fast on unexpected changes and executable-bit churn instead of proceeding as if the repository were clean. This protects the memory store from a class of subtle VCS mistakes that are easy for agents to miss.
+[FAVA Trails v0.5.7](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.7) made data integrity fail-closed. FAVA sync now blocks when the data repository has a dirty working copy or case-colliding tracked paths, while commit operations fail fast on unexpected changes and executable-bit churn. This protects the memory store from subtle VCS mistakes that are easy for agents to miss.
 
 ### Memory became visible to humans
 
-The new rich-view commands generate and serve a small Astro reader from trail records. Thoughts have stable ULID routes, derived titles, and snapshot metadata. It is intentionally a reader rather than another editing surface: humans can inspect what agents saved without bypassing the MCP lifecycle that governs changes.
+[FAVA Trails v0.5.8](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.8) made agent memory directly inspectable. Its rich-view commands generate and serve a small Astro reader from trail records, with stable ULID routes, derived titles, and snapshot metadata. It is intentionally a reader rather than another editing surface: humans can inspect what agents saved without bypassing the MCP lifecycle that governs changes.
 
 ### FAVA reached ChatGPT without exposing an unauthenticated public MCP endpoint
 
-The ChatGPT tunnel gateway runs a private loopback MCP runtime behind an authenticated secure tunnel, with detached lifecycle commands and a bounded `/healthz` readiness probe. Authorized ChatGPT requests can receive returned FAVA data through that tunnel, but the local MCP runtime is not exposed as an unauthenticated public endpoint. Structured MCP errors and output schemas survive the gateway boundary, so clients receive meaningful failures instead of transport-shaped ambiguity.
+The v0.5.8 ChatGPT tunnel gateway made FAVA reachable from an authorized ChatGPT client without publishing an unauthenticated MCP endpoint. It runs a private loopback MCP runtime behind an authenticated secure tunnel, with detached lifecycle commands and a bounded `/healthz` readiness probe. Authorized requests can receive returned FAVA data through that tunnel, while structured MCP errors and output schemas survive the gateway boundary.
 
 Tunnel startup was hardened over several releases. Readiness checks validate that the runtime identity can actually traverse the configured trail tree and parse representative data. Optional startup sync is bounded and fail-closed. Recurring autosync is disabled by default rather than quietly mutating shared state.
 
@@ -136,9 +136,9 @@ The trajectory is consistent: make important state explicit, make failure visibl
 
 ## Local models are most compelling when the task has clear error economics
 
-I do not think this benchmark proves that every agent workload should move to a local quantized model. It demonstrates something narrower and more useful.
+Local models are strongest when the task has a stable policy, structured output, auditable historical cases, and asymmetric failure costs. FAVA's promotion gate has all four.
 
-The FAVA Trust Gate has a stable prompt, structured output, historical cases, and asymmetric failure costs. Those properties make it a strong candidate for local inference. We can measure the model on the real task, inspect every disagreement, and decide whether its mistakes are acceptable.
+This benchmark does not prove that every agent workload should move to a local quantized model. It demonstrates something narrower and more useful: when a task has those properties, we can measure the model on the real job, inspect every disagreement, and decide whether its mistakes are acceptable.
 
 Here, they were.
 

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory.md
@@ -2,23 +2,15 @@
 
 ## FAVA Trails v0.6.0 brings local-model promotion gating. Our benchmark found that a quantized Qwen model was conservative, consistent, and good enough for the job
 
-The newest release of [FAVA Trails](https://github.com/MachineWisdomAI/fava-trails), v0.6.0, can use a local OpenAI-compatible model to decide which agent memories deserve to become permanent.
+The newest release of [FAVA Trails](https://github.com/MachineWisdomAI/fava-trails), v0.6.0, can use a local OpenAI-compatible model to decide which agent memories deserve to become permanent. That means a thought being considered for institutional memory no longer has to be sent to OpenRouter, Gemini, or another hosted model. The review can happen on the operator's own machine, while OpenRouter remains the default for people who prefer it.
 
-That means a thought being considered for institutional memory no longer has to be sent to OpenRouter, Gemini, or another hosted model. The review can happen on the operator's own machine, while OpenRouter remains the default for people who prefer it.
+A quantized local model still has to be trustworthy enough to act as the gatekeeper. We ran [49 historical cases and canaries](https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500) through an [Unsloth-served Qwen3.6 27B GGUF model](https://unsloth.ai/docs/models/qwen3.6). It returned valid structured verdicts in all 49 cases, preserved all 13 historical rejection boundaries in the corpus, and was stable across every repeated case. Every observed disagreement was conservative: the local model rejected additional material, but it did not reverse any of the 13 historical Gemini rejections.
 
-A quantized local model still has to be trustworthy enough to act as the gatekeeper.
-
-We ran [49 historical cases and canaries](https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500) through an Unsloth-served Qwen3.6 27B GGUF model. It returned valid structured verdicts in all 49 cases, preserved all 13 historical rejection boundaries in the corpus, and was stable across every repeated case. Every observed disagreement was conservative: the local model rejected additional material, but it did not reverse any of the 13 historical Gemini rejections.
-
-I then asked OpenAI Codex to re-audit the disagreements as a second-model adjudicator. It favored Gemini in six cases and the local model in three, leaving an interpretive net difference of three historical judgments. In exchange, promotion candidates in the Mac-local deployment stay local, per-thought hosted API fees disappear, and a hosted provider is removed from the critical path.
-
-For this job, that is a trade I am willing to make.
+I then asked OpenAI Codex running GPT 5.6 to re-audit the disagreements as a second-model adjudicator. It favored Gemini in six cases and the local model in three, leaving an interpretive net difference of three historical judgments. In exchange, promotion candidates in the Mac-local deployment stay local, per-thought hosted API fees disappear, and a hosted provider is removed from the critical path. For this job, that is a trade I am willing to make.
 
 ## The hard part is deciding what deserves to become memory
 
-Agents generate a lot of text. Most of it should not become durable context.
-
-A useful observation, a decision with rationale, or a hard-won negative result may help the next agent. Process narration, transient runtime state, unsupported claims, and instructions disguised as facts usually will not. If all of it is saved indiscriminately, “memory” becomes a larger context window full of noise and contradictions.
+Agents generate a lot of text. Most of it should not become durable context. A useful observation, a decision with rationale, or a hard-won negative result may help the next agent. Process narration, transient runtime state, unsupported claims, and instructions disguised as facts usually will not be helpful. If all of it is saved indiscriminately, "memory" becomes a larger context window full of noise and contradictions.
 
 FAVA Trails (short for Federated Agents Versioned Audit Trail) treats memory as curated, versioned knowledge rather than a transcript archive. Thoughts begin as drafts. A promotion gate reviews them before they enter permanent namespaces. Superseded beliefs remain in the audit history but disappear from normal recall. Every record is a Markdown file with structured metadata in a Git repository controlled by the operator, with Jujutsu handling atomic changes underneath.
 
@@ -28,17 +20,13 @@ The Trust Gate asks a deliberately simple question:
 
 The [production review prompt](https://github.com/MachineWisdomAI/fava-trails/blob/v0.6.0/src/fava_trails/data_repo_template/trust-gate-prompt.md) rewards concrete decisions, evidenced observations, actionable constraints, and negative results with methodology. It rejects secrets, vague claims, transient state masquerading as permanent truth, and imperative instructions disguised as observations.
 
-Before v0.6.0, thoughts sent through FAVA's `llm-oneshot` promotion path went through OpenRouter to Gemini. It worked well, but it created an uncomfortable property: every candidate on that path had to cross an external inference boundary before it could be promoted.
+Before v0.6.0, thoughts sent through FAVA's promotion path went through OpenRouter to Gemini. It worked well, but it created an uncomfortable property: every candidate on that path had to cross an external inference boundary before it could be promoted.
 
-## What we benchmarked
+### What we benchmarked
 
-The benchmark used 39 historical thoughts with prior Gemini verdicts (26 approvals and 13 rejections), plus 10 synthetic canaries. The local candidate was the quantized model exposed as `unsloth/Qwen3.6-27B-GGUF` through Unsloth Studio on the workstation.
+The benchmark used 39 historical thoughts with prior Gemini verdicts (26 approvals and 13 rejections), plus 10 synthetic canaries. The local candidate was the quantized model exposed as `unsloth/Qwen3.6-27B-GGUF` through Unsloth Studio on the workstation. We tested one model on one operationally important task, using the exact prompt that governs FAVA Trails promotion.
 
-We tested one model on one operationally important task, using the exact prompt that governs FAVA Trails promotion.
-
-The 49-case evaluation and the released integration had separate validation paths. The benchmark used WisdomHelm's provider-neutral `local-llm` CLI to send FAVA's exact production messages and parse the results with FAVA's production verdict parser. It did not change the production provider configuration or exercise the new v0.6 provider path end to end.
-
-After the release was integrated, [a separate live dogfood](https://github.com/MachineWisdomAI/fava-trails/pull/88) exercised that provider path directly. It approved a durable architectural decision and rejected an adversarial instruction.
+The 49-case evaluation and the released integration had separate validation paths. After the release was integrated, [a separate live dogfood](https://github.com/MachineWisdomAI/fava-trails/pull/88) exercised that provider path directly. It approved a durable architectural decision and rejected an adversarial instruction.
 
 The results were:
 
@@ -55,22 +43,18 @@ The results were:
 | p95 latency | 122.9 seconds |
 | Maximum latency | 172.5 seconds |
 
-Raw agreement was 79.6%, which sounds merely adequate until you look at the direction of the errors.
-
-Every disagreement was an additional rejection by the local model. Among the 13 historical Gemini rejections in this corpus, it did not reverse a single verdict. That matters because the cost of the two error types is asymmetric:
+Raw agreement was 79.6%, which sounds merely adequate until you look at the direction of the errors. Every disagreement was an additional rejection by the local model. Among the 13 historical Gemini rejections in this corpus, it did not reverse a single verdict. That matters because the cost of the two error types is asymmetric:
 
 - A false rejection is visible and recoverable. The thought remains a draft, can be improved, and can be resubmitted.
 - A false approval is quiet. Low-quality material enters institutional memory, consumes future context, and may steer later agents.
 
 A conservative critic is often preferable to a permissive one.
 
-## What the nine disagreements revealed
+### What the nine disagreements revealed
 
-The local model rejected nine historical thoughts Gemini had approved. Rather than treating Gemini as ground truth, I asked OpenAI Codex, separate from the quantized candidate, to judge each thought against the exact promotion prompt. This second-model review was a structured challenge to the historical verdicts, not independent human ground truth. It is published with the other [evaluation evidence](https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500).
+The local model rejected nine historical thoughts Gemini had approved. Rather than treating Gemini as ground truth, I asked OpenAI Codex running GPT 5.6 to judge each thought against the exact promotion prompt. This second-model review was a structured challenge to the historical verdicts, not independent human ground truth. It is published with the other [evaluation evidence](https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500).
 
-Gemini had the better verdict in six cases. The local model was simply too strict.
-
-But in three cases, the local model caught material Gemini should not have promoted:
+Gemini had the better verdict in six cases. The local model was simply too strict. But in three cases, the local model caught material Gemini should not have promoted:
 
 1. A transient builder-state handoff had been stored as a permanent review.
 2. An implementation-heavy artifact had been misclassified as a specification.
@@ -78,13 +62,7 @@ But in three cases, the local model caught material Gemini should not have promo
 
 So the historical disagreement set contained six lost approvals and three improved rejections: an interpretive net difference of three judgments after second-model adjudication, not a formal accuracy estimate. The tenth disagreement was a separate positive canary that the local model also rejected too conservatively.
 
-The evidence supports a small, understandable quality difference on this task, tilted in the safer direction. It is too narrow to establish that the local model is better than Gemini overall.
-
-The full evidence and caveats are recorded in [FAVA Trails issue #85](https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500).
-
-## The limits of the benchmark
-
-The benchmark supports one bounded conclusion: this local model had an acceptable error profile for FAVA's promotion prompt on this corpus. It does not establish general parity with Gemini, frontier models, or unrelated agent tasks.
+The evidence supports a small, understandable quality difference on this task, tilted in the safer direction. It is too narrow to establish that the local model is better than Gemini overall. The benchmark supports one bounded conclusion: this local model had an acceptable error profile for FAVA's promotion prompt on this corpus. It does not establish general parity with Gemini, frontier models, or unrelated agent tasks.
 
 The Gemini verdicts were historical references, not a fresh Gemini rerun. The benchmark covered a specific corpus and prompt, not arbitrary reasoning tasks. Long inputs were a weak spot: inputs over 40,000 characters achieved only 2/6 raw agreement and had a median latency of 122.9 seconds. The largest successful request contained 29,397 prompt tokens.
 
@@ -104,17 +82,19 @@ Failures remain fail-closed. If the local endpoint is unavailable, times out, re
 
 Local execution reduces external provider dependency. Failing closed prevents an invisible alternate decision path.
 
+### Why this task fits a local model
+
+Local models are strongest when the task has a stable policy, structured output, auditable historical cases, and asymmetric failure costs. FAVA's promotion gate has all four.
+
+For this kind of task, we can measure the model on the real job, inspect every disagreement, and decide whether its mistakes are acceptable. In this benchmark, I consider them acceptable.
+
+The local model preserved every historical rejection boundary, produced valid JSON every time, behaved consistently under repetition, and caught three approvals that deserved another look. It approved fewer historically approved candidates in exchange for keeping promotion payloads off hosted inference, eliminating per-thought hosted API fees, and reducing provider dependence.
+
 ## FAVA Trails changed substantially in the last few months
 
-From May through July, FAVA Trails added four operational layers around its memory core: safer synchronization, human-readable views, authenticated ChatGPT access, and local promotion gating. The local Trust Gate is the v0.6.0 headline, but it rests on that broader push to make agent memory inspectable, portable, and operationally safe.
+FAVA Trails has been evolving, adding operational layers around its memory core. The two most important additions are navigable HTML pretty views and authenticated ChatGPT access. The local Trust Gate is the v0.6.0 headline, but it rests on that broader push to make agent memory inspectable, portable, and operationally safe.
 
-Between [v0.5.6 and v0.6.0](https://github.com/MachineWisdomAI/fava-trails/compare/v0.5.6...v0.6.0), May 5 through July 31, the repository accumulated 66 commits. The public milestones also included [v0.5.7](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.7), [v0.5.8](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.8), and [v0.5.9](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.9).
-
-### Data integrity became fail-closed
-
-[FAVA Trails v0.5.7](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.7) made data integrity fail-closed. FAVA sync now blocks when the data repository has a dirty working copy or case-colliding tracked paths, while commit operations fail fast on unexpected changes and executable-bit churn. This protects the memory store from subtle VCS mistakes that are easy for agents to miss.
-
-### Memory became visible to humans
+### Memory became more glanceable to humans
 
 [FAVA Trails v0.5.8](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.8) made agent memory directly inspectable. Its rich-view commands generate and serve a small Astro reader from trail records, with stable ULID routes, derived titles, and snapshot metadata. It is intentionally a reader rather than another editing surface: humans can inspect what agents saved without bypassing the MCP lifecycle that governs changes.
 
@@ -123,21 +103,5 @@ Between [v0.5.6 and v0.6.0](https://github.com/MachineWisdomAI/fava-trails/compa
 The v0.5.8 ChatGPT tunnel gateway made FAVA reachable from an authorized ChatGPT client without publishing an unauthenticated MCP endpoint. It runs a private loopback MCP runtime behind an authenticated secure tunnel, with detached lifecycle commands and a bounded `/healthz` readiness probe. Authorized requests can receive returned FAVA data through that tunnel, while structured MCP errors and output schemas survive the gateway boundary.
 
 Tunnel startup was hardened over several releases. Readiness checks validate that the runtime identity can actually traverse the configured trail tree and parse representative data. Optional startup sync is bounded and fail-closed. Recurring autosync is disabled by default rather than quietly mutating shared state.
-
-### Read operations stopped having write-shaped side effects
-
-Read-only calls no longer create missing scopes. Exact-ULID lookup can find a unique thought across scopes and reports its source trail. Supersession preserves an existing confidence value when callers omit a replacement. These sound like small details; together, they make the system behave more like a dependable knowledge substrate and less like an optimistic demo.
-
-### Packaging and provider compatibility received production attention
-
-OpenRouter response compatibility was hardened in May. The MCP dependency was later constrained to the supported 1.x line so a fresh resolution could not select an incompatible major and crash the server before initialization. The v0.6.0 release itself passed 755 tests, Ruff, Semantic PR validation, and CodeQL before being published to PyPI through trusted publishing.
-
-## Why this task fits a local model
-
-Local models are strongest when the task has a stable policy, structured output, auditable historical cases, and asymmetric failure costs. FAVA's promotion gate has all four.
-
-For this kind of task, we can measure the model on the real job, inspect every disagreement, and decide whether its mistakes are acceptable. In this benchmark, I consider them acceptable.
-
-The local model preserved every historical rejection boundary, produced valid JSON every time, behaved consistently under repetition, and caught three approvals that deserved another look. It approved fewer historically approved candidates in exchange for keeping promotion payloads off hosted inference, eliminating per-thought hosted API fees, and reducing provider dependence.
 
 [FAVA Trails v0.6.0](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.6.0) is available now on [PyPI](https://pypi.org/project/fava-trails/0.6.0/). The project is open source under Apache 2.0.

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory.md
@@ -1,0 +1,156 @@
+# The Model That Decides What Our Agents Remember Now Runs Locally
+
+## FAVA Trails v0.6.0 brings local-model promotion gating—and our benchmark found that a quantized Qwen model was conservative, consistent, and good enough for the job
+
+The newest release of [FAVA Trails](https://github.com/MachineWisdomAI/fava-trails), v0.6.0, can use a local OpenAI-compatible model to decide which agent memories deserve to become permanent.
+
+That means a thought being considered for institutional memory no longer has to be sent to OpenRouter, Gemini, or another hosted model. The review can happen on the operator's own machine, while OpenRouter remains the default for people who prefer it.
+
+The obvious question is whether a quantized local model is actually trustworthy enough to act as the gatekeeper.
+
+We ran 49 historical cases and canaries through an Unsloth-served Qwen3.6 27B GGUF model. It returned valid structured verdicts in all 49 cases, preserved all 13 historical rejection boundaries, and was stable across every repeated case. Its errors were conservative: it rejected too much, but it never approved something Gemini had rejected.
+
+After I independently re-audited the disagreements, the local model's net regression against Gemini was only three historical judgments. In exchange, promotion candidates stay local, external inference cost disappears, and a hosted provider is removed from the critical path.
+
+For this job, that is a trade I am willing to make.
+
+## The problem is not storing memory. It is deciding what deserves to become memory.
+
+Agents generate a lot of text. Most of it should not become durable context.
+
+A useful observation, a decision with rationale, or a hard-won negative result may help the next agent. Process narration, transient runtime state, unsupported claims, and instructions disguised as facts usually will not. If all of it is saved indiscriminately, “memory” becomes a larger context window full of noise and contradictions.
+
+FAVA Trails—short for **Federated Agents Versioned Audit Trail**—treats memory as curated, versioned knowledge rather than a transcript archive. Thoughts begin as drafts. A promotion gate reviews them before they enter permanent namespaces. Superseded beliefs remain in the audit history but disappear from normal recall. Every record is a Markdown file with structured metadata in a Git repository controlled by the operator, with Jujutsu handling atomic changes underneath.
+
+The Trust Gate asks a deliberately simple question:
+
+> Will a future agent—with no context about this conversation—find this thought useful?
+
+The [production review prompt](https://github.com/MachineWisdomAI/fava-trails/blob/v0.6.0/src/fava_trails/data_repo_template/trust-gate-prompt.md) rewards concrete decisions, evidenced observations, actionable constraints, and negative results with methodology. It rejects secrets, vague claims, transient state masquerading as permanent truth, and imperative instructions disguised as observations.
+
+Until now, that review normally went through OpenRouter to Gemini. It worked well, but it created an uncomfortable property: everything being considered for durable memory had to cross an external inference boundary before it could be saved.
+
+## What we benchmarked
+
+The benchmark used 39 historical thoughts with prior Gemini verdicts—26 approvals and 13 rejections—plus 10 synthetic canaries. The local candidate was the quantized Qwen model already running through Unsloth Studio on the workstation.
+
+This was not a generic model benchmark. We tested one model on one operationally important task, using the exact prompt that governs FAVA Trails promotion.
+
+The results were:
+
+| Measure | Result |
+|---|---:|
+| Valid structured verdicts | 49/49 |
+| Parse, CLI, or retry failures | 0 |
+| Raw agreement with historical references and canaries | 39/49 (79.6%) |
+| Historical rejections matched | 13/13 |
+| Historical approvals matched | 17/26 |
+| Canaries matched | 9/10 |
+| Repeat consistency | 8/8 cases stable across three runs |
+| Median latency | 14.0 seconds |
+| p95 latency | 122.9 seconds |
+| Maximum latency | 172.5 seconds |
+
+At first glance, 79.6% agreement sounds merely adequate. But aggregate agreement hides the most important part of a gate: **which direction the errors go**.
+
+Every disagreement was an additional rejection by the local model. It did not approve a single thought that Gemini had historically rejected. That matters because the cost of the two error types is asymmetric:
+
+- A false rejection is visible and recoverable. The thought remains a draft, can be improved, and can be resubmitted.
+- A false approval is quiet. Low-quality material enters institutional memory, consumes future context, and may steer later agents.
+
+A conservative critic is often preferable to a permissive one.
+
+## The nine disagreements were not nine regressions
+
+The local model rejected nine historical thoughts Gemini had approved. Rather than treating Gemini as ground truth, I asked a more capable frontier model—separate from the quantized candidate—to re-audit each thought against the exact promotion prompt and then apply its own judgment.
+
+Gemini had the better verdict in six cases. The local model was simply too strict.
+
+But in three cases, the local model caught material Gemini should not have promoted:
+
+1. A transient builder-state handoff had been stored as a permanent review.
+2. An implementation-heavy artifact had been misclassified as a specification.
+3. An imperative task instruction had been presented as durable knowledge without provenance or rationale.
+
+So the historical disagreement set contained six lost approvals and three improved rejections: a net regression of three judgments, not nine. The tenth disagreement was a separate positive canary that the local model also rejected too conservatively.
+
+That does not make the local model “better than Gemini.” It means the quality difference on this task was small, understandable, and tilted in the safer direction.
+
+The full evidence and caveats are recorded in [FAVA Trails issue #85](https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500).
+
+## What the benchmark did not prove
+
+The result is encouraging, but it has boundaries.
+
+The Gemini verdicts were historical references, not a fresh Gemini rerun. The benchmark covered a specific corpus and prompt, not arbitrary reasoning tasks. Long inputs were a weak spot: inputs over 40,000 characters achieved only 2/6 raw agreement and had a median latency of 122.9 seconds. The largest successful request contained 29,397 prompt tokens.
+
+The local model was also confidently wrong when it was wrong. Its average confidence on disagreements was 0.93, so confidence is not a reliable trigger for escalation. Occasional sampling and verdict logging remain useful for detecting drift.
+
+This is exactly why task-specific evaluation matters. “Can a local model replace a frontier model?” is too broad to be useful. “Can this local model enforce this promotion policy with an acceptable error profile?” can be answered.
+
+For FAVA Trails, the answer was yes.
+
+## The implementation stays provider-neutral
+
+Although Unsloth Studio was the first live target, FAVA Trails v0.6.0 does not contain an Unsloth-specific transport. It uses the OpenAI-compatible interface already exposed by many local and hosted runtimes.
+
+Each machine can select its provider, exact model identifier, API base, timeout, credentials, and provider-specific request controls through the standard per-machine configuration at `~/.config/fava-trails/config.yaml`. Shared trail configuration does not need to change, so one workstation can use a local model while another machine or a ChatGPT gateway continues using OpenRouter.
+
+The credential path received the same attention as the model path. File-backed API keys must be owner-only regular files; symlinks are rejected. The key is reread for every promotion, and an authentication failure gets one retry only if the key actually changed. The MCP server, doctor, readiness checks, and tunnel preflight all resolve the same effective configuration.
+
+Failures remain fail-closed. If the local endpoint is unavailable, times out, rejects authentication, or returns malformed output, FAVA Trails does not silently fall back to a hosted provider and promote the thought anyway.
+
+That boundary is important: local execution should reduce external dependency, not create an invisible alternate decision path.
+
+## FAVA Trails changed substantially in the last few months
+
+The local Trust Gate is the headline for v0.6.0, but it sits on top of a broader push to make agent memory inspectable, portable, and operationally safe.
+
+Between [v0.5.6](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.6) on May 5 and [v0.6.0](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.6.0) on July 31, the repository accumulated 66 commits across 45 changed files. The public milestones also included [v0.5.7](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.7), [v0.5.8](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.8), and [v0.5.9](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.9). The more meaningful story is how the system's boundaries became explicit.
+
+### Data integrity became fail-closed
+
+FAVA sync now blocks when the data repository has a dirty working copy or case-colliding tracked paths. Commit operations fail fast on unexpected changes and executable-bit churn instead of proceeding as if the repository were clean. This protects the memory store from a class of subtle VCS mistakes that are easy for agents to miss.
+
+### Memory became visible to humans
+
+The new rich-view commands generate and serve a small Astro reader from trail records. Thoughts have stable ULID routes, derived titles, and snapshot metadata. It is intentionally a reader rather than another editing surface: humans can inspect what agents saved without bypassing the MCP lifecycle that governs changes.
+
+### FAVA reached ChatGPT without making the data public
+
+The ChatGPT tunnel gateway runs a private loopback MCP runtime behind a secure tunnel, with detached lifecycle commands and a bounded `/healthz` readiness probe. Structured MCP errors and output schemas survive the gateway boundary, so clients receive meaningful failures instead of transport-shaped ambiguity.
+
+Tunnel startup was hardened over several releases. Readiness checks validate that the runtime identity can actually traverse the configured trail tree and parse representative data. Optional startup sync is bounded and fail-closed. Recurring autosync is disabled by default rather than quietly mutating shared state.
+
+### Read operations stopped having write-shaped side effects
+
+Read-only calls no longer create missing scopes. Exact-ULID lookup can find a unique thought across scopes and reports its source trail. Supersession preserves an existing confidence value when callers omit a replacement. These sound like small details; together, they make the system behave more like a dependable knowledge substrate and less like an optimistic demo.
+
+### Packaging and provider compatibility received production attention
+
+OpenRouter response compatibility was hardened in May. The MCP dependency was later constrained to the supported 1.x line so a fresh resolution could not select an incompatible major and crash the server before initialization. The v0.6.0 release itself passed 755 tests, Ruff, Semantic PR validation, and CodeQL before being published to PyPI through trusted publishing.
+
+The trajectory is consistent: make important state explicit, make failure visible, and make every integration preserve the same memory semantics.
+
+## Local models are most compelling when the task has clear error economics
+
+I do not think this benchmark proves that every agent workload should move to a local quantized model. It demonstrates something narrower and more useful.
+
+The FAVA Trust Gate has a stable prompt, structured output, historical cases, and asymmetric failure costs. Those properties make it a strong candidate for local inference. We can measure the model on the real task, inspect every disagreement, and decide whether its mistakes are acceptable.
+
+Here, they were.
+
+The local model preserved every historical rejection boundary, produced valid JSON every time, behaved consistently under repetition, and even caught three approvals that deserved another look. It gave up some recall in exchange for privacy, zero per-thought hosted inference cost, and less provider dependence.
+
+That is not a consolation prize for using a smaller model. It is the result of matching a model to a bounded job—and designing the surrounding system so conservative mistakes are recoverable.
+
+[FAVA Trails v0.6.0](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.6.0) is available now on [PyPI](https://pypi.org/project/fava-trails/0.6.0/). The project is open source under Apache 2.0.
+
+---
+
+## Publication notes
+
+- **Suggested Substack preview text:** A quantized local Qwen model matched every historical rejection in FAVA Trails' promotion benchmark—and its conservative mistakes were recoverable. Here is what we learned while moving institutional-memory review off hosted inference.
+- **Suggested social text:** FAVA Trails v0.6.0 can now use a local model to decide what deserves permanent agent memory. We benchmarked 49 historical cases and canaries: 49/49 valid verdicts, 13/13 historical rejections preserved, and only three net historical regressions after auditing the disagreements.
+- **Suggested tags:** AI agents, agent memory, local LLMs, MCP, open source
+- **Suggested hero image:** A split scene showing noisy streams of agent thoughts approaching a small local gate, with only a few versioned memory cards continuing into a private archive. Avoid humanoid robots and generic glowing brains.

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory.md
@@ -1,30 +1,30 @@
 # FAVA Trails v0.6.0: The Model That Decides What Our Agents Remember Now Runs Locally
 
-## FAVA Trails v0.6.0 brings local-model promotion gating—and our benchmark found that a quantized Qwen model was conservative, consistent, and good enough for the job
+## FAVA Trails v0.6.0 brings local-model promotion gating. Our benchmark found that a quantized Qwen model was conservative, consistent, and good enough for the job
 
 The newest release of [FAVA Trails](https://github.com/MachineWisdomAI/fava-trails), v0.6.0, can use a local OpenAI-compatible model to decide which agent memories deserve to become permanent.
 
 That means a thought being considered for institutional memory no longer has to be sent to OpenRouter, Gemini, or another hosted model. The review can happen on the operator's own machine, while OpenRouter remains the default for people who prefer it.
 
-The obvious question is whether a quantized local model is actually trustworthy enough to act as the gatekeeper.
+A quantized local model still has to be trustworthy enough to act as the gatekeeper.
 
 We ran [49 historical cases and canaries](https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500) through an Unsloth-served Qwen3.6 27B GGUF model. It returned valid structured verdicts in all 49 cases, preserved all 13 historical rejection boundaries in the corpus, and was stable across every repeated case. Every observed disagreement was conservative: the local model rejected additional material, but it did not reverse any of the 13 historical Gemini rejections.
 
-After I asked OpenAI Codex to re-audit the disagreements as a separate second-model adjudicator, the local model's interpretive net difference against the historical Gemini references was only three judgments. In exchange, promotion candidates in the Mac-local deployment stay local, per-thought hosted API fees disappear, and a hosted provider is removed from the critical path.
+I then asked OpenAI Codex to re-audit the disagreements as a second-model adjudicator. The local model's interpretive net difference against the historical Gemini references was only three judgments. In exchange, promotion candidates in the Mac-local deployment stay local, per-thought hosted API fees disappear, and a hosted provider is removed from the critical path.
 
 For this job, that is a trade I am willing to make.
 
-## The problem is not storing memory. It is deciding what deserves to become memory.
+## The hard part is deciding what deserves to become memory
 
 Agents generate a lot of text. Most of it should not become durable context.
 
 A useful observation, a decision with rationale, or a hard-won negative result may help the next agent. Process narration, transient runtime state, unsupported claims, and instructions disguised as facts usually will not. If all of it is saved indiscriminately, “memory” becomes a larger context window full of noise and contradictions.
 
-FAVA Trails—short for **Federated Agents Versioned Audit Trail**—treats memory as curated, versioned knowledge rather than a transcript archive. Thoughts begin as drafts. A promotion gate reviews them before they enter permanent namespaces. Superseded beliefs remain in the audit history but disappear from normal recall. Every record is a Markdown file with structured metadata in a Git repository controlled by the operator, with Jujutsu handling atomic changes underneath.
+FAVA Trails (short for Federated Agents Versioned Audit Trail) treats memory as curated, versioned knowledge rather than a transcript archive. Thoughts begin as drafts. A promotion gate reviews them before they enter permanent namespaces. Superseded beliefs remain in the audit history but disappear from normal recall. Every record is a Markdown file with structured metadata in a Git repository controlled by the operator, with Jujutsu handling atomic changes underneath.
 
 The Trust Gate asks a deliberately simple question:
 
-> Will a future agent—with no context about this conversation—find this thought useful?
+> Will a future agent, with no context about this conversation, find this thought useful?
 
 The [production review prompt](https://github.com/MachineWisdomAI/fava-trails/blob/v0.6.0/src/fava_trails/data_repo_template/trust-gate-prompt.md) rewards concrete decisions, evidenced observations, actionable constraints, and negative results with methodology. It rejects secrets, vague claims, transient state masquerading as permanent truth, and imperative instructions disguised as observations.
 
@@ -32,9 +32,9 @@ Before v0.6.0, thoughts sent through FAVA's `llm-oneshot` promotion path went th
 
 ## What we benchmarked
 
-The benchmark used 39 historical thoughts with prior Gemini verdicts—26 approvals and 13 rejections—plus 10 synthetic canaries. The local candidate was the quantized model exposed as `unsloth/Qwen3.6-27B-GGUF` through Unsloth Studio on the workstation.
+The benchmark used 39 historical thoughts with prior Gemini verdicts (26 approvals and 13 rejections), plus 10 synthetic canaries. The local candidate was the quantized model exposed as `unsloth/Qwen3.6-27B-GGUF` through Unsloth Studio on the workstation.
 
-This was not a generic model benchmark. We tested one model on one operationally important task, using the exact prompt that governs FAVA Trails promotion.
+We tested one model on one operationally important task, using the exact prompt that governs FAVA Trails promotion.
 
 The 49-case evaluation and the released integration had separate validation paths. The benchmark used WisdomHelm's provider-neutral `local-llm` CLI to send FAVA's exact production messages and parse the results with FAVA's production verdict parser; it did not change the production provider configuration or exercise the new v0.6 provider path end to end. After the release was integrated, [a separate live dogfood](https://github.com/MachineWisdomAI/fava-trails/pull/88) exercised that provider path directly: it approved a durable architectural decision and rejected an adversarial instruction.
 
@@ -53,7 +53,7 @@ The results were:
 | p95 latency | 122.9 seconds |
 | Maximum latency | 172.5 seconds |
 
-At first glance, 79.6% agreement sounds merely adequate. But aggregate agreement hides the most important part of a gate: **which direction the errors go**.
+Raw agreement was 79.6%, which sounds merely adequate until you look at the direction of the errors.
 
 Every disagreement was an additional rejection by the local model. Among the 13 historical Gemini rejections in this corpus, it did not reverse a single verdict. That matters because the cost of the two error types is asymmetric:
 
@@ -62,9 +62,9 @@ Every disagreement was an additional rejection by the local model. Among the 13 
 
 A conservative critic is often preferable to a permissive one.
 
-## The nine disagreements were not nine regressions
+## What the nine disagreements revealed
 
-The local model rejected nine historical thoughts Gemini had approved. Rather than treating Gemini as ground truth, I asked OpenAI Codex—separate from the quantized candidate—to conduct a second-model adjudication of each thought against the exact promotion prompt and then apply its own judgment. This was not independent human ground truth; it was a structured challenge to the historical reference verdicts, published with the other [evaluation evidence](https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500).
+The local model rejected nine historical thoughts Gemini had approved. Rather than treating Gemini as ground truth, I asked OpenAI Codex, separate from the quantized candidate, to judge each thought against the exact promotion prompt. This second-model review was a structured challenge to the historical verdicts, not independent human ground truth. It is published with the other [evaluation evidence](https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500).
 
 Gemini had the better verdict in six cases. The local model was simply too strict.
 
@@ -76,11 +76,11 @@ But in three cases, the local model caught material Gemini should not have promo
 
 So the historical disagreement set contained six lost approvals and three improved rejections: an interpretive net difference of three judgments after second-model adjudication, not a formal accuracy estimate. The tenth disagreement was a separate positive canary that the local model also rejected too conservatively.
 
-That does not make the local model “better than Gemini.” It means the quality difference on this task was small, understandable, and tilted in the safer direction.
+The evidence supports a small, understandable quality difference on this task, tilted in the safer direction. It is too narrow to establish that the local model is better than Gemini overall.
 
 The full evidence and caveats are recorded in [FAVA Trails issue #85](https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500).
 
-## What the benchmark did not prove
+## The limits of the benchmark
 
 The benchmark supports one bounded conclusion: this local model had an acceptable error profile for FAVA's promotion prompt on this corpus. It does not establish general parity with Gemini, frontier models, or unrelated agent tasks.
 
@@ -88,9 +88,7 @@ The Gemini verdicts were historical references, not a fresh Gemini rerun. The be
 
 The local model was also confidently wrong when it was wrong. Its average confidence on disagreements was 0.93, so confidence is not a reliable trigger for escalation. Occasional sampling and verdict logging remain useful for detecting drift.
 
-This is exactly why task-specific evaluation matters. “Can a local model replace a frontier model?” is too broad to be useful. “Can this local model enforce this promotion policy with an acceptable error profile?” can be answered.
-
-For FAVA Trails, the answer was yes.
+Task-specific evaluation makes this decision possible because it asks whether this model enforces this promotion policy with an acceptable error profile. For FAVA Trails, the answer was yes.
 
 ## The implementation stays provider-neutral
 
@@ -98,17 +96,17 @@ For FAVA Trails, the answer was yes.
 
 Each machine can select its provider, exact model identifier, API base, timeout, credentials, and provider-specific request controls through the standard per-machine configuration at `~/.config/fava-trails/config.yaml`. Shared trail configuration does not need to change, so one workstation can use a local model while another machine or a ChatGPT gateway continues using OpenRouter.
 
-The credential path received the same attention as the model path. File-backed API keys must be owner-only regular files; symlinks are rejected. The key is reread for every promotion, and an authentication failure gets one retry only if the key actually changed. The MCP server, doctor, readiness checks, and tunnel preflight all resolve the same effective configuration.
+Credentials follow the same fail-closed rules. File-backed API keys must be owner-only regular files; symlinks are rejected. The key is reread for every promotion, and an authentication failure gets one retry only if the key actually changed. The MCP server, doctor, readiness checks, and tunnel preflight all resolve the same effective configuration.
 
 Failures remain fail-closed. If the local endpoint is unavailable, times out, rejects authentication, or returns malformed output, FAVA Trails does not silently fall back to a hosted provider and promote the thought anyway.
 
-That boundary is important: local execution should reduce external dependency, not create an invisible alternate decision path.
+Failing closed reduces external dependency without creating an invisible alternate decision path.
 
 ## FAVA Trails changed substantially in the last few months
 
 From May through July, FAVA Trails added four operational layers around its memory core: safer synchronization, human-readable views, authenticated ChatGPT access, and local promotion gating. The local Trust Gate is the v0.6.0 headline, but it rests on that broader push to make agent memory inspectable, portable, and operationally safe.
 
-Between [v0.5.6 and v0.6.0](https://github.com/MachineWisdomAI/fava-trails/compare/v0.5.6...v0.6.0)—May 5 through July 31—the repository accumulated 66 commits. The public milestones also included [v0.5.7](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.7), [v0.5.8](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.8), and [v0.5.9](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.9). The more meaningful story is how the system's boundaries became explicit.
+Between [v0.5.6 and v0.6.0](https://github.com/MachineWisdomAI/fava-trails/compare/v0.5.6...v0.6.0), May 5 through July 31, the repository accumulated 66 commits. The public milestones also included [v0.5.7](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.7), [v0.5.8](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.8), and [v0.5.9](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.9).
 
 ### Data integrity became fail-closed
 
@@ -132,18 +130,12 @@ Read-only calls no longer create missing scopes. Exact-ULID lookup can find a un
 
 OpenRouter response compatibility was hardened in May. The MCP dependency was later constrained to the supported 1.x line so a fresh resolution could not select an incompatible major and crash the server before initialization. The v0.6.0 release itself passed 755 tests, Ruff, Semantic PR validation, and CodeQL before being published to PyPI through trusted publishing.
 
-The trajectory is consistent: make important state explicit, make failure visible, and make every integration preserve the same memory semantics.
-
-## Local models are most compelling when the task has clear error economics
+## Why this task fits a local model
 
 Local models are strongest when the task has a stable policy, structured output, auditable historical cases, and asymmetric failure costs. FAVA's promotion gate has all four.
 
-This benchmark does not prove that every agent workload should move to a local quantized model. It demonstrates something narrower and more useful: when a task has those properties, we can measure the model on the real job, inspect every disagreement, and decide whether its mistakes are acceptable.
+For this kind of task, we can measure the model on the real job, inspect every disagreement, and decide whether its mistakes are acceptable. In this benchmark, I consider them acceptable.
 
-Here, they were.
-
-In this benchmark, the local model preserved every historical rejection boundary, produced valid JSON every time, behaved consistently under repetition, and caught three approvals that deserved another look. It approved fewer historically approved candidates in exchange for keeping promotion payloads off hosted inference, eliminating per-thought hosted API fees, and reducing provider dependence.
-
-That is not a consolation prize for using a smaller model. It is the result of matching a model to a bounded job—and designing the surrounding system so conservative mistakes are recoverable.
+The local model preserved every historical rejection boundary, produced valid JSON every time, behaved consistently under repetition, and caught three approvals that deserved another look. It approved fewer historically approved candidates in exchange for keeping promotion payloads off hosted inference, eliminating per-thought hosted API fees, and reducing provider dependence.
 
 [FAVA Trails v0.6.0](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.6.0) is available now on [PyPI](https://pypi.org/project/fava-trails/0.6.0/). The project is open source under Apache 2.0.

--- a/docs/articles/2026-07-31-local-models-can-guard-institutional-memory.md
+++ b/docs/articles/2026-07-31-local-models-can-guard-institutional-memory.md
@@ -1,4 +1,4 @@
-# The Model That Decides What Our Agents Remember Now Runs Locally
+# FAVA Trails v0.6.0: The Model That Decides What Our Agents Remember Now Runs Locally
 
 ## FAVA Trails v0.6.0 brings local-model promotion gating—and our benchmark found that a quantized Qwen model was conservative, consistent, and good enough for the job
 
@@ -8,9 +8,9 @@ That means a thought being considered for institutional memory no longer has to 
 
 The obvious question is whether a quantized local model is actually trustworthy enough to act as the gatekeeper.
 
-We ran 49 historical cases and canaries through an Unsloth-served Qwen3.6 27B GGUF model. It returned valid structured verdicts in all 49 cases, preserved all 13 historical rejection boundaries, and was stable across every repeated case. Its errors were conservative: it rejected too much, but it never approved something Gemini had rejected.
+We ran [49 historical cases and canaries](https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500) through an Unsloth-served Qwen3.6 27B GGUF model. It returned valid structured verdicts in all 49 cases, preserved all 13 historical rejection boundaries in the corpus, and was stable across every repeated case. Every observed disagreement was conservative: the local model rejected additional material, but it did not reverse any of the 13 historical Gemini rejections.
 
-After I independently re-audited the disagreements, the local model's net regression against Gemini was only three historical judgments. In exchange, promotion candidates stay local, external inference cost disappears, and a hosted provider is removed from the critical path.
+After I asked OpenAI Codex to re-audit the disagreements as a separate second-model adjudicator, the local model's interpretive net difference against the historical Gemini references was only three judgments. In exchange, promotion candidates in the Mac-local deployment stay local, per-thought hosted API fees disappear, and a hosted provider is removed from the critical path.
 
 For this job, that is a trade I am willing to make.
 
@@ -28,13 +28,15 @@ The Trust Gate asks a deliberately simple question:
 
 The [production review prompt](https://github.com/MachineWisdomAI/fava-trails/blob/v0.6.0/src/fava_trails/data_repo_template/trust-gate-prompt.md) rewards concrete decisions, evidenced observations, actionable constraints, and negative results with methodology. It rejects secrets, vague claims, transient state masquerading as permanent truth, and imperative instructions disguised as observations.
 
-Until now, that review normally went through OpenRouter to Gemini. It worked well, but it created an uncomfortable property: everything being considered for durable memory had to cross an external inference boundary before it could be saved.
+Before v0.6.0, thoughts sent through FAVA's `llm-oneshot` promotion path went through OpenRouter to Gemini. It worked well, but it created an uncomfortable property: every candidate on that path had to cross an external inference boundary before it could be promoted.
 
 ## What we benchmarked
 
-The benchmark used 39 historical thoughts with prior Gemini verdicts—26 approvals and 13 rejections—plus 10 synthetic canaries. The local candidate was the quantized Qwen model already running through Unsloth Studio on the workstation.
+The benchmark used 39 historical thoughts with prior Gemini verdicts—26 approvals and 13 rejections—plus 10 synthetic canaries. The local candidate was the quantized model exposed as `unsloth/Qwen3.6-27B-GGUF` through Unsloth Studio on the workstation.
 
 This was not a generic model benchmark. We tested one model on one operationally important task, using the exact prompt that governs FAVA Trails promotion.
+
+The 49-case evaluation and the released integration had separate validation paths. The benchmark used WisdomHelm's provider-neutral `local-llm` CLI to send FAVA's exact production messages and parse the results with FAVA's production verdict parser; it did not change the production provider configuration or exercise the new v0.6 provider path end to end. After the release was integrated, [a separate live dogfood](https://github.com/MachineWisdomAI/fava-trails/pull/88) exercised that provider path directly: it approved a durable architectural decision and rejected an adversarial instruction.
 
 The results were:
 
@@ -53,7 +55,7 @@ The results were:
 
 At first glance, 79.6% agreement sounds merely adequate. But aggregate agreement hides the most important part of a gate: **which direction the errors go**.
 
-Every disagreement was an additional rejection by the local model. It did not approve a single thought that Gemini had historically rejected. That matters because the cost of the two error types is asymmetric:
+Every disagreement was an additional rejection by the local model. Among the 13 historical Gemini rejections in this corpus, it did not reverse a single verdict. That matters because the cost of the two error types is asymmetric:
 
 - A false rejection is visible and recoverable. The thought remains a draft, can be improved, and can be resubmitted.
 - A false approval is quiet. Low-quality material enters institutional memory, consumes future context, and may steer later agents.
@@ -62,7 +64,7 @@ A conservative critic is often preferable to a permissive one.
 
 ## The nine disagreements were not nine regressions
 
-The local model rejected nine historical thoughts Gemini had approved. Rather than treating Gemini as ground truth, I asked a more capable frontier model—separate from the quantized candidate—to re-audit each thought against the exact promotion prompt and then apply its own judgment.
+The local model rejected nine historical thoughts Gemini had approved. Rather than treating Gemini as ground truth, I asked OpenAI Codex—separate from the quantized candidate—to conduct a second-model adjudication of each thought against the exact promotion prompt and then apply its own judgment. This was not independent human ground truth; it was a structured challenge to the historical reference verdicts, published with the other [evaluation evidence](https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500).
 
 Gemini had the better verdict in six cases. The local model was simply too strict.
 
@@ -72,7 +74,7 @@ But in three cases, the local model caught material Gemini should not have promo
 2. An implementation-heavy artifact had been misclassified as a specification.
 3. An imperative task instruction had been presented as durable knowledge without provenance or rationale.
 
-So the historical disagreement set contained six lost approvals and three improved rejections: a net regression of three judgments, not nine. The tenth disagreement was a separate positive canary that the local model also rejected too conservatively.
+So the historical disagreement set contained six lost approvals and three improved rejections: an interpretive net difference of three judgments after second-model adjudication, not a formal accuracy estimate. The tenth disagreement was a separate positive canary that the local model also rejected too conservatively.
 
 That does not make the local model “better than Gemini.” It means the quality difference on this task was small, understandable, and tilted in the safer direction.
 
@@ -106,7 +108,7 @@ That boundary is important: local execution should reduce external dependency, n
 
 The local Trust Gate is the headline for v0.6.0, but it sits on top of a broader push to make agent memory inspectable, portable, and operationally safe.
 
-Between [v0.5.6](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.6) on May 5 and [v0.6.0](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.6.0) on July 31, the repository accumulated 66 commits across 45 changed files. The public milestones also included [v0.5.7](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.7), [v0.5.8](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.8), and [v0.5.9](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.9). The more meaningful story is how the system's boundaries became explicit.
+Between [v0.5.6 and v0.6.0](https://github.com/MachineWisdomAI/fava-trails/compare/v0.5.6...v0.6.0)—May 5 through July 31—the repository accumulated 66 commits. The public milestones also included [v0.5.7](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.7), [v0.5.8](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.8), and [v0.5.9](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.9). The more meaningful story is how the system's boundaries became explicit.
 
 ### Data integrity became fail-closed
 
@@ -116,9 +118,9 @@ FAVA sync now blocks when the data repository has a dirty working copy or case-c
 
 The new rich-view commands generate and serve a small Astro reader from trail records. Thoughts have stable ULID routes, derived titles, and snapshot metadata. It is intentionally a reader rather than another editing surface: humans can inspect what agents saved without bypassing the MCP lifecycle that governs changes.
 
-### FAVA reached ChatGPT without making the data public
+### FAVA reached ChatGPT without exposing an unauthenticated public MCP endpoint
 
-The ChatGPT tunnel gateway runs a private loopback MCP runtime behind a secure tunnel, with detached lifecycle commands and a bounded `/healthz` readiness probe. Structured MCP errors and output schemas survive the gateway boundary, so clients receive meaningful failures instead of transport-shaped ambiguity.
+The ChatGPT tunnel gateway runs a private loopback MCP runtime behind an authenticated secure tunnel, with detached lifecycle commands and a bounded `/healthz` readiness probe. Authorized ChatGPT requests can receive returned FAVA data through that tunnel, but the local MCP runtime is not exposed as an unauthenticated public endpoint. Structured MCP errors and output schemas survive the gateway boundary, so clients receive meaningful failures instead of transport-shaped ambiguity.
 
 Tunnel startup was hardened over several releases. Readiness checks validate that the runtime identity can actually traverse the configured trail tree and parse representative data. Optional startup sync is bounded and fail-closed. Recurring autosync is disabled by default rather than quietly mutating shared state.
 
@@ -140,17 +142,8 @@ The FAVA Trust Gate has a stable prompt, structured output, historical cases, an
 
 Here, they were.
 
-The local model preserved every historical rejection boundary, produced valid JSON every time, behaved consistently under repetition, and even caught three approvals that deserved another look. It gave up some recall in exchange for privacy, zero per-thought hosted inference cost, and less provider dependence.
+In this benchmark, the local model preserved every historical rejection boundary, produced valid JSON every time, behaved consistently under repetition, and caught three approvals that deserved another look. It approved fewer historically approved candidates in exchange for keeping promotion payloads off hosted inference, eliminating per-thought hosted API fees, and reducing provider dependence.
 
 That is not a consolation prize for using a smaller model. It is the result of matching a model to a bounded job—and designing the surrounding system so conservative mistakes are recoverable.
 
 [FAVA Trails v0.6.0](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.6.0) is available now on [PyPI](https://pypi.org/project/fava-trails/0.6.0/). The project is open source under Apache 2.0.
-
----
-
-## Publication notes
-
-- **Suggested Substack preview text:** A quantized local Qwen model matched every historical rejection in FAVA Trails' promotion benchmark—and its conservative mistakes were recoverable. Here is what we learned while moving institutional-memory review off hosted inference.
-- **Suggested social text:** FAVA Trails v0.6.0 can now use a local model to decide what deserves permanent agent memory. We benchmarked 49 historical cases and canaries: 49/49 valid verdicts, 13/13 historical rejections preserved, and only three net historical regressions after auditing the disagreements.
-- **Suggested tags:** AI agents, agent memory, local LLMs, MCP, open source
-- **Suggested hero image:** A split scene showing noisy streams of agent thoughts approaching a small local gate, with only a few versioned memory cards continuing into a private archive. Avoid humanoid robots and generic glowing brains.

--- a/docs/research/fava-trails-v0.6.0-article-research.md
+++ b/docs/research/fava-trails-v0.6.0-article-research.md
@@ -1,0 +1,69 @@
+# Research: FAVA Trails v0.6.0 and the local Trust Gate benchmark
+
+Research date: 2026-07-31. Primary sources only. This note supports the accompanying Substack draft.
+
+## Thesis
+
+FAVA Trails v0.6.0 moves the judgment boundary—not merely inference—onto the machine that owns the context. A machine can now run the model deciding what becomes durable institutional memory while retaining the existing promotion prompt, fail-closed behavior, audit trail, and shared data model.
+
+The benchmark supports a narrow claim: the tested quantized Qwen3.6 27B model was credible for this promotion-gate task. It was structurally reliable, preserved every historical rejection boundary, and showed a small, conservative net regression after the disagreements were independently adjudicated. It does not establish general parity with Gemini or frontier models.
+
+## Benchmark method
+
+The corpus contained 49 cases:
+
+- 13 unique historical thoughts Gemini had rejected;
+- a deterministic, stratified sample of 26 historical thoughts Gemini had approved; and
+- 10 prompt-derived canaries: four positive controls and six rejection cases.
+
+The replay constructed the production FAVA Trust Gate messages, including XML-escaped thought bodies and redacted metadata, and used FAVA's production verdict parser. Historical Gemini decisions were comparison references, not a fresh rerun or unquestionable ground truth. Eight representative cases were repeated three times, and two short requests were also tested concurrently.
+
+Primary evidence: [issue #85 benchmark comment](https://github.com/MachineWisdomAI/fava-trails/issues/85#issuecomment-5142775500).
+
+## Results
+
+| Measure | Result |
+|---|---:|
+| Valid structured verdicts | 49/49 |
+| Parse, CLI, or retry failures | 0 |
+| Raw agreement with references and canaries | 39/49 (79.6%) |
+| Historical rejections matched | 13/13 |
+| Historical approvals matched | 17/26 |
+| Canaries matched | 9/10 |
+| Repeat consistency | 8/8 stable across three runs |
+| Median / p95 / maximum latency | 14.0s / 122.9s / 172.5s |
+
+All ten disagreements were additional local-model rejections. No permissive error was observed against the 13 historical rejection cases in this corpus.
+
+The nine historical disagreements were independently re-audited against the exact prompt. Gemini's approval was judged better in six cases; the local rejection was judged better in three. The separate tenth disagreement was an over-rejected positive canary. The historical comparison therefore produced a net regression of three judgments, not nine. This is an interpretive adjudication, not a formal accuracy estimate.
+
+## Important limitations
+
+- Call 79.6% raw agreement, not accuracy.
+- The corpus is focused and historical Gemini was not rerun.
+- Inputs above 40,000 characters achieved only 2/6 agreement and had 122.9-second median latency.
+- Disagreement confidence averaged 0.93, so confidence did not reveal over-strict judgments.
+- Repeat stability covered eight selected cases, not the entire corpus.
+- “No permissive error was observed” must not become “the model cannot make false approvals.”
+
+## What v0.6.0 shipped
+
+- Provider-neutral OpenAI-compatible Trust Gate configuration.
+- Standard per-machine config at `$XDG_CONFIG_HOME/fava-trails/config.yaml`.
+- Separation of machine-specific runtime choices from shared trail configuration.
+- Owner-only, non-symlink credential files with per-promotion rereads and one changed-key retry after a 401.
+- Provider-specific request controls without an Unsloth-specific SDK or transport.
+- Provider/model provenance and consistent effective configuration across MCP promotion, doctor, readiness, and tunnel preflight.
+- Backward-compatible OpenRouter defaults and no automatic hosted fallback after local failure.
+
+Primary sources: [v0.6.0 release](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.6.0), [issue #85](https://github.com/MachineWisdomAI/fava-trails/issues/85), [implementation PR #87](https://github.com/MachineWisdomAI/fava-trails/pull/87), and [release PR #88](https://github.com/MachineWisdomAI/fava-trails/pull/88).
+
+## May–July product arc
+
+- [v0.5.6](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.6): hardened the hosted OpenRouter response boundary.
+- [v0.5.7](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.7): blocked unsafe sync and commits when Git/JJ data was dirty, case-colliding, or unexpectedly changed.
+- [v0.5.8](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.8): added human-readable rich views, a ChatGPT secure-tunnel gateway, MCP output schemas, structured error preservation, safer scope lookup, and tunnel lifecycle hardening.
+- [v0.5.9](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.5.9): added bounded fail-closed tunnel readiness and stabilized the runtime dependency boundary.
+- [v0.6.0](https://github.com/MachineWisdomAI/fava-trails/releases/tag/v0.6.0): made local promotion gating a supported per-machine operating mode.
+
+Between v0.5.6 on 2026-05-05 and v0.6.0 on 2026-07-31, the repository recorded 66 commits across 45 changed files. Earlier public packaging and lifecycle-hook releases are useful background but fall outside the strict three-month window.

--- a/docs/research/fava-trails-v0.6.0-article-research.md
+++ b/docs/research/fava-trails-v0.6.0-article-research.md
@@ -6,7 +6,7 @@ Research date: 2026-07-31. Primary sources only. This note supports the accompan
 
 FAVA Trails v0.6.0 moves the judgment boundary—not merely inference—onto the machine that owns the context. A machine can now run the model deciding what becomes durable institutional memory while retaining the existing promotion prompt, fail-closed behavior, audit trail, and shared data model.
 
-The benchmark supports a narrow claim: the tested quantized Qwen3.6 27B model was credible for this promotion-gate task. It was structurally reliable, preserved every historical rejection boundary, and showed a small, conservative net regression after the disagreements were independently adjudicated. It does not establish general parity with Gemini or frontier models.
+The benchmark supports a narrow claim: the tested quantized Qwen3.6 27B model was credible for this promotion-gate task. It was structurally reliable, preserved every historical rejection boundary in the corpus, and showed a small, conservative interpretive net difference after second-model adjudication. It does not establish general parity with Gemini or frontier models.
 
 ## Benchmark method
 

--- a/docs/research/fava-trails-v0.6.0-article-research.md
+++ b/docs/research/fava-trails-v0.6.0-article-research.md
@@ -35,7 +35,7 @@ Primary evidence: [issue #85 benchmark comment](https://github.com/MachineWisdom
 
 All ten disagreements were additional local-model rejections. No permissive error was observed against the 13 historical rejection cases in this corpus.
 
-The nine historical disagreements were independently re-audited against the exact prompt. Gemini's approval was judged better in six cases; the local rejection was judged better in three. The separate tenth disagreement was an over-rejected positive canary. The historical comparison therefore produced a net regression of three judgments, not nine. This is an interpretive adjudication, not a formal accuracy estimate.
+The nine historical disagreements were re-audited by OpenAI Codex as a separate second-model adjudicator against the exact prompt. Gemini's approval was judged better in six cases; the local rejection was judged better in three. The separate tenth disagreement was an over-rejected positive canary. The historical comparison therefore produced an interpretive net difference of three judgments, not nine. This was not independent human ground truth or a formal accuracy estimate.
 
 ## Important limitations
 


### PR DESCRIPTION
## Summary

- add a Substack-ready article about FAVA Trails v0.6.0 and local promotion gating
- document the 49-case Unsloth/Qwen benchmark, disagreement adjudication, limitations, and provider-neutral implementation
- recap the major FAVA Trails work shipped from May through July
- include a separate publishing brief and primary-source research record

## Verification

- benchmark claims checked against issue #85 and the v0.6.0 release evidence
- benchmark CLI replay kept distinct from the released provider-path dogfood
- completed writing-optimized synthesis and audit passes
- completed a no-ai-slop edit while preserving all evidence and caveats
- aligned the public issue evidence with the article
- `git diff --check origin/main...HEAD`

Docs only; no runtime behavior changed.