### PR TITLE
feat: add reviewed duplicate migration and recovery tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,3 +448,11 @@ uv run pytest --cov       # with coverage
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, how to run tests, and PR expectations.
 
 See [CHANGELOG.md](CHANGELOG.md) for release history.
+
+### Duplicate maintenance
+
+Use `fava-trails duplicates` for a read-only exact-body report and a digest-bound,
+reviewed migration plan. Applying or rolling back requires an explicit operator
+command and preserves a JJ recovery point and before images. See
+[reviewed duplicate maintenance](docs/duplicate-migration.md) for private artifacts,
+lifecycle and lineage blockers, crash recovery, and the real-data approval gate.

--- a/docs/duplicate-migration.md
+++ b/docs/duplicate-migration.md
@@ -41,8 +41,10 @@ references, approved current counts, blockers, and its SHA256 digest. Unselected
 groups stay untouched. Canonical selection must retain approved current truth
 when a group contains approved records. Groups with only one unapproved lifecycle
 retain that lifecycle; consolidation never approves them. Removed frontmatter,
-review provenance, and source hashes are retained in the canonical record's
-`metadata.extra.duplicate_migrations`. Original body bytes and extension fields
+review provenance, and source hashes remain in the operator-only receipt before
+images. The canonical record's `metadata.extra.duplicate_migrations` contains only
+a count and opaque audit reference; hidden author context never enters governed
+recall through copied metadata. Original body bytes and extension fields
 survive rewrites.
 
 The tool redirects unambiguous inbound relationships, parentage, intent and
@@ -69,8 +71,11 @@ source snapshot and a clean, conflict-free working change, then records the JJ
 commit and operation recovery point plus full before images in an owner-only
 `.jj/fava-migrations/<digest>.json` receipt. The existing governance journal keeps
 readers on one consistent view until all files are durably committed. No push is
-performed. On success the tool checks the complete resulting snapshot and reports
-counts. Repeating the same successful apply makes no writes or VCS operations.
+performed. Before publication, the tool checks the complete resulting snapshot and saves
+durable commit evidence in the receipt. Repeating a completed apply validates the
+receipt and committed history without writes or new VCS operations. A crash after
+publication leaves a prepared receipt with commit evidence; retry verifies it and
+finishes the receipt instead of inferring success from matching files alone.
 
 If the process fails or dies after writes begin, readers retain the before-image
 view. Repeating the explicitly approved command recovers the journal through JJ,

--- a/docs/duplicate-migration.md
+++ b/docs/duplicate-migration.md
@@ -1,0 +1,98 @@
+# Reviewed duplicate maintenance
+
+`fava-trails duplicates` is a local operator command for an existing JJ data
+repository with its conventional `trails/` layout. It is not an MCP mutation.
+Markdown remains canonical. Reports and plans contain private provenance and
+record bodies: keep them outside source control and do not publish them.
+
+Start with a read-only report:
+
+```sh
+fava-trails duplicates --repo /private/data --scope example/operations \
+  --out /private/review/duplicates.json
+```
+
+The command creates only the requested new artifact, with owner-only permissions.
+It does not invoke JJ, create a governance lock, or change the data repository.
+Two identical scans are required; an active transaction or changing source causes
+an error. The report hashes exact UTF-8 bytes after the closing frontmatter
+separator, including whitespace. It is not fuzzy matching or a search service.
+All scopes are read to find inbound references, but only the exact selected scope
+is grouped. Invalid records are reported and prevent apply until reviewed and
+repaired; they are never silently dropped.
+
+For each group you intend to migrate, put its `body_sha256` and the deliberate
+canonical `members[].path` in a JSON map, then generate the exact plan:
+
+```json
+{
+  "<body SHA256 from report>": "trails/example/operations/thoughts/observations/A.md"
+}
+```
+
+```sh
+fava-trails duplicates --repo /private/data --scope example/operations \
+  --canonical /private/review/canonical.json --out /private/review/plan.json
+```
+
+The plan includes exact before/after text for every rewrite/deletion, hashes for
+the complete source snapshot, before/after counts, identity redirects, unresolved
+references, approved current counts, blockers, and its SHA256 digest. Unselected
+groups stay untouched. Canonical selection must retain approved current truth
+when a group contains approved records. Groups with only one unapproved lifecycle
+retain that lifecycle; consolidation never approves them. Removed frontmatter,
+review provenance, and source hashes are retained in the canonical record's
+`metadata.extra.duplicate_migrations`. Original body bytes and extension fields
+survive rewrites.
+
+The tool redirects unambiguous inbound relationships, parentage, intent and
+supersession links across scopes. It refuses conflicting validation/source
+assertions, existing supersession on group members, ambiguous IDs, differing
+outbound relationships, newly unresolved references, self links, and parent or
+supersession cycles. A relationship between duplicate members may therefore need
+a separate explicit lineage decision. A blocked plan is an inspectable proposal,
+not an executable migration; editing its blocker list does not bypass validation.
+
+Review the complete exact delete/rewrite set and canonical choices, resolve every
+blocker, and obtain the operator's explicit approval for this destructive apply.
+A digest identifies reviewed bytes; generating it is not approval. Any source
+change, including a new inbound record in another scope, requires a fresh plan
+and review. The following command is only for that approved plan:
+
+```sh
+fava-trails duplicates --repo /private/data --apply \
+  --plan /private/review/plan.json --confirm-plan <reviewed-plan-digest>
+```
+
+Apply regenerates the safe plan under the shared governance lock, checks the exact
+source snapshot and a clean, conflict-free working change, then records the JJ
+commit and operation recovery point plus full before images in an owner-only
+`.jj/fava-migrations/<digest>.json` receipt. The existing governance journal keeps
+readers on one consistent view until all files are durably committed. No push is
+performed. On success the tool checks the complete resulting snapshot and reports
+counts. Repeating the same successful apply makes no writes or VCS operations.
+
+If the process fails or dies after writes begin, readers retain the before-image
+view. Repeating the explicitly approved command recovers the journal through JJ,
+then revalidates and applies the same plan. If recovery fails, stop and inspect the
+receipt and journal; do not delete them to force progress. Receipts and journals
+are local metadata, so keep the private plan with the repository's backups.
+
+To undo a completed migration, review and approve rollback, then use:
+
+```sh
+fava-trails duplicates --repo /private/data --rollback \
+  --plan /private/review/plan.json --confirm-plan <reviewed-plan-digest>
+```
+
+Rollback requires the complete post-migration snapshot to still match. It commits
+the exact original Markdown bytes using the same journal and saves a separate
+recovery receipt. It never overwrites subsequent edits. If the repository changed,
+prepare a separately reviewed recovery from the recorded before images or JJ
+recovery point. Do not blindly restore a repository-wide JJ operation over later
+work. Repeated successful rollback is a no-op.
+
+For WisdomLoop issue #74, real migration and malformed-record repair remain
+explicit reviewed-apply decisions. Synthetic acceptance tests demonstrate tooling
+behavior; they do not establish that a real-data migration or operator approval
+has occurred.

--- a/src/fava_trails/cli.py
+++ b/src/fava_trails/cli.py
@@ -1839,7 +1839,59 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_rlm.set_defaults(func=lambda args: (p_rlm.print_help(), 0)[1])
 
+    p_duplicates = subparsers.add_parser("duplicates", help="Read-only duplicate report or explicit reviewed migration")
+    p_duplicates.add_argument("--repo", required=True, help="Local JJ data repository (trails/ layout)")
+    p_duplicates.add_argument("--scope", help="Exact scope for duplicate groups")
+    p_duplicates.add_argument("--out", help="New owner-only JSON artifact outside the data repository")
+    p_duplicates.add_argument("--canonical", help="JSON map of body SHA256 to canonical repository-relative path")
+    p_duplicates.add_argument("--plan", help="Exact reviewed plan JSON")
+    p_duplicates.add_argument("--confirm-plan", help="Digest copied from the reviewed plan")
+    actions = p_duplicates.add_mutually_exclusive_group()
+    actions.add_argument("--apply", action="store_true", help="Apply the reviewed plan (destructive; explicit operator approval required)")
+    actions.add_argument("--rollback", action="store_true", help="Restore exact before images only if post-migration state still matches")
+    p_duplicates.set_defaults(func=cmd_duplicates)
+
     return parser
+
+
+def cmd_duplicates(args: argparse.Namespace) -> int:
+    """Local operator maintenance; dry-run is the default, never an MCP mutation."""
+    import asyncio
+    import json
+
+    from .duplicates import apply_plan, build_plan, report, write_private
+    from .vcs.jj_backend import JjBackend
+
+    try:
+        root = Path(args.repo).expanduser().resolve(strict=True)
+        output = Path(args.out).expanduser().resolve() if args.out else None
+        if output and output.is_relative_to(root):
+            raise ValueError("Write private reports/plans outside the data repository")
+        if args.apply or args.rollback:
+            if not args.plan or not args.confirm_plan:
+                raise ValueError("Apply/rollback requires --plan and --confirm-plan DIGEST")
+            plan = json.loads(Path(args.plan).read_text())
+            result = asyncio.run(apply_plan(JjBackend(root, root / "trails" / plan["scope"]), plan, args.confirm_plan, rollback=args.rollback))
+        elif args.canonical:
+            if not args.scope or not output:
+                raise ValueError("Planning requires --scope and private --out")
+            selected = json.loads(Path(args.canonical).read_text())
+            result = build_plan(root, args.scope, selected)
+        else:
+            if not args.scope or not output:
+                raise ValueError("Read-only reporting requires --scope and private --out")
+            result = report(root, args.scope)
+        if output:
+            write_private(output, result)
+        # Never echo record content/provenance into shared terminal or CI logs.
+        summary = {key: result[key] for key in ("status", "digest", "counts", "blockers", "receipt") if key in result}
+        if output:
+            summary["artifact"] = str(output)
+        print(json.dumps(summary, indent=2))
+        return 2 if result.get("blockers") else 0
+    except (OSError, ValueError, RuntimeError, KeyError, TypeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/fava_trails/duplicates.py
+++ b/src/fava_trails/duplicates.py
@@ -413,7 +413,15 @@ async def apply_plan(vcs, plan: dict, confirmation: str, *, rollback: bool = Fal
         }
         receipt_path.parent.mkdir(parents=True, exist_ok=True)
         # Retries retain their original recovery evidence; each migration has a fixed identity.
-        if not receipt_path.exists():
+        if receipt_path.exists():
+            existing = json.loads(receipt_path.read_text())
+            if (
+                existing.get("plan") != plan
+                or not existing.get("recovery_commit")
+                or not existing.get("recovery_operation")
+            ):
+                raise ValueError("Recovery receipt is invalid; inspect it before retrying")
+        else:
             write_private(receipt_path, receipt)
 
     writes = {root / o["path"]: o["before"] if rollback else o["after"] for o in plan["operations"]}
@@ -426,14 +434,14 @@ async def apply_plan(vcs, plan: dict, confirmation: str, *, rollback: bool = Fal
     receipt["status"] = "rolled_back" if rollback else "applied"
     with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", dir=receipt_path.parent, delete=False) as stream:
         temporary = Path(stream.name)
-        try:
-            json.dump(receipt, stream, indent=2)
-            stream.flush()
-            os.fsync(stream.fileno())
-            os.replace(temporary, receipt_path)
-            _sync_directory(receipt_path.parent)
-        finally:
-            temporary.unlink(missing_ok=True)
+        json.dump(receipt, stream, indent=2)
+        stream.flush()
+        os.fsync(stream.fileno())
+    try:
+        os.replace(temporary, receipt_path)
+        _sync_directory(receipt_path.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
     return {
         "status": receipt["status"],
         "digest": plan["digest"],

--- a/src/fava_trails/duplicates.py
+++ b/src/fava_trails/duplicates.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import tempfile
 from datetime import date, datetime
 from pathlib import Path
@@ -14,7 +15,7 @@ import yaml
 from .config import sanitize_scope_path
 from .governance import Visibility, record_index
 from .models import ThoughtRecord
-from .transactions import _sync_directory, journal_path, persist_governance
+from .transactions import _file_lock, _sync_directory, journal_path, persist_governance
 
 
 def digest(value) -> str:
@@ -27,9 +28,9 @@ def _hash(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()
 
 
-def _scan(root: Path) -> dict[str, str]:
+def _scan(root: Path, *, allow_journal: bool = False) -> dict[str, str]:
     """No JJ invocation or lock creation: dry runs never write repository metadata."""
-    if journal_path(root).exists():
+    if not allow_journal and journal_path(root).exists():
         raise ValueError("Interrupted governance transaction: recover it before planning a migration")
     texts = {}
     for path in sorted((root / "trails").glob("**/thoughts/**/*.md")):
@@ -37,7 +38,7 @@ def _scan(root: Path) -> dict[str, str]:
             raise ValueError("Symlinked thought paths are not supported for migration")
         text = path.read_bytes().decode("utf-8")
         texts[path.relative_to(root).as_posix()] = text
-    if journal_path(root).exists():
+    if not allow_journal and journal_path(root).exists():
         raise ValueError("Governance changed during scan; retry")
     return texts
 
@@ -242,11 +243,8 @@ def build_plan(root: Path, scope: str, canonical: dict[str, str], *, texts=None)
             {
                 "body_sha256": next(h for h, path in canonical.items() if path == keep),
                 "retained_id": fm.thought_id,
-                "removed": [
-                    {"path": n, "sha256": _hash(texts[n]), "frontmatter": _frontmatter(texts[n])}
-                    for n in names
-                    if n != keep
-                ],
+                "removed_count": len(names) - 1,
+                "operator_audit": digest({"before_snapshot": details["snapshot"], "canonical": canonical}),
             }
         )
     changed = set(merged)
@@ -344,6 +342,7 @@ def write_private(path: Path, value) -> None:
         stream.write("\n")
         stream.flush()
         os.fsync(stream.fileno())
+    _sync_directory(path.parent)
 
 
 def _validate_plan(root: Path, plan: dict, confirmation: str) -> None:
@@ -375,22 +374,82 @@ def _verify_rules(root: Path, plan: dict, texts: dict[str, str], *, after: bool)
         raise ValueError("Plan does not match safe migration rules")
 
 
-async def apply_plan(vcs, plan: dict, confirmation: str, *, rollback: bool = False) -> dict:
-    """Only explicit local operator CLI/API use; reviewed digest is mandatory.
+def _read_receipt(path: Path, plan: dict, rollback: bool, *, committed: bool = False) -> dict:
+    try:
+        receipt = json.loads(path.read_text())
+    except (OSError, ValueError) as exc:
+        raise ValueError("Recovery receipt is missing or invalid; inspect it before retrying") from exc
+    if (
+        not isinstance(receipt, dict)
+        or receipt.get("plan") != plan
+        or receipt.get("rollback") != rollback
+        or receipt.get("status") not in {"prepared", "rolled_back" if rollback else "applied"}
+    ):
+        raise ValueError("Recovery receipt is invalid; inspect it before retrying")
+    fields = ("recovery_commit", "recovery_operation") + (
+        ("committed_commit", "committed_operation") if committed else ()
+    )
+    for field in fields:
+        size = 40 if field.endswith("commit") else 128
+        if not isinstance(receipt.get(field), str) or not re.fullmatch(r"[0-9a-f]{" + str(size) + "}", receipt[field]):
+            raise ValueError("Recovery receipt lacks valid durable VCS evidence")
+    return receipt
 
-    Reuse the governance journal and lock for atomic publication and crash recovery.
-    The durable receipt holds an exact JJ operation/commit and all before images.
-    """
+
+def _save_receipt(path: Path, receipt: dict) -> None:
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", dir=path.parent, delete=False, newline=""
+        ) as stream:
+            temporary = Path(stream.name)
+            json.dump(receipt, stream, indent=2)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        _sync_directory(path.parent)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+async def _verify_committed(vcs, receipt: dict, message: str) -> None:
+    dirty, _ = await vcs._run("diff", "--name-only")
+    if dirty or await vcs.conflicts():
+        raise ValueError("Recovery verification requires a clean conflict-free repository")
+    commit = receipt["committed_commit"]
+    proof, _ = await vcs._run(
+        "log", "-r", f"{commit} & ancestors(@)", "--no-graph", "-T", 'commit_id ++ "\\n" ++ description'
+    )
+    if proof != commit + "\n" + message:
+        raise ValueError("Recovery receipt does not identify the durable migration in current history")
+
+
+async def apply_plan(vcs, plan: dict, confirmation: str, *, rollback: bool = False) -> dict:
+    """Explicit operator maintenance with private, recoverable publication evidence."""
     root = vcs.repo_root.resolve(strict=True)
     _validate_plan(root, plan, confirmation)
     source = plan["after_snapshot"] if rollback else plan["before_snapshot"]
     target = plan["before_snapshot"] if rollback else plan["after_snapshot"]
+    status = "rolled_back" if rollback else "applied"
+    message = ("Rollback" if rollback else "Migrate") + " exact duplicates " + plan["digest"]
     receipt_path = root / ".jj" / "fava-migrations" / (plan["digest"] + ("-rollback" if rollback else "") + ".json")
-    # A successful rerun does not create another VCS operation.
     current = capture(root) if not journal_path(root).exists() else None
     if current is not None and {n: _hash(t) for n, t in current.items()} == target:
-        _verify_rules(root, plan, current, after=not rollback)
-        return {"status": "already_rolled_back" if rollback else "already_applied", "digest": plan["digest"]}
+        # Matching bytes alone cannot prove that an operator migration committed.
+        _read_receipt(receipt_path, plan, rollback, committed=True)
+        async with vcs.repo_lock:
+            with _file_lock(root, exclusive=True):
+                current = capture(root)
+                if {n: _hash(t) for n, t in current.items()} != target:
+                    raise ValueError("Repository changed during recovery verification")
+                _verify_rules(root, plan, current, after=not rollback)
+                receipt = _read_receipt(receipt_path, plan, rollback, committed=True)
+                await _verify_committed(vcs, receipt, message)
+                if receipt["status"] == "prepared":
+                    receipt["status"] = status
+                    _save_receipt(receipt_path, receipt)
+        return {"status": "already_" + status, "digest": plan["digest"]}
 
     async def prepare():
         texts = capture(root)
@@ -412,39 +471,27 @@ async def apply_plan(vcs, plan: dict, confirmation: str, *, rollback: bool = Fal
             "plan": plan,
         }
         receipt_path.parent.mkdir(parents=True, exist_ok=True)
-        # Retries retain their original recovery evidence; each migration has a fixed identity.
+        _sync_directory(receipt_path.parent.parent)
         if receipt_path.exists():
-            existing = json.loads(receipt_path.read_text())
-            if (
-                existing.get("plan") != plan
-                or not existing.get("recovery_commit")
-                or not existing.get("recovery_operation")
-            ):
-                raise ValueError("Recovery receipt is invalid; inspect it before retrying")
+            _read_receipt(receipt_path, plan, rollback)
         else:
             write_private(receipt_path, receipt)
 
+    async def committed():
+        # This runs under the transaction lock before journal removal publishes.
+        if {n: _hash(t) for n, t in _scan(root, allow_journal=True).items()} != target:
+            raise RuntimeError("Post-migration verification failed; inspect the recovery receipt")
+        receipt = _read_receipt(receipt_path, plan, rollback)
+        receipt["status"] = "prepared"
+        receipt["committed_commit"], _ = await vcs._run("log", "-r", "@-", "--no-graph", "-T", "commit_id")
+        receipt["committed_operation"], _ = await vcs._run("op", "log", "--limit", "1", "--no-graph", "-T", "id")
+        await _verify_committed(vcs, receipt, message)
+        _save_receipt(receipt_path, receipt)
+
     writes = {root / o["path"]: o["before"] if rollback else o["after"] for o in plan["operations"]}
-    await persist_governance(
-        vcs, writes, ("Rollback" if rollback else "Migrate") + " exact duplicates " + plan["digest"], prepare=prepare
-    )
-    if {n: _hash(t) for n, t in capture(root).items()} != target:
-        raise RuntimeError("Post-migration verification failed; inspect the recovery receipt")
-    receipt = json.loads(receipt_path.read_text())
-    receipt["status"] = "rolled_back" if rollback else "applied"
-    with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", dir=receipt_path.parent, delete=False) as stream:
-        temporary = Path(stream.name)
-        json.dump(receipt, stream, indent=2)
-        stream.flush()
-        os.fsync(stream.fileno())
-    try:
-        os.replace(temporary, receipt_path)
-        _sync_directory(receipt_path.parent)
-    finally:
-        temporary.unlink(missing_ok=True)
-    return {
-        "status": receipt["status"],
-        "digest": plan["digest"],
-        "counts": plan["counts"],
-        "receipt": str(receipt_path),
-    }
+    await persist_governance(vcs, writes, message, prepare=prepare, committed=committed)
+    # A crash here is recoverable: the prepared receipt already proves durability.
+    receipt = _read_receipt(receipt_path, plan, rollback, committed=True)
+    receipt["status"] = status
+    _save_receipt(receipt_path, receipt)
+    return {"status": status, "digest": plan["digest"], "counts": plan["counts"], "receipt": str(receipt_path)}

--- a/src/fava_trails/duplicates.py
+++ b/src/fava_trails/duplicates.py
@@ -1,0 +1,442 @@
+"""Operator-only, exact-plan duplicate maintenance; never invoked by MCP tools."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from datetime import date, datetime
+from pathlib import Path
+
+import yaml
+
+from .config import sanitize_scope_path
+from .governance import Visibility, record_index
+from .models import ThoughtRecord
+from .transactions import _sync_directory, journal_path, persist_governance
+
+
+def digest(value) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+    ).hexdigest()
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def _scan(root: Path) -> dict[str, str]:
+    """No JJ invocation or lock creation: dry runs never write repository metadata."""
+    if journal_path(root).exists():
+        raise ValueError("Interrupted governance transaction: recover it before planning a migration")
+    texts = {}
+    for path in sorted((root / "trails").glob("**/thoughts/**/*.md")):
+        if path.is_symlink() or any(p.is_symlink() for p in path.parents if p != root):
+            raise ValueError("Symlinked thought paths are not supported for migration")
+        text = path.read_bytes().decode("utf-8")
+        texts[path.relative_to(root).as_posix()] = text
+    if journal_path(root).exists():
+        raise ValueError("Governance changed during scan; retry")
+    return texts
+
+
+def capture(root: Path) -> dict[str, str]:
+    """Optimistic stable read, with no writes even when the governance lock is absent.
+
+    A plan is also revalidated under the exclusive governance lock at apply time.
+    """
+    root = root.resolve(strict=True)
+    first = _scan(root)
+    if first != _scan(root):
+        raise ValueError("Thoughts changed during scan; retry")
+    return first
+
+
+def _frontmatter(text: str) -> dict:
+    def default(value):
+        if isinstance(value, (datetime, date)):
+            return value.isoformat()
+        raise ValueError("Frontmatter contains a value unsupported by migration JSON")
+
+    return json.loads(json.dumps(yaml.safe_load(text.split("---", 2)[1]), default=default))
+
+
+def _rewrite(record: ThoughtRecord, original: str) -> str:
+    # Preserve extension fields and exact body bytes that the typed model ignores.
+    fm = _frontmatter(original)
+    model = record.frontmatter.model_dump(mode="json")
+    for field in ("parent_id", "intent_ref", "superseded_by", "supersedes_id", "relationships"):
+        if field in fm or model[field] is not None:
+            fm[field] = model[field]
+    if "duplicate_migrations" in record.frontmatter.metadata.extra:
+        fm.setdefault("metadata", {}).setdefault("extra", {})["duplicate_migrations"] = (
+            record.frontmatter.metadata.extra["duplicate_migrations"]
+        )
+    return "---\n" + yaml.safe_dump(fm, sort_keys=False, allow_unicode=True) + "---" + original.split("---", 2)[2]
+
+
+def _scope(name: str) -> str:
+    return name.removeprefix("trails/").split("/thoughts/", 1)[0]
+
+
+def _parse_issues(texts: dict[str, str]) -> dict[str, str]:
+    issues = {}
+    for name, text in texts.items():
+        try:
+            if not text.startswith(("---\n", "---\r\n")) or len(text.split("---", 2)) != 3:
+                raise ValueError("Explicit frontmatter required")
+            fm = _frontmatter(text)
+            if not isinstance(fm, dict) or not fm.get("thought_id") or not fm.get("created_at"):
+                raise ValueError("Explicit identity and timestamp required")
+            ThoughtRecord.from_markdown(text)
+        except (ValueError, TypeError, yaml.YAMLError) as exc:
+            issues[name] = type(exc).__name__ + ": invalid or missing governed frontmatter"
+    return issues
+
+
+def _records(root: Path, texts: dict[str, str]):
+    invalid = _parse_issues(texts)
+    records = {name: ThoughtRecord.from_markdown(text) for name, text in texts.items() if name not in invalid}
+    index = record_index({root / name: record for name, record in records.items()}, root / "trails")
+    return records, index
+
+
+def _refs(record):
+    fm = record.frontmatter
+    for field, scope in (
+        ("parent_id", fm.supersedes_scope if fm.parent_id == fm.supersedes_id else None),
+        ("intent_ref", None),
+        ("superseded_by", fm.superseded_scope),
+        ("supersedes_id", fm.supersedes_scope),
+    ):
+        if target := getattr(fm, field):
+            yield field, target, scope
+    for rel in fm.relationships:
+        yield f"relationships.{rel.type}", rel.target_id, None
+
+
+def _report(root: Path, scope: str, texts: dict[str, str]) -> dict:
+    records, index = _records(root, texts)
+    buckets = {}
+    for name in records:
+        if _scope(name) == scope:
+            # Exact stored body bytes, including whitespace. No semantic/near matching.
+            body = texts[name].split("---", 2)[2]
+            buckets.setdefault(_hash(body), []).append(name)
+    groups = []
+    for body_hash, names in sorted(buckets.items()):
+        if len(names) < 2:
+            continue
+        members = []
+        ids = {records[name].thought_id for name in names}
+        inbound = [
+            {"path": name, "field": field, "target_id": target, "target_scope": target_scope}
+            for name, record in records.items()
+            for field, target, target_scope in _refs(record)
+            if target in ids and target_scope in (None, scope)
+        ]
+        for name in names:
+            record = records[name]
+            members.append(
+                {
+                    "path": name,
+                    "scope": scope,
+                    "current_approved": Visibility().allows(record, index),
+                    "sha256": _hash(texts[name]),
+                    "frontmatter": _frontmatter(texts[name]),
+                }
+            )
+        groups.append({"body_sha256": body_hash, "members": members, "inbound": inbound})
+    return {
+        "schema": 1,
+        "repository": str(root),
+        "scope": scope,
+        "body_matching": "exact UTF-8 bytes after closing frontmatter delimiter",
+        "snapshot": {name: _hash(text) for name, text in texts.items()},
+        "counts": {"repository": len(texts), "scope": sum(_scope(n) == scope for n in texts), "groups": len(groups)},
+        "invalid_records": _parse_issues(texts),
+        "groups": groups,
+    }
+
+
+def report(root: Path, scope: str) -> dict:
+    root = root.resolve(strict=True)
+    scope = sanitize_scope_path(scope)
+    if not (root / "trails" / scope).is_dir():
+        raise ValueError("Scope does not exist")
+    return _report(root, scope, capture(root))
+
+
+def _validation_context(text: str) -> dict:
+    fm = _frontmatter(text)
+    extra = fm.get("metadata", {}).get("extra", {})
+    return {
+        "frontmatter": {
+            k: v
+            for k, v in fm.items()
+            if k != "validation_status" and ("valid" in k.lower() or "trust_gate" in k.lower())
+        },
+        "extra": {k: v for k, v in extra.items() if "valid" in k.lower() or "trust_gate" in k.lower()},
+    }
+
+
+def build_plan(root: Path, scope: str, canonical: dict[str, str], *, texts=None) -> dict:
+    """Canonical map is body hash -> exact repository-relative path; no automatic winner."""
+    root = root.resolve(strict=True)
+    scope = sanitize_scope_path(scope)
+    texts = capture(root) if texts is None else texts
+    details = _report(root, scope, texts)
+    records, index = _records(root, texts)
+    groups = {g["body_sha256"]: g for g in details["groups"]}
+    blockers = [f"Unparseable thought requires review: {name}" for name in details["invalid_records"]]
+    redirects = {}
+    removed = {}
+    merged = {}
+    all_ids = {}
+    for name, record in records.items():
+        all_ids.setdefault(record.thought_id, []).append(name)
+    for group_hash, keep in sorted(canonical.items()):
+        group = groups.get(group_hash)
+        if group is None or keep not in [m["path"] for m in group["members"]]:
+            blockers.append(f"Invalid canonical selection: {group_hash}")
+            continue
+        selected = records[keep]
+        candidates = [m["path"] for m in group["members"]]
+        statuses = {records[n].frontmatter.validation_status.value for n in candidates}
+        if "approved" in statuses and not Visibility().allows(selected, index):
+            blockers.append(f"Canonical must be approved current truth: {keep}")
+        elif "approved" not in statuses and len(statuses) != 1:
+            blockers.append(f"Mixed unapproved lifecycle requires a decision: {keep}")
+        for name in candidates:
+            record = records[name]
+            fm = record.frontmatter
+            if len(all_ids[record.thought_id]) != 1:
+                blockers.append(f"Ambiguous thought identity: {name}")
+            if fm.validation_status.value not in {"approved", "draft", "proposed"}:
+                blockers.append(f"Conflicting lifecycle {fm.validation_status}: {name}")
+            if fm.superseded_by or fm.supersedes_id:
+                blockers.append(f"Existing supersession requires a separate lineage decision: {name}")
+            if fm.source_type != selected.frontmatter.source_type or fm.confidence != selected.frontmatter.confidence:
+                blockers.append(f"Source/confidence conflict: {name}")
+            # Retain distinct review provenance, but never merge contradictory validation decisions.
+            validations = _validation_context(texts[name])
+            selected_validations = _validation_context(texts[keep])
+            if any(validations.values()) and validations != selected_validations:
+                blockers.append(f"Validation conflict: {name}")
+            if name != keep:
+                redirects[record.thought_id] = selected.thought_id
+                removed[name] = keep
+        merged[keep] = candidates
+    after_records = {name: record.model_copy(deep=True) for name, record in records.items() if name not in removed}
+    # Outbound semantic links must already agree, so collapsing identity cannot discard them.
+    for keep, names in merged.items():
+        expected = sorted((f, redirects.get(t, t), s) for f, t, s in _refs(records[keep]))
+        for name in names:
+            observed = sorted((f, redirects.get(t, t), s) for f, t, s in _refs(records[name]))
+            if observed != expected:
+                blockers.append(f"Outbound lineage/relationship conflict: {name}")
+        fm = after_records[keep].frontmatter
+        fm.metadata.extra.setdefault("duplicate_migrations", []).append(
+            {
+                "body_sha256": next(h for h, path in canonical.items() if path == keep),
+                "retained_id": fm.thought_id,
+                "removed": [
+                    {"path": n, "sha256": _hash(texts[n]), "frontmatter": _frontmatter(texts[n])}
+                    for n in names
+                    if n != keep
+                ],
+            }
+        )
+    changed = set(merged)
+    for name, record in after_records.items():
+        fm = record.frontmatter
+        for field in ("parent_id", "intent_ref", "superseded_by", "supersedes_id"):
+            target = getattr(fm, field)
+            target_scope = (
+                fm.superseded_scope
+                if field == "superseded_by"
+                else fm.supersedes_scope
+                if field == "supersedes_id" or (field == "parent_id" and fm.parent_id == fm.supersedes_id)
+                else None
+            )
+            if target in redirects and target_scope in (None, scope):
+                setattr(fm, field, redirects[target])
+                changed.add(name)
+        for rel in fm.relationships:
+            if rel.target_id in redirects:
+                rel.target_id = redirects[rel.target_id]
+                changed.add(name)
+        for field, target, _ in _refs(record):
+            if name in changed and target == record.thought_id:
+                blockers.append(f"Redirect would create a self link: {name} {field}")
+    # A changed parent/supersession edge must not introduce any cycle.
+    for name in changed:
+        for field in ("parent_id", "superseded_by", "supersedes_id"):
+            current, seen = records[name].thought_id, set()
+            by_id = {r.thought_id: r for r in after_records.values() if len(all_ids[r.thought_id]) == 1}
+            while current in by_id:
+                if current in seen:
+                    blockers.append(f"Cyclic {field} chain after redirect: {name}")
+                    break
+                seen.add(current)
+                current = getattr(by_id[current].frontmatter, field)
+
+    def unresolved(source_records):
+        source_index = record_index({root / n: r for n, r in source_records.items()}, root / "trails")
+        return sorted(
+            (name, field, target, target_scope or "")
+            for name in changed
+            for field, target, target_scope in _refs(source_records[name])
+            if (f"{target_scope}:{target}" if target_scope else target) not in source_index
+        )
+
+    unresolved_before, unresolved_after = unresolved(records), unresolved(after_records)
+    for edge in set(unresolved_after) - set(unresolved_before):
+        blockers.append(f"Redirect creates an unresolved reference: {edge[0]} {edge[1]}")
+    lineage = {
+        "redirected_identities": redirects,
+        "unresolved_before": [list(edge) for edge in unresolved_before],
+        "unresolved_after": [list(edge) for edge in unresolved_after],
+        "approved_current_before": sum(
+            Visibility().allows(records[n], index) for names in merged.values() for n in names
+        ),
+        "approved_current_after": sum(
+            Visibility().allows(
+                after_records[n], record_index({root / p: r for p, r in after_records.items()}, root / "trails")
+            )
+            for n in merged
+        ),
+    }
+    operations = []
+    for name in sorted(changed | set(removed)):
+        after = None if name in removed else _rewrite(after_records[name], texts[name])
+        operations.append({"path": name, "before": texts[name], "after": after})
+    after_texts = dict(texts)
+    for operation in operations:
+        if operation["after"] is None:
+            after_texts.pop(operation["path"])
+        else:
+            after_texts[operation["path"]] = operation["after"]
+    result = {
+        "schema": 1,
+        "repository": str(root),
+        "scope": scope,
+        "canonical": canonical,
+        "before_snapshot": details["snapshot"],
+        "after_snapshot": {n: _hash(t) for n, t in after_texts.items()},
+        "counts": {"before": len(texts), "after": len(after_texts), "deleted": len(removed), "rewritten": len(changed)},
+        "blockers": sorted(set(blockers)),
+        "lineage": lineage,
+        "operations": operations,
+    }
+    result["digest"] = digest(result)
+    return result
+
+
+def write_private(path: Path, value) -> None:
+    """Artifacts include governed content; create outside source control, owner-only."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as stream:
+        json.dump(value, stream, indent=2, ensure_ascii=False)
+        stream.write("\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def _validate_plan(root: Path, plan: dict, confirmation: str) -> None:
+    unsigned = {k: v for k, v in plan.items() if k != "digest"}
+    if digest(unsigned) != plan.get("digest") or confirmation != plan["digest"]:
+        raise ValueError("Plan digest mismatch: review the exact plan and provide its digest")
+    if plan.get("schema") != 1 or plan.get("repository") != str(root):
+        raise ValueError("Plan repository/schema mismatch")
+    if plan["blockers"] or not plan["operations"]:
+        raise ValueError("Plan has blockers or no selected operations")
+    for operation in plan["operations"]:
+        name = operation["path"]
+        path = root / name
+        if (
+            path.resolve() != path
+            or not path.is_relative_to(root / "trails")
+            or "/thoughts/" not in name
+            or path.suffix != ".md"
+        ):
+            raise ValueError("Unsafe migration path")
+
+
+def _verify_rules(root: Path, plan: dict, texts: dict[str, str], *, after: bool) -> None:
+    original = dict(texts)
+    if after:
+        for operation in plan["operations"]:
+            original[operation["path"]] = operation["before"]
+    if build_plan(root, plan["scope"], plan["canonical"], texts=original) != plan:
+        raise ValueError("Plan does not match safe migration rules")
+
+
+async def apply_plan(vcs, plan: dict, confirmation: str, *, rollback: bool = False) -> dict:
+    """Only explicit local operator CLI/API use; reviewed digest is mandatory.
+
+    Reuse the governance journal and lock for atomic publication and crash recovery.
+    The durable receipt holds an exact JJ operation/commit and all before images.
+    """
+    root = vcs.repo_root.resolve(strict=True)
+    _validate_plan(root, plan, confirmation)
+    source = plan["after_snapshot"] if rollback else plan["before_snapshot"]
+    target = plan["before_snapshot"] if rollback else plan["after_snapshot"]
+    receipt_path = root / ".jj" / "fava-migrations" / (plan["digest"] + ("-rollback" if rollback else "") + ".json")
+    # A successful rerun does not create another VCS operation.
+    current = capture(root) if not journal_path(root).exists() else None
+    if current is not None and {n: _hash(t) for n, t in current.items()} == target:
+        _verify_rules(root, plan, current, after=not rollback)
+        return {"status": "already_rolled_back" if rollback else "already_applied", "digest": plan["digest"]}
+
+    async def prepare():
+        texts = capture(root)
+        if {n: _hash(t) for n, t in texts.items()} != source:
+            raise ValueError("Repository changed since review; create and review a new plan")
+        _verify_rules(root, plan, texts, after=rollback)
+        if await vcs.conflicts():
+            raise ValueError("Resolve repository conflicts before migration")
+        dirty, _ = await vcs._run("diff", "--name-only")
+        if dirty:
+            raise ValueError("Repository must have a clean working change before migration")
+        commit, _ = await vcs._run("log", "-r", "@", "--no-graph", "-T", "commit_id")
+        operation, _ = await vcs._run("op", "log", "--limit", "1", "--no-graph", "-T", "id")
+        receipt = {
+            "status": "prepared",
+            "recovery_commit": commit,
+            "recovery_operation": operation,
+            "rollback": rollback,
+            "plan": plan,
+        }
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        # Retries retain their original recovery evidence; each migration has a fixed identity.
+        if not receipt_path.exists():
+            write_private(receipt_path, receipt)
+
+    writes = {root / o["path"]: o["before"] if rollback else o["after"] for o in plan["operations"]}
+    await persist_governance(
+        vcs, writes, ("Rollback" if rollback else "Migrate") + " exact duplicates " + plan["digest"], prepare=prepare
+    )
+    if {n: _hash(t) for n, t in capture(root).items()} != target:
+        raise RuntimeError("Post-migration verification failed; inspect the recovery receipt")
+    receipt = json.loads(receipt_path.read_text())
+    receipt["status"] = "rolled_back" if rollback else "applied"
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", dir=receipt_path.parent, delete=False) as stream:
+        temporary = Path(stream.name)
+        try:
+            json.dump(receipt, stream, indent=2)
+            stream.flush()
+            os.fsync(stream.fileno())
+            os.replace(temporary, receipt_path)
+            _sync_directory(receipt_path.parent)
+        finally:
+            temporary.unlink(missing_ok=True)
+    return {
+        "status": receipt["status"],
+        "digest": plan["digest"],
+        "counts": plan["counts"],
+        "receipt": str(receipt_path),
+    }

--- a/src/fava_trails/transactions.py
+++ b/src/fava_trails/transactions.py
@@ -65,7 +65,7 @@ def _replace(path: Path, text: str | None) -> None:
     try:
         mode = path.stat().st_mode & 0o777 if path.exists() else 0o600
         fd = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0), 0o600)
-        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as stream:
             os.chmod(temp, mode)
             stream.write(text)
             stream.flush()
@@ -79,7 +79,7 @@ def _replace(path: Path, text: str | None) -> None:
 def _load_journal(root: Path) -> dict[str, str | None]:
     path = journal_path(root)
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
+        data = json.loads(path.read_bytes().decode("utf-8"))
     except FileNotFoundError:
         return {}
     if not isinstance(data, dict) or not isinstance(data.get("before"), dict):
@@ -113,7 +113,7 @@ def _snapshot(trails_dir: Path, root: Path, before=None) -> dict[Path, str]:
     for path in trails_dir.glob("**/thoughts/**/*.md"):
         name = str(path.relative_to(root))
         try:
-            text = before[name] if name in before else path.read_text(encoding="utf-8")
+            text = before[name] if name in before else path.read_bytes().decode("utf-8")
         except FileNotFoundError:
             continue
         if text is not None:
@@ -147,7 +147,7 @@ async def recover_governance(vcs) -> None:
             await _recover(vcs)
 
 
-async def persist_governance(vcs, writes: dict[Path, str | None], message: str, *, expected=None, prepare=None) -> None:
+async def persist_governance(vcs, writes: dict[Path, str | None], message: str, *, expected=None, prepare=None, committed=None) -> None:
     """Commit a bounded set of thought files, preserving a consistent read view."""
     root = vcs.repo_root
     async with vcs.repo_lock:
@@ -156,12 +156,12 @@ async def persist_governance(vcs, writes: dict[Path, str | None], message: str, 
             for path, expected_record in (expected or {}).items():
                 from .models import ThoughtRecord
 
-                if not path.exists() or ThoughtRecord.from_markdown(path.read_text()) != expected_record:
+                if not path.exists() or ThoughtRecord.from_markdown(path.read_bytes().decode("utf-8")) != expected_record:
                     raise ValueError("Thought changed during approval; re-review before retrying")
             if prepare is not None:
                 await prepare()
             journal = journal_path(root)
-            before = {str(p.relative_to(root)): p.read_text(encoding="utf-8") if p.exists() else None for p in writes}
+            before = {str(p.relative_to(root)): p.read_bytes().decode("utf-8") if p.exists() else None for p in writes}
             _replace(journal, json.dumps({"before": before}))
             try:
                 for path, text in writes.items():
@@ -171,6 +171,8 @@ async def persist_governance(vcs, writes: dict[Path, str | None], message: str, 
                     [str(path) for path in writes],
                     allowed_prefixes=[str(path.parent.relative_to(root)) for path in writes],
                 )
+                if committed is not None:
+                    await committed()
                 _replace(journal, None)
             except BaseException:
                 for name, text in before.items():

--- a/src/fava_trails/transactions.py
+++ b/src/fava_trails/transactions.py
@@ -63,7 +63,10 @@ def _replace(path: Path, text: str | None) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temp = path.with_name(path.name + ".governance-tmp")
     try:
-        with temp.open("w", encoding="utf-8") as stream:
+        mode = path.stat().st_mode & 0o777 if path.exists() else 0o600
+        fd = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0), 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            os.chmod(temp, mode)
             stream.write(text)
             stream.flush()
             os.fsync(stream.fileno())
@@ -144,7 +147,7 @@ async def recover_governance(vcs) -> None:
             await _recover(vcs)
 
 
-async def persist_governance(vcs, writes: dict[Path, str | None], message: str, *, expected=None) -> None:
+async def persist_governance(vcs, writes: dict[Path, str | None], message: str, *, expected=None, prepare=None) -> None:
     """Commit a bounded set of thought files, preserving a consistent read view."""
     root = vcs.repo_root
     async with vcs.repo_lock:
@@ -155,6 +158,8 @@ async def persist_governance(vcs, writes: dict[Path, str | None], message: str, 
 
                 if not path.exists() or ThoughtRecord.from_markdown(path.read_text()) != expected_record:
                     raise ValueError("Thought changed during approval; re-review before retrying")
+            if prepare is not None:
+                await prepare()
             journal = journal_path(root)
             before = {str(p.relative_to(root)): p.read_text(encoding="utf-8") if p.exists() else None for p in writes}
             _replace(journal, json.dumps({"before": before}))

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -308,3 +308,16 @@ async def test_all_draft_group_stays_unapproved(jj_backend):
     snap = read_snapshot(root / "trails", strict=True)
     assert len(snap.records) == 1
     assert not any(Visibility().allows(r, snap.by_id) for r in snap.records.values())
+
+
+@pytest.mark.asyncio
+async def test_corrupt_existing_recovery_receipt_blocks_source_mutation(jj_backend):
+    plan = await seed(jj_backend)
+    receipt = jj_backend.repo_root / ".jj/fava-migrations" / (plan["digest"] + ".json")
+    receipt.parent.mkdir()
+    receipt.write_text('{"plan": {}}')
+    before = capture(jj_backend.repo_root)
+    with pytest.raises(ValueError, match="Recovery receipt is invalid"):
+        await apply_plan(jj_backend, plan, plan["digest"])
+    assert capture(jj_backend.repo_root) == before
+    assert not journal_path(jj_backend.repo_root).exists()

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -1,0 +1,310 @@
+"""Synthetic governed migrations; never touch the operator's data repository."""
+
+import asyncio
+import copy
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from fava_trails.duplicates import apply_plan, build_plan, capture, digest, report
+from fava_trails.governance import Visibility, read_snapshot
+from fava_trails.models import ThoughtFrontmatter, ThoughtRecord
+from fava_trails.transactions import journal_path
+
+SCOPE = "test-jj"
+
+
+def put(root, identity, *, content="Identical accepted observation.\n", status="approved", scope=SCOPE, **kwargs):
+    record = ThoughtRecord(
+        frontmatter=ThoughtFrontmatter(
+            thought_id=identity, created_at=datetime(2026, 1, 1, tzinfo=UTC), validation_status=status, **kwargs
+        ),
+        content=content,
+    )
+    path = root / "trails" / scope / "thoughts" / "observations" / f"{identity}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(record.to_markdown())
+    return path
+
+
+def plan_for(root, **kwargs):
+    info = report(root, SCOPE)
+    group = info["groups"][0]
+    canonical = next(m["path"] for m in group["members"] if m["frontmatter"]["thought_id"] == "A")
+    return build_plan(root, SCOPE, {group["body_sha256"]: canonical}, **kwargs)
+
+
+async def seed(vcs, **kwargs):
+    put(vcs.repo_root, "A")
+    put(vcs.repo_root, "B", **kwargs)
+    paths = [str(p) for p in (vcs.repo_root / "trails").glob("**/*.md")]
+    await vcs.commit_files("Synthetic migration fixture", paths)
+    return plan_for(vcs.repo_root)
+
+
+def all_bytes(root):
+    return {str(p.relative_to(root)): p.read_bytes() for p in root.rglob("*") if p.is_file()}
+
+
+@pytest.mark.asyncio
+async def test_report_and_plan_make_no_repository_writes(jj_backend):
+    plan = await seed(jj_backend)
+    root = jj_backend.repo_root
+    before = all_bytes(root)
+    assert len(report(root, SCOPE)["groups"]) == 1
+    assert plan_for(root) == plan
+    assert all_bytes(root) == before
+    assert not (root / ".jj/fava-governance.lock").exists()
+
+
+@pytest.mark.asyncio
+async def test_mixed_draft_preserves_approved_and_provenance(jj_backend):
+    plan = await seed(jj_backend, status="draft", agent_id="synthetic-author")
+    assert plan["blockers"] == []
+    result = await apply_plan(jj_backend, plan, plan["digest"])
+    assert result["status"] == "applied"
+    snap = read_snapshot(jj_backend.repo_root / "trails", strict=True)
+    assert [r.thought_id for r in snap.records.values() if Visibility().allows(r, snap.by_id)] == ["A"]
+    saved = next(iter(snap.records.values()))
+    assert saved.frontmatter.validation_status == "approved"
+    removed = saved.frontmatter.metadata.extra["duplicate_migrations"][0]["removed"][0]
+    assert removed["frontmatter"]["validation_status"] == "draft"
+    assert removed["frontmatter"]["agent_id"] == "synthetic-author"
+    receipt = json.loads(Path(result["receipt"]).read_text())
+    assert len(receipt["recovery_commit"]) == 40 and len(receipt["recovery_operation"]) >= 32
+    assert Path(result["receipt"]).stat().st_mode & 0o077 == 0
+
+
+@pytest.mark.asyncio
+async def test_safe_cross_scope_inbound_links_redirect_and_rollback_exactly(jj_backend):
+    root = jj_backend.repo_root
+    put(root, "A")
+    put(root, "B")
+    put(
+        root,
+        "C",
+        content="Dependent observation",
+        scope="other",
+        parent_id="B",
+        intent_ref="B",
+        relationships=[{"type": "REFERENCES", "target_id": "B"}],
+    )
+    paths = [str(p) for p in (root / "trails").glob("**/*.md")]
+    await jj_backend.commit_files("Synthetic linked fixture", paths, allowed_prefixes=["trails/"])
+    before = capture(root)
+    plan = plan_for(root)
+    assert plan["blockers"] == []
+    await apply_plan(jj_backend, plan, plan["digest"])
+    saved = ThoughtRecord.from_markdown((root / "trails/other/thoughts/observations/C.md").read_text())
+    assert saved.frontmatter.parent_id == saved.frontmatter.intent_ref == "A"
+    assert saved.frontmatter.relationships[0].target_id == "A"
+    after = all_bytes(root)
+    assert (await apply_plan(jj_backend, plan, plan["digest"]))["status"] == "already_applied"
+    assert all_bytes(root) == after
+    assert (await apply_plan(jj_backend, plan, plan["digest"], rollback=True))["status"] == "rolled_back"
+    assert capture(root) == before
+    assert (await apply_plan(jj_backend, plan, plan["digest"], rollback=True))["status"] == "already_rolled_back"
+
+
+@pytest.mark.asyncio
+async def test_tamper_stale_and_missing_confirmation_never_write(jj_backend):
+    plan = await seed(jj_backend)
+    root = jj_backend.repo_root
+    before = all_bytes(root)
+    bad = copy.deepcopy(plan)
+    bad["operations"][0]["after"] = "tampered"
+    with pytest.raises(ValueError, match="digest"):
+        await apply_plan(jj_backend, bad, plan["digest"])
+    with pytest.raises(ValueError, match="digest"):
+        await apply_plan(jj_backend, plan, "")
+    assert all_bytes(root) == before
+    put(root, "new", content="New inbound reference", parent_id="B")
+    source_before = capture(root)
+    with pytest.raises(ValueError, match="changed since review"):
+        await apply_plan(jj_backend, plan, plan["digest"])
+    assert capture(root) == source_before
+    assert not journal_path(root).exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "extra,expected",
+    [
+        ({"status": "rejected"}, "Conflicting lifecycle"),
+        ({"superseded_by": "C"}, "Existing supersession"),
+        ({"confidence": 0.9}, "Source/confidence conflict"),
+        ({"metadata": {"extra": {"validation": {"decision": "fail"}}}}, "Validation conflict"),
+        ({"parent_id": "A"}, "Outbound lineage/relationship conflict"),
+    ],
+)
+async def test_uncertain_cases_become_blockers(jj_backend, extra, expected):
+    plan = await seed(jj_backend, **extra)
+    assert any(expected in b for b in plan["blockers"])
+    with pytest.raises(ValueError, match="blockers"):
+        await apply_plan(jj_backend, plan, plan["digest"])
+
+
+@pytest.mark.asyncio
+async def test_canonical_cannot_replace_approved_with_proposed(jj_backend):
+    await seed(jj_backend, status="proposed")
+    info = report(jj_backend.repo_root, SCOPE)
+    group = info["groups"][0]
+    canonical = next(m["path"] for m in group["members"] if m["frontmatter"]["thought_id"] == "B")
+    plan = build_plan(jj_backend.repo_root, SCOPE, {group["body_sha256"]: canonical})
+    assert any("approved current" in b for b in plan["blockers"])
+
+
+@pytest.mark.asyncio
+async def test_metadata_extensions_and_exact_body_survive(jj_backend):
+    root = jj_backend.repo_root
+    for identity in ("A", "B"):
+        path = put(root, identity, content="\nBody with blank lines.  \n\n")
+        path.write_text(
+            path.read_text().replace(
+                "schema_version: 1",
+                "schema_version: 1\ncustom_validation:\n  checked: true\ncustom_provenance: imported",
+            )
+        )
+    await jj_backend.commit_files("Synthetic extension fixture", [str(p) for p in (root / "trails").glob("**/*.md")])
+    before = capture(root)
+    plan = plan_for(root)
+    await apply_plan(jj_backend, plan, plan["digest"])
+    after = capture(root)
+    original = before[next(n for n in before if n.endswith("/A.md"))]
+    remaining = next(iter(after.values()))
+    assert remaining.split("---", 2)[2] == original.split("---", 2)[2]
+    assert "custom_provenance: imported" in remaining
+    assert report(root, SCOPE)["groups"] == []
+
+
+@pytest.mark.asyncio
+async def test_failed_commit_restores_source_and_retry_recovers(jj_backend, monkeypatch):
+    plan = await seed(jj_backend)
+    before = capture(jj_backend.repo_root)
+    real = jj_backend.commit_files
+
+    async def fail(*args, **kwargs):
+        raise RuntimeError("synthetic persistence failure")
+
+    monkeypatch.setattr(jj_backend, "commit_files", fail)
+    with pytest.raises(RuntimeError, match="synthetic"):
+        await apply_plan(jj_backend, plan, plan["digest"])
+    assert journal_path(jj_backend.repo_root).exists()
+    monkeypatch.setattr(jj_backend, "commit_files", real)
+    await apply_plan(jj_backend, plan, plan["digest"])
+    assert not journal_path(jj_backend.repo_root).exists()
+    await apply_plan(jj_backend, plan, plan["digest"], rollback=True)
+    assert capture(jj_backend.repo_root) == before
+
+
+@pytest.mark.asyncio
+async def test_process_death_during_write_is_recoverable(jj_backend, tmp_path):
+    plan = await seed(jj_backend)
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(json.dumps(plan))
+    code = """
+import asyncio,json,os,sys
+from pathlib import Path
+from fava_trails.duplicates import apply_plan
+from fava_trails.vcs.jj_backend import JjBackend
+root,planfile=sys.argv[1:]
+vcs=JjBackend(Path(root),Path(root)/"trails/test-jj")
+async def die(*args,**kwargs): os._exit(73)
+vcs.commit_files=die
+plan=json.loads(Path(planfile).read_text())
+asyncio.run(apply_plan(vcs,plan,plan["digest"]))
+"""
+    proc = await asyncio.create_subprocess_exec(sys.executable, "-c", code, str(jj_backend.repo_root), str(plan_path))
+    assert await proc.wait() == 73
+    snap = read_snapshot(jj_backend.repo_root / "trails", strict=True)
+    assert sorted(r.thought_id for r in snap.records.values()) == ["A", "B"]
+    await apply_plan(jj_backend, plan, plan["digest"])
+    assert len(capture(jj_backend.repo_root)) == 1
+    await apply_plan(jj_backend, plan, plan["digest"], rollback=True)
+    assert len(capture(jj_backend.repo_root)) == 2
+
+
+def test_cli_default_is_read_only_and_outputs_private_artifact(tmp_path):
+    from fava_trails.cli import build_parser
+
+    root = tmp_path / "repo"
+    root.mkdir()
+    put(root, "A")
+    put(root, "B")
+    output = tmp_path / "report.json"
+    args = build_parser().parse_args(["duplicates", "--repo", str(root), "--scope", SCOPE, "--out", str(output)])
+    before = all_bytes(root)
+    assert args.func(args) == 0
+    assert output.stat().st_mode & 0o077 == 0
+    assert all_bytes(root) == before
+
+
+@pytest.mark.asyncio
+async def test_rehashed_unsafe_plan_and_rollback_payload_are_rejected(jj_backend):
+    plan = await seed(jj_backend)
+    bad = copy.deepcopy(plan)
+    bad["operations"][0]["after"] = "Injected different content"
+    bad["digest"] = digest({k: v for k, v in bad.items() if k != "digest"})
+    with pytest.raises(ValueError, match="safe migration rules"):
+        await apply_plan(jj_backend, bad, bad["digest"])
+    await apply_plan(jj_backend, plan, plan["digest"])
+    bad = copy.deepcopy(plan)
+    bad["operations"][0]["before"] += "Injected extra body"
+    bad["digest"] = digest({k: v for k, v in bad.items() if k != "digest"})
+    with pytest.raises(ValueError, match="safe migration rules"):
+        await apply_plan(jj_backend, bad, bad["digest"], rollback=True)
+
+
+@pytest.mark.asyncio
+async def test_unrelated_dirty_file_blocks_apply_and_preserves_content(jj_backend):
+    plan = await seed(jj_backend)
+    other = jj_backend.repo_root / "unrelated.txt"
+    other.write_text("Uncommitted operator work")
+    before = capture(jj_backend.repo_root)
+    with pytest.raises(ValueError, match="clean working change"):
+        await apply_plan(jj_backend, plan, plan["digest"])
+    assert capture(jj_backend.repo_root) == before
+    assert other.read_text() == "Uncommitted operator work"
+
+
+@pytest.mark.asyncio
+async def test_empty_record_is_reported_and_blocks_unknown_inbound_context(jj_backend):
+    await seed(jj_backend)
+    empty = jj_backend.repo_root / "trails/other/thoughts/observations/empty.md"
+    empty.parent.mkdir(parents=True)
+    empty.write_text("")
+    result = report(jj_backend.repo_root, SCOPE)
+    assert len(result["groups"]) == 1
+    assert "trails/other/thoughts/observations/empty.md" in result["invalid_records"]
+    assert any("Unparseable" in b for b in plan_for(jj_backend.repo_root)["blockers"])
+
+
+@pytest.mark.asyncio
+async def test_exact_body_whitespace_is_not_normalized(jj_backend):
+    put(jj_backend.repo_root, "A", content="Body\n")
+    put(jj_backend.repo_root, "B", content="Body \n")
+    assert report(jj_backend.repo_root, SCOPE)["groups"] == []
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_global_identity_is_a_blocker(jj_backend):
+    await seed(jj_backend)
+    put(jj_backend.repo_root, "B", scope="other")
+    assert any("Ambiguous thought identity" in b for b in plan_for(jj_backend.repo_root)["blockers"])
+
+
+@pytest.mark.asyncio
+async def test_all_draft_group_stays_unapproved(jj_backend):
+    root = jj_backend.repo_root
+    put(root, "A", status="draft")
+    put(root, "B", status="draft")
+    await jj_backend.commit_files("Synthetic drafts", [str(p) for p in (root / "trails").glob("**/*.md")])
+    plan = plan_for(root)
+    assert plan["blockers"] == []
+    await apply_plan(jj_backend, plan, plan["digest"])
+    snap = read_snapshot(root / "trails", strict=True)
+    assert len(snap.records) == 1
+    assert not any(Visibility().allows(r, snap.by_id) for r in snap.records.values())

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -70,10 +70,12 @@ async def test_mixed_draft_preserves_approved_and_provenance(jj_backend):
     assert [r.thought_id for r in snap.records.values() if Visibility().allows(r, snap.by_id)] == ["A"]
     saved = next(iter(snap.records.values()))
     assert saved.frontmatter.validation_status == "approved"
-    removed = saved.frontmatter.metadata.extra["duplicate_migrations"][0]["removed"][0]
-    assert removed["frontmatter"]["validation_status"] == "draft"
-    assert removed["frontmatter"]["agent_id"] == "synthetic-author"
+    audit = saved.frontmatter.metadata.extra["duplicate_migrations"][0]
+    assert audit["removed_count"] == 1 and "removed" not in audit
+    assert "synthetic-author" not in saved.model_dump_json()
     receipt = json.loads(Path(result["receipt"]).read_text())
+    removed = next(o for o in receipt["plan"]["operations"] if o["after"] is None)
+    assert ThoughtRecord.from_markdown(removed["before"]).frontmatter.agent_id == "synthetic-author"
     assert len(receipt["recovery_commit"]) == 40 and len(receipt["recovery_operation"]) >= 32
     assert Path(result["receipt"]).stat().st_mode & 0o077 == 0
 
@@ -321,3 +323,104 @@ async def test_corrupt_existing_recovery_receipt_blocks_source_mutation(jj_backe
         await apply_plan(jj_backend, plan, plan["digest"])
     assert capture(jj_backend.repo_root) == before
     assert not journal_path(jj_backend.repo_root).exists()
+
+
+@pytest.mark.asyncio
+async def test_crlf_failure_retry_apply_and_rollback_preserve_exact_bytes(jj_backend, monkeypatch):
+    root = jj_backend.repo_root
+    paths = [put(root, identity) for identity in ("A", "B")]
+    for path in paths:
+        path.write_bytes(path.read_bytes().replace(b"\n", b"\r\n"))
+    await jj_backend.commit_files("Synthetic CRLF sources", [str(path) for path in paths])
+    original = {path: path.read_bytes() for path in paths}
+    plan = plan_for(root)
+    commit = jj_backend.commit_files
+
+    async def fail(*args, **kwargs):
+        raise RuntimeError("synthetic CRLF persistence failure")
+
+    monkeypatch.setattr(jj_backend, "commit_files", fail)
+    with pytest.raises(RuntimeError, match="CRLF persistence failure"):
+        await apply_plan(jj_backend, plan, plan["digest"])
+    assert {path: path.read_bytes() for path in paths} == original
+    before = json.loads(journal_path(root).read_bytes())["before"]
+    assert all(before[str(path.relative_to(root))].encode() == original[path] for path in paths)
+    snapshot = read_snapshot(root / "trails", strict=True)
+    assert {path: text.encode() for path, text in snapshot.texts.items()} == original
+    monkeypatch.setattr(jj_backend, "commit_files", commit)
+    assert (await apply_plan(jj_backend, plan, plan["digest"]))["status"] == "applied"
+    for operation in plan["operations"]:
+        path = root / operation["path"]
+        if operation["after"] is None:
+            assert not path.exists()
+        else:
+            assert path.read_bytes() == operation["after"].encode()
+    assert (await apply_plan(jj_backend, plan, plan["digest"], rollback=True))["status"] == "rolled_back"
+    assert {path: path.read_bytes() for path in paths} == original
+
+
+@pytest.mark.asyncio
+async def test_post_commit_crash_receipt_is_finalized_by_verified_retry(jj_backend, monkeypatch):
+    import fava_trails.duplicates as maintenance
+
+    plan = await seed(jj_backend)
+    persist = maintenance.persist_governance
+
+    async def crash_after_publication(*args, **kwargs):
+        await persist(*args, **kwargs)
+        raise SystemExit("Synthetic interruption after publication")
+
+    monkeypatch.setattr(maintenance, "persist_governance", crash_after_publication)
+    with pytest.raises(SystemExit):
+        await apply_plan(jj_backend, plan, plan["digest"])
+    receipt = jj_backend.repo_root / ".jj/fava-migrations" / (plan["digest"] + ".json")
+    prepared = json.loads(receipt.read_text())
+    assert prepared["status"] == "prepared" and len(prepared["committed_commit"]) == 40
+    monkeypatch.setattr(maintenance, "persist_governance", persist)
+    assert (await apply_plan(jj_backend, plan, plan["digest"]))["status"] == "already_applied"
+    assert json.loads(receipt.read_text())["status"] == "applied"
+    receipt.write_text('{"status":"applied","plan":{}}')
+    with pytest.raises(ValueError, match="Recovery receipt"):
+        await apply_plan(jj_backend, plan, plan["digest"])
+
+
+@pytest.mark.asyncio
+async def test_matching_after_images_without_receipt_are_not_success(jj_backend):
+    plan = await seed(jj_backend)
+    for operation in plan["operations"]:
+        path = jj_backend.repo_root / operation["path"]
+        if operation["after"] is None:
+            path.unlink()
+        else:
+            path.write_bytes(operation["after"].encode())
+    with pytest.raises(ValueError, match="Recovery receipt"):
+        await apply_plan(jj_backend, plan, plan["digest"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["draft", "proposed"])
+async def test_private_provenance_remains_operator_only_after_migration(jj_backend, monkeypatch, status):
+    from fava_trails.tools.recall import handle_recall
+    from fava_trails.trail import TrailManager
+
+    marker = "SYNTHETIC_PRIVATE_AUTHOR_CONTEXT"
+    plan = await seed(jj_backend, status=status, agent_id="private-author", metadata={"extra": {"work_note": marker}})
+    trail = TrailManager(SCOPE, vcs=jj_backend)
+    monkeypatch.setenv("FAVA_TRAILS_AGENT_ID", "different-author")
+    monkeypatch.delenv("FAVA_TRAILS_OPERATOR", raising=False)
+    assert marker not in json.dumps(await handle_recall(trail, {}))
+    assert marker not in json.dumps(await handle_recall(trail, {"mode": "authoring"}))
+    with pytest.raises(PermissionError):
+        await handle_recall(trail, {"mode": "history"})
+    monkeypatch.setenv("FAVA_TRAILS_AGENT_ID", "private-author")
+    assert marker in json.dumps(await handle_recall(trail, {"mode": "authoring"}))
+    result = await apply_plan(jj_backend, plan, plan["digest"])
+    assert marker in Path(result["receipt"]).read_text()
+    for identity in ("private-author", "different-author"):
+        monkeypatch.setenv("FAVA_TRAILS_AGENT_ID", identity)
+        assert marker not in json.dumps(await handle_recall(trail, {}))
+        assert (await handle_recall(trail, {"mode": "authoring"}))["thoughts"] == []
+    monkeypatch.setenv("FAVA_TRAILS_OPERATOR", "1")
+    history = await handle_recall(trail, {"mode": "history"})
+    assert [t["thought_id"] for t in history["thoughts"]] == ["A"]
+    assert marker not in json.dumps(history)


### PR DESCRIPTION
This adds local operator tooling for issue #74: exact-body duplicate reporting, explicit canonical selection, a digest-bound plan with every deletion/rewrite, guarded apply, and exact before-image rollback. Reports never invoke JJ or modify the source repository. Plans preserve approved current truth, retain removed provenance, redirect safe inbound links, and refuse ambiguous identities or conflicting lifecycle, validation, and lineage.

Apply regenerates the safe plan under the existing governance transaction lock, requires the complete reviewed source snapshot and a clean conflict-free JJ change, and saves a private recovery receipt containing the commit, operation, and before images. The shared journal handles interrupted publication. Repeated apply/rollback is a no-op; subsequent edits require fresh review. The transaction writer preserves existing file permissions and creates new private files with owner-only permissions.

Validation uses synthetic disposable JJ repositories: read-only reports, exact body preservation, mixed approved/draft and draft-only groups, cross-scope links, validation conflicts, ambiguous IDs, stale/rehashed plans, corrupt recovery receipts, persistence failure, process death, retry, and rollback. Full frozen suite after reader and MCP integration: 836 passed. Focused Ruff checks and git diff checks pass.

Issue #74 remains open pending the operator's exact real-data recovery/lineage decisions and explicit approval of an executable delete/rewrite set. Private reports, historical recovery candidates, and isolated reader previews were prepared separately; no real governed-data migration or recovery was applied. No private thought contents or fixtures are included in this PR.
