### PR TITLE
fix: support MCP 2 server registration and protocol compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,3 @@ jobs:
         run: uv run pytest -v
         env:
           JJ_CONFIG: /dev/null
-
-      - name: Verify installed wheel MCP startup
-        run: |
-          uv build --wheel
-          uv run --isolated --no-project --with dist/*.whl --with pytest --with pytest-asyncio pytest tests/test_mcp_protocol.py -v
-        env:
-          JJ_CONFIG: /dev/null
-          FAVA_EXPECT_WHEEL: "1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,3 +35,11 @@ jobs:
         run: uv run pytest -v
         env:
           JJ_CONFIG: /dev/null
+
+      - name: Verify installed wheel MCP startup
+        run: |
+          uv build --wheel
+          uv run --isolated --no-project --with dist/*.whl --with pytest --with pytest-asyncio pytest tests/test_mcp_protocol.py -v
+        env:
+          JJ_CONFIG: /dev/null
+          FAVA_EXPECT_WHEEL: "1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to FAVA Trails are documented here.
 
 ## Unreleased
 
+### Changed
+- Support MCP SDK 2.2 with explicit low-level handlers, preserving tool schemas, annotations, input/output validation, structured results, and Markdown usage guidance over stdio and Streamable HTTP. Adds installed-wheel protocol tests for legacy initialization and current SDK clients. Resolves #83.
+
 ## [0.6.1] — 2026-08-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ fava-trails clone https://github.com/YOUR-ORG/fava-trails-data.git fava-trails-d
 
 ### Register the MCP server
 
+FAVA uses MCP SDK 2.2 or later within the 2.x series. Existing stdio client
+configuration and the private Streamable HTTP endpoint remain supported, including
+legacy `initialize` clients. Tool input/output schemas, annotations, and structured
+responses are preserved. Restart a configured server after updating its package;
+installing the package alone does not update a running process.
+
 Add to your MCP client config:
 - **Claude Code CLI**: `~/.claude.json` (top-level `mcpServers` key)
 - **Claude Desktop**: `claude_desktop_config.json`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ classifiers = [
     "Development Status :: 4 - Beta",
 ]
 dependencies = [
-    "mcp>=1.28.1,<2.0",
+    "mcp>=2.2.0,<3.0",
+    "jsonschema>=4.26.0,<5.0",
     "pydantic>=2.0.0,<3.0",
     "pyyaml>=6.0,<7.0",
     "python-ulid>=3.0.0,<4.0",

--- a/src/fava_trails/server.py
+++ b/src/fava_trails/server.py
@@ -1,6 +1,6 @@
 """FAVA Trails MCP Server 🫛👣 — Federated Agents Versioned Audit Trail.
 
-Provides 16 MCP tools for versioned agent memory via JJ (Jujutsu) VCS.
+Provides 17 MCP tools for versioned agent memory via JJ (Jujutsu) VCS.
 All tool responses are token-optimized JSON summaries — no raw VCS output.
 """
 
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import importlib.resources
+import json
 import logging
 import logging.handlers
 import os
@@ -17,9 +18,18 @@ from collections.abc import Callable, Coroutine
 from pathlib import Path
 from typing import Any
 
-from mcp.server import Server
+import jsonschema
+from mcp.server import Server, ServerRequestContext
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool, ToolAnnotations
+from mcp.types import (
+    CallToolRequestParams,
+    CallToolResult,
+    ListToolsResult,
+    PaginatedRequestParams,
+    TextContent,
+    Tool,
+    ToolAnnotations,
+)
 
 from .config import (
     ConfigStore,
@@ -157,8 +167,6 @@ def _load_usage_guide() -> str:
 
     return "Error: AGENTS_USAGE_INSTRUCTIONS.md not found. Check your installation."
 
-
-server = Server("fava-trails", instructions=_build_server_instructions())
 
 # Trail manager cache: trail_name -> TrailManager
 _trail_managers: dict[str, TrailManager] = {}
@@ -308,6 +316,7 @@ STRUCTURED_RESULT_SCHEMA: dict[str, Any] = {
 def _structured_or_common_error(success_schema: dict[str, Any]) -> dict[str, Any]:
     """Allow a precise success shape while preserving structured error responses."""
     return {
+        "type": "object",
         "anyOf": [
             success_schema,
             STRUCTURED_RESULT_SCHEMA,
@@ -854,22 +863,20 @@ def with_tool_timeout(
     return wrapper
 
 
-@server.list_tools()
 async def handle_list_tools() -> list[Tool]:
     """List all FAVA Trails tools."""
     return [
         Tool(
             name=td["name"],
             description=td["description"],
-            inputSchema=td["inputSchema"],
-            outputSchema=td["outputSchema"],
+            input_schema=td["inputSchema"],
+            output_schema=td["outputSchema"],
             annotations=ToolAnnotations(**td["annotations"]),
         )
         for td in TOOL_DEFINITIONS
     ]
 
 
-@server.call_tool()
 @with_tool_timeout
 async def handle_call_tool(name: str, arguments: dict[str, Any]) -> Any:
     """Route tool calls to handlers. Responses are structured JSON (except get_usage_guide which returns markdown)."""
@@ -1072,6 +1079,57 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> Any:
 
     logger.info("Tool call completed: %s %s", name, _summarize_tool_result(result))
     return result
+
+
+async def _list_tools(ctx: ServerRequestContext, params: PaginatedRequestParams | None) -> ListToolsResult:
+    """Adapt the canonical tool catalogue to the SDK's explicit handler API."""
+    return ListToolsResult(tools=await handle_list_tools())
+
+
+def _tool_error(message: str) -> CallToolResult:
+    return CallToolResult(content=[TextContent(type="text", text=message)], is_error=True)
+
+
+async def _call_tool(ctx: ServerRequestContext, params: CallToolRequestParams) -> CallToolResult:
+    """Preserve v1 validation and result semantics at the v2 transport boundary.
+
+    Domain error/blocked dictionaries remain structured results. Invalid schemas
+    and unexpected adapter failures are MCP tool errors; cancellation propagates.
+    """
+    definition = next((tool for tool in TOOL_DEFINITIONS if tool["name"] == params.name), None)
+    arguments = params.arguments or {}
+    if definition is not None:
+        try:
+            jsonschema.validate(arguments, definition["inputSchema"])
+        except jsonschema.ValidationError as exc:
+            return _tool_error(f"Input validation error: {exc.message}")
+
+    try:
+        result = await handle_call_tool(params.name, arguments)
+        if isinstance(result, tuple):
+            content, structured = result
+        else:
+            structured = result
+            content = [TextContent(type="text", text=json.dumps(result, ensure_ascii=False))]
+        if definition is not None:
+            try:
+                jsonschema.validate(structured, definition["outputSchema"])
+            except jsonschema.ValidationError:
+                # A malformed handler result may contain data that should never
+                # reach this caller. Do not echo the rejected value in the error.
+                return _tool_error("Output validation error: result does not match the tool output schema")
+        return CallToolResult(content=content, structured_content=structured)
+    except Exception:
+        logger.exception("MCP tool adapter failed for %s", params.name)
+        return _tool_error("Tool execution failed")
+
+
+server = Server(
+    "fava-trails",
+    instructions=_build_server_instructions(),
+    on_list_tools=_list_tools,
+    on_call_tool=_call_tool,
+)
 
 
 def run():

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -1,0 +1,157 @@
+"""SDK upgrades must preserve the real executable and both protocol generations."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import jsonschema
+import pytest
+import pytest_asyncio
+from mcp import Client
+
+from fava_trails import server
+
+
+@pytest_asyncio.fixture
+async def stdio_rpc(tmp_fava_home, tmp_path):
+    """Run the installed console script against synthetic data with bounded I/O."""
+    executable = Path(sys.executable).parent / "fava-trails-server"
+    assert executable.is_file(), "The installed package must provide its console entrypoint"
+    if os.environ.get("FAVA_EXPECT_WHEEL") == "1":
+        assert "site-packages" in Path(server.__file__).parts
+    env = {key: value for key, value in os.environ.items() if not key.startswith("FAVA_TRAILS_")}
+    env.update({
+        "FAVA_TRAILS_DATA_REPO": str(tmp_fava_home),
+        "FAVA_TRAILS_DIR": str(tmp_fava_home / "trails"),
+        "FAVA_TRAILS_LOG_DIR": str(tmp_path / "logs"),
+        "FAVA_TRAILS_AGENT_ID": "synthetic-wire-agent",
+        "XDG_CONFIG_HOME": str(tmp_path / "xdg-config"),
+    })
+    with (tmp_path / "server-stderr.log").open("wb") as stderr:
+        process = await asyncio.create_subprocess_exec(
+            str(executable), cwd=tmp_path, env=env,
+            stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE, stderr=stderr,
+        )
+        next_id = 0
+
+        async def rpc(method, params=None, *, notification=False):
+            nonlocal next_id
+            next_id += 1
+            message = {"jsonrpc": "2.0", "method": method}
+            if params is not None:
+                message["params"] = params
+            if not notification:
+                message["id"] = next_id
+            process.stdin.write((json.dumps(message) + "\n").encode())
+            await process.stdin.drain()
+            if notification:
+                return None
+            async with asyncio.timeout(30):
+                while True:
+                    line = await process.stdout.readline()
+                    assert line, (tmp_path / "server-stderr.log").read_text()
+                    response = json.loads(line)
+                    if response.get("id") == next_id:
+                        assert "result" in response, response
+                        return response["result"]
+
+        try:
+            yield rpc
+        finally:
+            if process.returncode is None:
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), 5)
+                except TimeoutError:
+                    process.kill()
+                    await asyncio.wait_for(process.wait(), 5)
+
+
+@pytest.mark.asyncio
+async def test_installed_stdio_initialize_list_and_call(stdio_rpc, tmp_fava_home):
+    initialized = await stdio_rpc("initialize", {
+        "protocolVersion": "2025-11-25", "capabilities": {},
+        "clientInfo": {"name": "synthetic-legacy-client", "version": "1"},
+    })
+    assert initialized["protocolVersion"] == "2025-11-25"
+    assert "tools" in initialized["capabilities"]
+    assert "Governed Visibility" in initialized["instructions"]
+    await stdio_rpc("notifications/initialized", notification=True)
+    listed = await stdio_rpc("tools/list")
+    by_name = {tool["name"]: tool for tool in listed["tools"]}
+    assert len(by_name) == 17
+    for definition in server.TOOL_DEFINITIONS:
+        tool = by_name[definition["name"]]
+        assert tool["inputSchema"] == definition["inputSchema"]
+        assert tool["outputSchema"] == definition["outputSchema"]
+        assert tool["outputSchema"]["type"] == "object"
+        for key, value in definition["annotations"].items():
+            assert tool["annotations"][key] == value
+        jsonschema.Draft202012Validator.check_schema(tool["inputSchema"])
+        jsonschema.Draft202012Validator.check_schema(tool["outputSchema"])
+
+    async def call(name, arguments):
+        return await stdio_rpc("tools/call", {"name": name, "arguments": arguments})
+
+    guide = await call("get_usage_guide", {})
+    assert not guide.get("isError", False)
+    assert guide["content"][0]["text"] == guide["structuredContent"]["content"]
+    assert guide["content"][0]["text"].startswith("# Using FAVA Trails")
+
+    # Missing required content and wrong types must fail before creating a scope.
+    scope = "synthetic/wire"
+    for arguments in ({"trail_name": scope}, {"trail_name": scope, "content": 123}):
+        invalid = await call("save_thought", arguments)
+        assert invalid["isError"] is True
+        assert not invalid.get("structuredContent")
+        assert "Input validation error" in invalid["content"][0]["text"]
+        assert not (tmp_fava_home / "trails" / scope).exists()
+
+    saved = await call("save_thought", {"trail_name": scope, "content": "Synthetic wire draft"})
+    assert not saved.get("isError", False)
+    assert saved["structuredContent"]["status"] == "ok"
+    assert json.loads(saved["content"][0]["text"]) == saved["structuredContent"]
+    governed = await call("recall", {"trail_name": scope})
+    assert governed["structuredContent"]["count"] == 0
+    authoring = await call("recall", {"trail_name": scope, "mode": "authoring"})
+    assert authoring["structuredContent"]["count"] == 1
+    assert authoring["structuredContent"]["thoughts"][0]["agent_id"] == "synthetic-wire-agent"
+    missing = await call("recall", {"trail_name": "synthetic/missing"})
+    assert not missing.get("isError", False)
+    assert missing["structuredContent"]["status"] == "error"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["legacy", "auto"])
+async def test_sdk_clients_preserve_validation_and_error_shapes(mode, monkeypatch):
+    handler = AsyncMock(return_value={"status": "blocked", "message": "Synthetic conflict"})
+    monkeypatch.setattr(server, "handle_call_tool", handler)
+    async with Client(server.server, mode=mode, read_timeout_seconds=5) as client:
+        tools = await client.list_tools()
+        assert len(tools.tools) == 17
+        invalid = await client.call_tool("save_thought", {"trail_name": "synthetic/wire", "content": 123})
+        assert invalid.is_error
+        assert invalid.structured_content is None
+        handler.assert_not_awaited()
+        blocked = await client.call_tool("sync", {"trail_name": "synthetic/wire"})
+        assert not blocked.is_error
+        assert blocked.structured_content["status"] == "blocked"
+        handler.return_value = {"status": "error", "message": "Synthetic timeout"}
+        failed = await client.call_tool("sync", {"trail_name": "synthetic/wire"})
+        assert not failed.is_error
+        assert failed.structured_content["status"] == "error"
+        handler.return_value = {"unexpected": "synthetic-private-rejected-output"}
+        malformed = await client.call_tool("sync", {"trail_name": "synthetic/wire"})
+        assert malformed.is_error
+        assert malformed.structured_content is None
+        assert "synthetic-private" not in malformed.model_dump_json()
+        handler.side_effect = RuntimeError("synthetic-private-adapter-exception")
+        crashed = await client.call_tool("sync", {"trail_name": "synthetic/wire"})
+        assert crashed.is_error
+        assert crashed.structured_content is None
+        assert "synthetic-private" not in crashed.model_dump_json()

--- a/tests/test_packaged_mcp.py
+++ b/tests/test_packaged_mcp.py
@@ -1,0 +1,32 @@
+"""The regular CI suite must exercise the installed wheel's real MCP entrypoint."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_built_wheel_starts_and_serves_mcp(tmp_path):
+    root = Path(__file__).resolve().parent.parent
+    uv = shutil.which("uv")
+    assert uv, "Run the package verification with the project's uv toolchain"
+    build = subprocess.run(
+        [uv, "build", "--wheel", "--out-dir", str(tmp_path / "dist")],
+        cwd=root, capture_output=True, text=True, timeout=120,
+    )
+    assert build.returncode == 0, build.stdout + build.stderr
+    wheels = list((tmp_path / "dist").glob("*.whl"))
+    assert len(wheels) == 1
+    env = {**os.environ, "FAVA_EXPECT_WHEEL": "1"}
+    verified = subprocess.run(
+        [
+            uv, "run", "--isolated", "--no-project", "--python", sys.executable,
+            "--with", str(wheels[0]), "--with", "pytest>=9,<10", "--with", "pytest-asyncio>=1.3,<2",
+            "pytest", str(root / "tests" / "test_mcp_protocol.py"), "-v",
+        ],
+        cwd=tmp_path, env=env, capture_output=True, text=True, timeout=180,
+    )
+    assert verified.returncode == 0, verified.stdout + verified.stderr

--- a/tests/test_server_instructions.py
+++ b/tests/test_server_instructions.py
@@ -124,7 +124,7 @@ class TestToolMetadata:
         """Every advertised tool must declare an output schema."""
         for td in TOOL_DEFINITIONS:
             assert "outputSchema" in td, td["name"]
-            assert td["outputSchema"].get("type") == "object" or "anyOf" in td["outputSchema"]
+            assert td["outputSchema"]["type"] == "object"
 
     def test_all_tools_have_annotations(self):
         """Every advertised tool must include MCP tool annotations."""
@@ -165,21 +165,21 @@ class TestToolMetadata:
         by_name = {tool.name: tool for tool in tools}
 
         recall = by_name["recall"]
-        assert recall.outputSchema
-        assert recall.outputSchema["anyOf"][0]["required"] == [
+        assert recall.output_schema
+        assert recall.output_schema["anyOf"][0]["required"] == [
             "status",
             "count",
             "thoughts",
             "filters",
         ]
         assert recall.annotations
-        assert recall.annotations.readOnlyHint is True
+        assert recall.annotations.read_only_hint is True
 
         save_thought = by_name["save_thought"]
-        assert save_thought.outputSchema
+        assert save_thought.output_schema
         assert save_thought.annotations
-        assert save_thought.annotations.readOnlyHint is False
-        assert save_thought.annotations.openWorldHint is True
+        assert save_thought.annotations.read_only_hint is False
+        assert save_thought.annotations.open_world_hint is True
 
     def test_all_tool_schemas_accept_common_error_result(self):
         """Structured error payloads must not be hidden by output validation."""

--- a/uv.lock
+++ b/uv.lock
@@ -385,7 +385,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "python_full_version < '3.12' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
@@ -418,43 +418,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -500,6 +500,7 @@ source = { editable = "." }
 dependencies = [
     { name = "any-llm-sdk" },
     { name = "httpx" },
+    { name = "jsonschema" },
     { name = "mcp" },
     { name = "pydantic" },
     { name = "python-ulid" },
@@ -553,9 +554,10 @@ requires-dist = [
     { name = "any-llm-sdk", extras = ["mistral"], marker = "extra == 'mistral'", specifier = ">=1.10.0,<2.0" },
     { name = "any-llm-sdk", extras = ["ollama"], marker = "extra == 'ollama'", specifier = ">=1.10.0,<2.0" },
     { name = "httpx", specifier = ">=0.27.0,<1.0" },
+    { name = "jsonschema", specifier = ">=4.26.0,<5.0" },
     { name = "llmlingua", marker = "extra == 'all'", specifier = ">=0.2.0,<1.0" },
     { name = "llmlingua", marker = "extra == 'secom'", specifier = ">=0.2.0,<1.0" },
-    { name = "mcp", specifier = ">=1.28.1,<2.0" },
+    { name = "mcp", specifier = ">=2.2.0,<3.0" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0" },
     { name = "python-ulid", specifier = ">=3.0.0,<4.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
@@ -713,6 +715,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -728,12 +743,29 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -758,11 +790,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -1042,15 +1074,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.0"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1060,9 +1092,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/31/ac54fb0fdd5b37de704486e288bba4fbbb463f24cfcfedbede407b854513/mcp-2.2.0.tar.gz", hash = "sha256:2dc37ecb1974becdcebdbf7561e7c15a07dbbf20ba21ba16c3593b3038b3afbd", size = 4084129, upload-time = "2026-09-07T16:06:23.439Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ff/8e7eade68b8a28f7da0ed1085544341b51f9c935dbf6b95c76b7edfea6a0/mcp-2.2.0-py3-none-any.whl", hash = "sha256:bde982589473a060ae145e3406e9a5333fe538c97229ba841f5a7f92be004f81", size = 365656, upload-time = "2026-09-07T16:06:19.711Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/91/762d7755d971aff8a28d75f7961656148edf27875c8026e6385aaab08ae7/mcp_types-2.2.0.tar.gz", hash = "sha256:d3ed53703ddd10d9c6399f29d322bb66f3f67ab41348ac8556ba23e07fedefad", size = 65892, upload-time = "2026-09-07T16:06:25.187Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/6ffba5d8cd5dd9b8a19478875c50e04945314ba5074e84d749283f27f62d/mcp_types-2.2.0-py3-none-any.whl", hash = "sha256:ea476b73ee86709ab5abc9452385ed36cc05907e582355622e294595c9a04f13", size = 69106, upload-time = "2026-09-07T16:06:21.461Z" },
 ]
 
 [[package]]
@@ -1213,7 +1258,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "python_full_version < '3.12' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1252,7 +1297,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "python_full_version < '3.12' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1264,7 +1309,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.12' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1294,9 +1339,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "python_full_version < '3.12' or sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "python_full_version < '3.12' or sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.12' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1308,7 +1353,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.12' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -1690,20 +1735,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1765,15 +1796,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -2448,6 +2470,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
     { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
     { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
MCP 2 removed the decorators used to register FAVA's tools, so installing that major version prevented the server from starting. This change uses the supported MCP 2.2 low-level constructor handlers and raises the dependency range to `>=2.2.0,<3.0`.

The transport adapters preserve the 17 tool definitions, schema validation before mutation, structured domain error/blocked/timeout results, and Markdown usage guidance. Legacy output schemas explicitly declare their object root so `tools/list` works with initialized clients. Unexpected adapter failures and invalid output return tool errors without echoing rejected data. Governance and tool handlers remain unchanged.

Validation:
- `uv sync --frozen`, full Ruff, and `uv run pytest -v`: 815 passed on combined head `9ee2775948efb39880d1e3acbc9156b6b7be9477`, including the delivered reader changes.
- Built wheel installed in an isolated environment: real `fava-trails-server` stdio initialize/list/call plus legacy/current SDK client tests: 3 passed.
- Existing Streamable HTTP initialization/list/call/safe-sync and readiness tests pass in the full suite.
- A regular packaging test repeats installed-wheel startup checks through the existing Python 3.11 CI workflow; it passed locally. No workflow change is required.
- Original SDK delta independently reviewed clean; delivered reader main `043902c` merged without conflicts, with SDK code unchanged. Native review and native fallback completed. The single external Claude review attempt was unavailable because its CLI was not logged in; no setup repair or retry was attempted.

No running server, vendor installation, real data, or gateway configuration was changed.

Closes #83
