### PR TITLE
fix: stop installing stale JJ by default; preserve compatible installs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,12 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Supported minimum (integration floor) and current official stable.
+        # install-jj resolves "latest" from GitHub; pin via --version for reproducibility.
+        jj_version: ["0.28.0", "0.45.1"]
 
     steps:
       - uses: actions/checkout@v4
@@ -23,10 +29,18 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen
 
-      - name: Install JJ
+      - name: Install JJ (${{ matrix.jj_version }})
         run: |
-          uv run fava-trails install-jj
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          # Explicit pin so CI is reproducible; production default resolves GitHub latest.
+          # Hide any preinstalled jj so we exercise the managed install path.
+          mkdir -p "$HOME/bin-shadow"
+          printf '#!/bin/sh\necho "shadow"\nexit 1\n' > "$HOME/bin-shadow/jj"
+          chmod +x "$HOME/bin-shadow/jj"
+          # Prefer empty PATH segment for jj discovery during install:
+          hash -r || true
+          uv run fava-trails install-jj --version "${{ matrix.jj_version }}" --force
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/jj" --version
 
       - name: Lint
         run: uv run ruff check src/ tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to FAVA Trails are documented here.
 
 ### Changed
 - Support MCP SDK 2.2 with explicit low-level handlers, preserving tool schemas, annotations, input/output validation, structured results, and Markdown usage guidance over stdio and Streamable HTTP. Adds installed-wheel protocol tests for legacy initialization and current SDK clients. Resolves #83.
+- **JJ installer policy (issue #98):** `fava-trails install-jj` and `scripts/install-jj.sh` reuse any installed JJ `>= 0.28.0` (including newer), never silently downgrade or overwrite a user-managed binary, resolve current GitHub stable when install is needed (explicit `--version` / `JJ_VERSION` override retained), verify GitHub asset SHA-256 digests when published, and install atomically with restore-on-failure. CI matrix covers JJ **0.28.0** and **0.45.1**. See `docs/jj-compatibility.md`.
 
 ## [0.6.1] — 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to FAVA Trails are documented here.
 
 ### Changed
 - Support MCP SDK 2.2 with explicit low-level handlers, preserving tool schemas, annotations, input/output validation, structured results, and Markdown usage guidance over stdio and Streamable HTTP. Adds installed-wheel protocol tests for legacy initialization and current SDK clients. Resolves #83.
-- **JJ installer policy (issue #98):** `fava-trails install-jj` (canonical `jj_install.py`; `scripts/install-jj.sh` is a thin delegate) reuses any installed JJ `>= 0.28.0` before platform checks, never silently downgrades or overwrites a user-managed binary, resolves current GitHub stable when install is needed (explicit `--version` / `JJ_VERSION` override retained), verifies GitHub asset SHA-256 digests when published, validates archive members safely, and installs atomically with restore of the prior managed binary after any post-replacement failure. CI matrix covers JJ **0.28.0** and **0.45.1**. See `docs/jj-compatibility.md`.
+- **JJ installer policy (issue #98):** `fava-trails install-jj` (canonical `jj_install.py`; `scripts/install-jj.sh` is a thin Bash 3.2-safe delegate) reuses any installed JJ `>= 0.28.0` before platform checks, never silently downgrades or overwrites a user-managed binary, resolves current GitHub stable when install is needed (explicit `--version` / `JJ_VERSION` override retained), verifies GitHub asset SHA-256 digests when published, requires exactly one safe regular `jj` archive member, installs atomically with restore of the prior managed binary after any post-replacement failure, and PATH-hints the selected install directory. CI matrix covers JJ **0.28.0** and **0.45.1**. See `docs/jj-compatibility.md`.
 
 ## [0.6.1] — 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to FAVA Trails are documented here.
 
 ### Changed
 - Support MCP SDK 2.2 with explicit low-level handlers, preserving tool schemas, annotations, input/output validation, structured results, and Markdown usage guidance over stdio and Streamable HTTP. Adds installed-wheel protocol tests for legacy initialization and current SDK clients. Resolves #83.
-- **JJ installer policy (issue #98):** `fava-trails install-jj` and `scripts/install-jj.sh` reuse any installed JJ `>= 0.28.0` (including newer), never silently downgrade or overwrite a user-managed binary, resolve current GitHub stable when install is needed (explicit `--version` / `JJ_VERSION` override retained), verify GitHub asset SHA-256 digests when published, and install atomically with restore-on-failure. CI matrix covers JJ **0.28.0** and **0.45.1**. See `docs/jj-compatibility.md`.
+- **JJ installer policy (issue #98):** `fava-trails install-jj` (canonical `jj_install.py`; `scripts/install-jj.sh` is a thin delegate) reuses any installed JJ `>= 0.28.0` before platform checks, never silently downgrades or overwrites a user-managed binary, resolves current GitHub stable when install is needed (explicit `--version` / `JJ_VERSION` override retained), verifies GitHub asset SHA-256 digests when published, validates archive members safely, and installs atomically with restore of the prior managed binary after any post-replacement failure. CI matrix covers JJ **0.28.0** and **0.45.1**. See `docs/jj-compatibility.md`.
 
 ## [0.6.1] — 2026-08-01
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thank you for your interest in contributing! This guide covers everything you ne
 fava-trails install-jj
 ```
 
-This downloads a pre-built binary for your platform to `~/.local/bin/jj`. Supports Linux (x86_64, aarch64) and macOS (x86_64, arm64). Make sure `~/.local/bin` is in your `PATH`. Alternatively, install manually from [jj-vcs.github.io/jj](https://jj-vcs.github.io/jj/).
+This **reuses** any already-installed JJ at or above the supported minimum (**0.28.0**), including newer versions. It never silently downgrades or overwrites a user-managed `jj`. When installation is needed, it resolves the current official GitHub stable release into the managed path `~/.local/bin/jj` (override with `--version` / `JJ_VERSION` for reproducible environments). Supports Linux (x86_64, aarch64) and macOS (x86_64, arm64). Make sure `~/.local/bin` is in your `PATH` if you rely on the managed binary. From a source checkout you can also run `scripts/install-jj.sh` (thin wrapper around the same Python installer). Alternatively, install manually from [jj-vcs.github.io/jj](https://jj-vcs.github.io/jj/). See [docs/jj-compatibility.md](docs/jj-compatibility.md).
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ FAVA Trails uses [Jujutsu (JJ)](https://jj-vcs.github.io/jj/) as its storage eng
 fava-trails install-jj
 ```
 
+This reuses any already-installed JJ at or above the supported minimum (**0.28.0**), including newer versions. It never silently downgrades or overwrites a user-managed `jj`. When installation is needed, it resolves the current official GitHub stable release (override with `--version` / `JJ_VERSION` for reproducible environments). See [docs/jj-compatibility.md](docs/jj-compatibility.md).
+
 ### From PyPI (recommended)
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@
 |-----------|--------------------------|
 | FAVA Trails | 0.4.0+ |
 | Python | 3.11+ |
-| JJ (Jujutsu) | 0.28.0+ |
+| JJ (Jujutsu) | 0.28.0+ (install resolves current GitHub stable; see docs/jj-compatibility.md) |
 
 Older versions do not receive security updates. Please upgrade to the latest release.
 

--- a/docs/jj-compatibility.md
+++ b/docs/jj-compatibility.md
@@ -26,20 +26,32 @@ Evidence (local + CI matrix, 2026-09-09):
 
 ## Installer policy
 
-Both `fava-trails install-jj` and `scripts/install-jj.sh` share this behavior:
+Canonical implementation: `src/fava_trails/jj_install.py`, exposed as
+`fava-trails install-jj` and as `python -m fava_trails.jj_install`.
+`scripts/install-jj.sh` is a **thin entrypoint** that delegates to that module
+(or the packaged CLI) so digest checks, archive validation, and restore policy
+cannot drift across two implementations.
 
-1. **Reuse** any installed `jj` with version `>= 0.28.0` (including newer than
-   the last CI pin). Report `action` / `path` / `version` / `reason`.
+Shared behavior:
+
+1. **Reuse first** — any installed `jj` with version `>= 0.28.0` (including newer
+   than the last CI pin) is selected **before** platform/download checks, so a
+   compatible binary is kept even on hosts without a FAVA-downloadable asset.
+   Report `action` / `path` / `version` / `reason`.
 2. **Never silently downgrade** or overwrite a **user-managed** executable
    (anything other than the managed `~/.local/bin/jj` path).
 3. When install is needed, **resolve GitHub latest stable** with bounded
    network timeouts, unless an explicit version override is set.
 4. **Integrity**: use GitHub release asset `digest` (`sha256:…`) when the API
-   publishes it; older tags without digests still verify `--version` after
-   extract.
-5. **Atomic install** to `~/.local/bin/jj` with restore of the prior managed
-   binary if verification fails.
-6. Offline / API failure: if a compatible JJ is already present, keep it and
+   publishes it; a published digest is never silently discarded. Older tags
+   without digests still verify `--version` after extract.
+5. **Safe archive handling**: only a single regular `jj` member is written;
+   path traversal, absolute paths, and non-regular entries are rejected.
+6. **Atomic install** to `~/.local/bin/jj` with restore of the prior managed
+   binary if verification fails **at any point after replacement begins**
+   (including post-replace `--version` failure when the new file is already at
+   the destination).
+7. Offline / API failure: if a compatible JJ is already present, keep it and
    report the resolution error in the reason; otherwise exit non-zero without
    changing disk state.
 

--- a/docs/jj-compatibility.md
+++ b/docs/jj-compatibility.md
@@ -41,7 +41,9 @@ Shared behavior:
 2. **Never silently downgrade** or overwrite a **user-managed** executable
    (anything other than the managed `~/.local/bin/jj` path).
 3. When install is needed, **resolve GitHub latest stable** with bounded
-   network timeouts, unless an explicit version override is set.
+   network timeouts, unless an explicit version override is set. Invalid
+   `--version` / `JJ_VERSION` values return a structured
+   `action`/`path`/`version`/`reason` error (no traceback).
 4. **Integrity**: use GitHub release asset `digest` (`sha256:…`) when the API
    publishes it; a published digest is never silently discarded. Older tags
    without digests still verify `--version` after extract.

--- a/docs/jj-compatibility.md
+++ b/docs/jj-compatibility.md
@@ -1,0 +1,73 @@
+# JJ (Jujutsu) compatibility
+
+FAVA Trails uses [Jujutsu](https://jj-vcs.github.io/jj/) in Git-colocate mode as
+its storage engine. This document records the supported floor, install policy,
+and versions exercised by automated tests.
+
+## Supported minimum
+
+| Component | Policy |
+|-----------|--------|
+| **Minimum supported JJ** | **0.28.0** |
+| **Install default** | Current official GitHub stable (`jj-vcs/jj` latest release), not a frozen patch |
+| **Override** | `fava-trails install-jj --version X.Y.Z` or `JJ_VERSION=X.Y.Z` |
+
+The minimum is the oldest release against which FAVA Trails runs its real JJ
+integration suite on disposable repositories (init, save, promote/reject freeze,
+supersede, status, sync dirty-path). Newer releases that preserve the command
+surface FAVA uses are accepted without forcing an upgrade.
+
+Evidence (local + CI matrix, 2026-09-09):
+
+| JJ version | `tests/test_jj_backend.py` | `tests/test_jj_compat_matrix.py` | `tests/test_tools.py` (subset) |
+|------------|----------------------------|----------------------------------|--------------------------------|
+| 0.28.0 | pass | pass | pass |
+| 0.45.1 (then-current stable) | pass | pass | pass |
+
+## Installer policy
+
+Both `fava-trails install-jj` and `scripts/install-jj.sh` share this behavior:
+
+1. **Reuse** any installed `jj` with version `>= 0.28.0` (including newer than
+   the last CI pin). Report `action` / `path` / `version` / `reason`.
+2. **Never silently downgrade** or overwrite a **user-managed** executable
+   (anything other than the managed `~/.local/bin/jj` path).
+3. When install is needed, **resolve GitHub latest stable** with bounded
+   network timeouts, unless an explicit version override is set.
+4. **Integrity**: use GitHub release asset `digest` (`sha256:…`) when the API
+   publishes it; older tags without digests still verify `--version` after
+   extract.
+5. **Atomic install** to `~/.local/bin/jj` with restore of the prior managed
+   binary if verification fails.
+6. Offline / API failure: if a compatible JJ is already present, keep it and
+   report the resolution error in the reason; otherwise exit non-zero without
+   changing disk state.
+
+## Command surface FAVA relies on
+
+These JJ invocations are used by `JjBackend` and must remain available on
+supported versions:
+
+- `jj git init --colocate`
+- `jj config set --repo …` (including `ui.conflict-marker-style=snapshot`)
+- `jj new -m`, `jj describe -m`, `jj status`
+- `jj diff --name-only`, `jj diff --stat`, `jj diff --git`
+- `jj log` with templates / revsets (`conflicts()`, `description(exact:"")`, `@`, `@-`)
+- `jj bookmark set`, `jj git fetch --all-remotes`, `jj rebase -d …`
+- `jj git push --allow-empty-description` / `-b`
+- `jj abandon`, `jj op log`, `jj op restore`, `jj util gc`
+
+### Incompatible command changes observed
+
+None between **0.28.0** and **0.45.1** for the surface above. FAVA does not use
+removed legacy names (`jj untrack`, `branches()` revset, etc.).
+
+If a future JJ release breaks a listed invocation, raise the documented minimum
+and note the incompatibility here.
+
+## CI
+
+`.github/workflows/test.yml` installs an explicit matrix of JJ versions via
+`fava-trails install-jj --version <pin> --force` so the suite runs on both the
+supported minimum and a current stable pin. Production installs without
+`--version` follow GitHub latest.

--- a/docs/jj-compatibility.md
+++ b/docs/jj-compatibility.md
@@ -54,16 +54,19 @@ supported versions:
 - `jj diff --name-only`, `jj diff --stat`, `jj diff --git`
 - `jj log` with templates / revsets (`conflicts()`, `description(exact:"")`, `@`, `@-`)
 - `jj bookmark set`, `jj git fetch --all-remotes`, `jj rebase -d …`
-- `jj git push --allow-empty-description` / `-b`
+- `jj git push --allow-empty-description` / `-b` (tracked bookmarks)
+- `jj git push --all` when seeding a remote that does not yet have the bookmark
 - `jj abandon`, `jj op log`, `jj op restore`, `jj util gc`
 
 ### Incompatible command changes observed
 
-None between **0.28.0** and **0.45.1** for the surface above. FAVA does not use
-removed legacy names (`jj untrack`, `branches()` revset, etc.).
+| Change | Impact on FAVA |
+|--------|----------------|
+| `jj git push --allow-new` removed (JJ **0.42+**) | Not used by `JjBackend._git_push` (tracked `-b` / `--all` only). Tests that seed a brand-new remote bookmark must use `--all` (or track + push), not `--allow-new`. |
 
-If a future JJ release breaks a listed invocation, raise the documented minimum
-and note the incompatibility here.
+FAVA does not use other removed legacy names (`jj untrack`, `branches()` revset,
+etc.). If a future JJ release breaks a listed invocation, raise the documented
+minimum and note the incompatibility here.
 
 ## CI
 

--- a/docs/jj-compatibility.md
+++ b/docs/jj-compatibility.md
@@ -45,15 +45,21 @@ Shared behavior:
 4. **Integrity**: use GitHub release asset `digest` (`sha256:…`) when the API
    publishes it; a published digest is never silently discarded. Older tags
    without digests still verify `--version` after extract.
-5. **Safe archive handling**: only a single regular `jj` member is written;
-   path traversal, absolute paths, and non-regular entries are rejected.
-6. **Atomic install** to `~/.local/bin/jj` with restore of the prior managed
-   binary if verification fails **at any point after replacement begins**
+5. **Safe archive handling**: exactly one regular `jj` member is written;
+   path traversal, absolute paths, non-regular entries (symlinks/dirs), and
+   ambiguous archives with multiple `jj` candidates are rejected.
+6. **Atomic install** to the managed install dir (default `~/.local/bin/jj`;
+   override with `--install-dir` / `INSTALL_DIR`) with restore of the prior
+   managed binary if verification fails **at any point after replacement begins**
    (including post-replace `--version` failure when the new file is already at
-   the destination).
+   the destination). PATH guidance after install refers to the selected install
+   directory, not always `~/.local/bin`.
 7. Offline / API failure: if a compatible JJ is already present, keep it and
    report the resolution error in the reason; otherwise exit non-zero without
    changing disk state.
+8. `scripts/install-jj.sh` builds forwarded argv with `set --` only so the
+   documented no-argument path works under macOS Bash 3.2 + `set -u` (empty
+   array expansion is not used).
 
 ## Command surface FAVA relies on
 

--- a/docs/jj-compatibility.md
+++ b/docs/jj-compatibility.md
@@ -49,11 +49,12 @@ Shared behavior:
    path traversal, absolute paths, non-regular entries (symlinks/dirs), and
    ambiguous archives with multiple `jj` candidates are rejected.
 6. **Atomic install** to the managed install dir (default `~/.local/bin/jj`;
-   override with `--install-dir` / `INSTALL_DIR`) with restore of the prior
-   managed binary if verification fails **at any point after replacement begins**
-   (including post-replace `--version` failure when the new file is already at
-   the destination). PATH guidance after install refers to the selected install
-   directory, not always `~/.local/bin`.
+   override with `--install-dir` / `INSTALL_DIR`). If verification fails **at any
+   point after replacement begins** (including post-replace `--version` when the
+   new file is already at the destination): restore the prior managed binary when
+   one existed; otherwise remove the failed destination so a fresh install does
+   not leave an invalid unverified executable. PATH guidance after install refers
+   to the selected install directory (shell-quoted), not always `~/.local/bin`.
 7. Offline / API failure: if a compatible JJ is already present, keep it and
    report the resolution error in the reason; otherwise exit non-zero without
    changing disk state.

--- a/scripts/install-jj.sh
+++ b/scripts/install-jj.sh
@@ -1,329 +1,65 @@
 #!/usr/bin/env bash
-# Install or select Jujutsu (JJ) for FAVA Trails.
-# Policy mirrors src/fava_trails/jj_install.py (issue #98):
-#   - Reuse any installed JJ >= JJ_MIN_VERSION (never silently downgrade).
-#   - Never overwrite a user-managed executable outside ~/.local/bin/jj.
-#   - When install is needed, resolve GitHub latest stable unless JJ_VERSION is set.
-#   - Verify SHA-256 when GitHub publishes asset digests; atomic install; restore on failure.
+# Thin entrypoint for JJ install/selection (issue #98).
+#
+# Canonical policy lives in src/fava_trails/jj_install.py (digest verification,
+# safe archive extraction, atomic install with restore-on-failure, reuse rules).
+# This script only locates a Python interpreter and delegates — avoiding a second
+# policy implementation that can drift (e.g. silent digest loss without Python/jq).
+#
+# Usage:
+#   scripts/install-jj.sh
+#   JJ_VERSION=0.28.0 scripts/install-jj.sh
+#   FORCE=1 scripts/install-jj.sh
+#   INSTALL_DIR=~/.local/bin scripts/install-jj.sh
+# Extra args are forwarded to the Python installer (--version, --force, --install-dir).
 set -euo pipefail
 
-JJ_MIN_VERSION="${JJ_MIN_VERSION:-0.28.0}"
-INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
-MANAGED_BINARY="${INSTALL_DIR}/jj"
-GITHUB_API_LATEST="https://api.github.com/repos/jj-vcs/jj/releases/latest"
-NETWORK_TIMEOUT="${NETWORK_TIMEOUT:-30}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODULE_PATH="${ROOT}/src/fava_trails/jj_install.py"
 
-log() { printf '%s\n' "$*"; }
+ARGS=()
+if [[ -n "${JJ_VERSION:-}" ]]; then
+  ARGS+=(--version "${JJ_VERSION}")
+fi
+if [[ "${FORCE:-0}" == "1" ]]; then
+  ARGS+=(--force)
+fi
+# INSTALL_DIR is read by the Python installer via env; also pass flag for the module CLI.
+MODULE_ARGS=("${ARGS[@]}")
+if [[ -n "${INSTALL_DIR:-}" ]]; then
+  MODULE_ARGS+=(--install-dir "${INSTALL_DIR}")
+fi
+# Allow callers to pass flags directly as well.
+MODULE_ARGS+=("$@")
+CLI_ARGS=("${ARGS[@]}")
+CLI_ARGS+=("$@")
+
 err() { printf '%s\n' "$*" >&2; }
 
-report() {
-  local action="$1" path="${2:-}" version="${3:-}" reason="$4"
-  log "action:  ${action}"
-  log "path:    ${path:-'(none)'}"
-  log "version: ${version:-'(none)'}"
-  log "reason:  ${reason}"
-}
-
-version_ge() {
-  # Return 0 if $1 >= $2 (semver X.Y.Z)
-  local a b
-  IFS=. read -r a1 a2 a3 <<<"${1}"
-  IFS=. read -r b1 b2 b3 <<<"${2}"
-  a1=${a1:-0}; a2=${a2:-0}; a3=${a3:-0}
-  b1=${b1:-0}; b2=${b2:-0}; b3=${b3:-0}
-  if (( a1 != b1 )); then (( a1 > b1 )); return; fi
-  if (( a2 != b2 )); then (( a2 > b2 )); return; fi
-  (( a3 >= b3 ))
-}
-
-parse_jj_version() {
-  # stdin or $1 → prints X.Y.Z or empty
-  local text="${1:-}"
-  if [[ -z "${text}" ]]; then
-    text="$(cat || true)"
+# Prefer the in-tree canonical module when this script lives in a source checkout.
+# That keeps INSTALL_DIR / policy aligned with this revision (not a stale packaged CLI).
+if [[ -f "${MODULE_PATH}" ]]; then
+  if ! command -v python3 >/dev/null 2>&1 && ! command -v python >/dev/null 2>&1; then
+    err "Python 3 is required to install JJ via scripts/install-jj.sh."
+    err "The canonical installer is src/fava_trails/jj_install.py (also: fava-trails install-jj)."
+    err "Install Python 3, or install JJ manually from: https://jj-vcs.github.io/jj/"
+    exit 1
   fi
-  if [[ "${text}" =~ [Jj][Jj][[:space:]]+([0-9]+\.[0-9]+\.[0-9]+) ]]; then
-    printf '%s\n' "${BASH_REMATCH[1]}"
-  fi
-}
-
-probe_jj() {
-  local bin="$1"
-  if [[ ! -x "${bin}" ]]; then
-    return 1
-  fi
-  local out
-  out="$("${bin}" --version 2>/dev/null || true)"
-  parse_jj_version "${out}"
-}
-
-is_managed() {
-  local bin="$1"
-  local managed resolved
-  managed="$(cd "$(dirname "${MANAGED_BINARY}")" 2>/dev/null && pwd)/$(basename "${MANAGED_BINARY}")" || true
-  resolved="$(cd "$(dirname "${bin}")" 2>/dev/null && pwd)/$(basename "${bin}")" || true
-  [[ -n "${managed}" && "${resolved}" == "${managed}" ]]
-}
-
-detect_suffix() {
-  local os arch
-  os="$(uname -s)"
-  arch="$(uname -m)"
-  case "${os}" in
-    Linux)
-      case "${arch}" in
-        x86_64) printf '%s\n' "x86_64-unknown-linux-musl" ;;
-        aarch64|arm64) printf '%s\n' "aarch64-unknown-linux-musl" ;;
-        *) err "Unsupported Linux architecture: ${arch}"; err "Install manually from: https://jj-vcs.github.io/jj/"; return 1 ;;
-      esac
-      ;;
-    Darwin)
-      case "${arch}" in
-        x86_64) printf '%s\n' "x86_64-apple-darwin" ;;
-        arm64|aarch64) printf '%s\n' "aarch64-apple-darwin" ;;
-        *) err "Unsupported macOS architecture: ${arch}"; err "Install manually from: https://jj-vcs.github.io/jj/"; return 1 ;;
-      esac
-      ;;
-    MINGW*|MSYS*|CYGWIN*|Windows_NT)
-      err "Windows detected. Install JJ with:"
-      err "  winget install Jujutsu.Jujutsu"
-      err "Or manually from: https://jj-vcs.github.io/jj/"
-      return 1
-      ;;
-    *)
-      err "Unsupported OS: ${os}"
-      err "Install manually from: https://jj-vcs.github.io/jj/"
-      return 1
-      ;;
-  esac
-}
-
-api_get() {
-  local url="$1"
-  curl -fsSL --max-time "${NETWORK_TIMEOUT}" \
-    -H "Accept: application/vnd.github+json" \
-    -H "User-Agent: fava-trails-install-jj.sh" \
-    -H "X-GitHub-Api-Version: 2022-11-28" \
-    "${url}"
-}
-
-resolve_release() {
-  # Sets: RESOLVED_VERSION RESOLVED_URL RESOLVED_SHA256 RESOLVED_SOURCE
-  local suffix="$1"
-  local explicit="${JJ_VERSION:-}"
-  local json tag asset_name digest url api
-
-  if [[ -n "${explicit}" ]]; then
-    explicit="${explicit#v}"
-    api="https://api.github.com/repos/jj-vcs/jj/releases/tags/v${explicit}"
-    if ! json="$(api_get "${api}")"; then
-      err "Network error resolving JJ v${explicit}"
-      return 1
-    fi
-    RESOLVED_VERSION="${explicit}"
-    RESOLVED_SOURCE="explicit"
-  else
-    if ! json="$(api_get "${GITHUB_API_LATEST}")"; then
-      err "Network error resolving latest JJ release"
-      return 1
-    fi
-    tag="$(printf '%s' "${json}" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
-    tag="${tag#v}"
-    if [[ -z "${tag}" ]]; then
-      err "GitHub latest release response missing tag_name"
-      return 1
-    fi
-    RESOLVED_VERSION="${tag}"
-    RESOLVED_SOURCE="latest"
-  fi
-
-  asset_name="jj-v${RESOLVED_VERSION}-${suffix}.tar.gz"
-  RESOLVED_URL="https://github.com/jj-vcs/jj/releases/download/v${RESOLVED_VERSION}/${asset_name}"
-  RESOLVED_SHA256=""
-
-  # Prefer browser_download_url + digest from assets when present (requires python or jq).
   if command -v python3 >/dev/null 2>&1; then
-    local parsed
-    parsed="$(JJ_JSON="${json}" JJ_ASSET="${asset_name}" python3 - <<'PY'
-import json, os
-data = json.loads(os.environ["JJ_JSON"])
-name = os.environ["JJ_ASSET"]
-url = ""
-sha = ""
-for a in data.get("assets") or []:
-    if a.get("name") == name:
-        url = a.get("browser_download_url") or ""
-        d = a.get("digest") or ""
-        if isinstance(d, str) and d.startswith("sha256:"):
-            sha = d.split(":", 1)[1].strip().lower()
-        break
-print(url)
-print(sha)
-PY
-)"
-    local p_url p_sha
-    p_url="$(printf '%s\n' "${parsed}" | sed -n '1p')"
-    p_sha="$(printf '%s\n' "${parsed}" | sed -n '2p')"
-    [[ -n "${p_url}" ]] && RESOLVED_URL="${p_url}"
-    [[ -n "${p_sha}" ]] && RESOLVED_SHA256="${p_sha}"
-  fi
-}
-
-sha256_file() {
-  local f="$1"
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "${f}" | awk '{print $1}'
-  elif command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 "${f}" | awk '{print $1}'
+    PY="$(command -v python3)"
   else
-    err "No sha256sum/shasum available to verify download"
-    return 1
+    PY="$(command -v python)"
   fi
-}
-
-atomic_install() {
-  local extracted="$1"
-  local dest="$2"
-  local expected="$3"
-  local staged backup got
-  mkdir -p "$(dirname "${dest}")"
-  staged="${dest}.fava-new"
-  backup="${dest}.fava-prev"
-  rm -f "${staged}"
-  cp "${extracted}" "${staged}"
-  chmod +x "${staged}"
-  got="$(probe_jj "${staged}" || true)"
-  if [[ "${got}" != "${expected}" ]]; then
-    rm -f "${staged}"
-    err "version mismatch after extract: expected ${expected}, got ${got:-unknown}"
-    return 1
-  fi
-  if [[ -e "${dest}" || -L "${dest}" ]]; then
-    rm -f "${backup}"
-    mv "${dest}" "${backup}"
-  fi
-  if ! mv "${staged}" "${dest}"; then
-    if [[ -e "${backup}" ]]; then
-      mv "${backup}" "${dest}" || true
-    fi
-    err "failed to move staged binary into place"
-    return 1
-  fi
-  got="$(probe_jj "${dest}" || true)"
-  if [[ "${got}" != "${expected}" ]]; then
-    if [[ -e "${backup}" ]]; then
-      mv "${backup}" "${dest}" || true
-    fi
-    err "post-install version verification failed"
-    return 1
-  fi
-  rm -f "${backup}"
-}
-
-# ── main ─────────────────────────────────────────────────────────────────────
-
-SUFFIX="$(detect_suffix)" || exit 1
-
-EXISTING_BIN=""
-EXISTING_VER=""
-if command -v jj >/dev/null 2>&1; then
-  EXISTING_BIN="$(command -v jj)"
-elif [[ -x "${MANAGED_BINARY}" ]]; then
-  EXISTING_BIN="${MANAGED_BINARY}"
-fi
-if [[ -n "${EXISTING_BIN}" ]]; then
-  EXISTING_VER="$(probe_jj "${EXISTING_BIN}" || true)"
+  export PYTHONPATH="${ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}"
+  exec "${PY}" -m fava_trails.jj_install "${MODULE_ARGS[@]}"
 fi
 
-FORCE="${FORCE:-0}"
-EXPLICIT="${JJ_VERSION:-}"
-
-if [[ -n "${EXISTING_BIN}" && -n "${EXISTING_VER}" && "${FORCE}" != "1" ]]; then
-  if [[ -n "${EXPLICIT}" ]]; then
-    want="${EXPLICIT#v}"
-    if [[ "${EXISTING_VER}" == "${want}" ]]; then
-      report "reuse" "${EXISTING_BIN}" "${EXISTING_VER}" \
-        "exact match for requested ${want} at ${EXISTING_BIN}"
-      exit 0
-    fi
-    if ! is_managed "${EXISTING_BIN}"; then
-      report "refuse" "${EXISTING_BIN}" "${EXISTING_VER}" \
-        "user-managed JJ ${EXISTING_VER} at ${EXISTING_BIN} differs from requested ${want}; refusing to overwrite"
-      exit 1
-    fi
-  elif version_ge "${EXISTING_VER}" "${JJ_MIN_VERSION}"; then
-    report "reuse" "${EXISTING_BIN}" "${EXISTING_VER}" \
-      "compatible installed JJ ${EXISTING_VER} (>= ${JJ_MIN_VERSION}) at ${EXISTING_BIN}; not downgrading or replacing"
-    exit 0
-  else
-    if ! is_managed "${EXISTING_BIN}"; then
-      report "refuse" "${EXISTING_BIN}" "${EXISTING_VER}" \
-        "user-managed JJ ${EXISTING_VER} at ${EXISTING_BIN} is below minimum ${JJ_MIN_VERSION}; refusing to overwrite"
-      exit 1
-    fi
-  fi
+# Packaged install: delegate to the CLI (INSTALL_DIR env is honored by the installer).
+if command -v fava-trails >/dev/null 2>&1; then
+  exec fava-trails install-jj "${CLI_ARGS[@]}"
 fi
 
-if ! resolve_release "${SUFFIX}"; then
-  if [[ -n "${EXISTING_BIN}" && -n "${EXISTING_VER}" ]] && version_ge "${EXISTING_VER}" "${JJ_MIN_VERSION}" && [[ -z "${EXPLICIT}" ]]; then
-    report "reuse" "${EXISTING_BIN}" "${EXISTING_VER}" \
-      "release resolution failed; reusing compatible installed JJ ${EXISTING_VER}"
-    exit 0
-  fi
-  report "error" "${EXISTING_BIN}" "${EXISTING_VER}" \
-    "could not resolve JJ release and no compatible install available"
-  exit 1
-fi
-
-if [[ -n "${EXISTING_BIN}" && -n "${EXISTING_VER}" ]] && is_managed "${EXISTING_BIN}" && [[ "${EXISTING_VER}" == "${RESOLVED_VERSION}" ]]; then
-  report "reuse" "${EXISTING_BIN}" "${EXISTING_VER}" "managed JJ already at target ${RESOLVED_VERSION}"
-  exit 0
-fi
-
-TMPDIR="$(mktemp -d)"
-trap 'rm -rf "${TMPDIR}"' EXIT
-TARBALL="${TMPDIR}/jj.tar.gz"
-log "Downloading JJ v${RESOLVED_VERSION} (${RESOLVED_SOURCE}) for ${SUFFIX}..."
-if ! curl -fsSL --max-time "${NETWORK_TIMEOUT}" -o "${TARBALL}" "${RESOLVED_URL}"; then
-  report "error" "${EXISTING_BIN}" "${EXISTING_VER}" "download failed; prior executable preserved if present"
-  exit 1
-fi
-
-if [[ -n "${RESOLVED_SHA256}" ]]; then
-  actual="$(sha256_file "${TARBALL}")"
-  if [[ "${actual}" != "${RESOLVED_SHA256}" ]]; then
-    report "error" "${EXISTING_BIN}" "${EXISTING_VER}" "SHA-256 mismatch; prior executable preserved if present"
-    exit 1
-  fi
-fi
-
-tar -xzf "${TARBALL}" -C "${TMPDIR}"
-if [[ ! -f "${TMPDIR}/jj" ]]; then
-  # Some archives nest the binary; find leaf named jj
-  found="$(find "${TMPDIR}" -type f -name jj | head -1 || true)"
-  if [[ -z "${found}" ]]; then
-    report "error" "${EXISTING_BIN}" "${EXISTING_VER}" "jj binary not found in tarball"
-    exit 1
-  fi
-  cp "${found}" "${TMPDIR}/jj"
-fi
-chmod +x "${TMPDIR}/jj"
-
-if ! atomic_install "${TMPDIR}/jj" "${MANAGED_BINARY}" "${RESOLVED_VERSION}"; then
-  report "error" "${EXISTING_BIN}" "${EXISTING_VER}" "install failed; prior executable preserved if present"
-  exit 1
-fi
-
-integrity_note="no official digest for this tag"
-[[ -n "${RESOLVED_SHA256}" ]] && integrity_note="sha256 verified"
-report "install" "${MANAGED_BINARY}" "${RESOLVED_VERSION}" \
-  "installed JJ ${RESOLVED_VERSION} to ${MANAGED_BINARY} (resolved via ${RESOLVED_SOURCE}, ${integrity_note})"
-
-if ! command -v jj >/dev/null 2>&1; then
-  log ""
-  log "Warning: ${INSTALL_DIR} is not in your PATH."
-  log "Add it with:"
-  log "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bashrc && source ~/.bashrc"
-fi
-
-exit 0
+err "Could not find src/fava_trails/jj_install.py or the fava-trails CLI."
+err "Install the package (pip/uv) or run from a FAVA Trails source checkout."
+err "Or install JJ manually from: https://jj-vcs.github.io/jj/"
+exit 1

--- a/scripts/install-jj.sh
+++ b/scripts/install-jj.sh
@@ -12,29 +12,45 @@
 #   FORCE=1 scripts/install-jj.sh
 #   INSTALL_DIR=~/.local/bin scripts/install-jj.sh
 # Extra args are forwarded to the Python installer (--version, --force, --install-dir).
+#
+# Bash 3.2 note (macOS /bin/bash): under `set -u`, expanding an empty array via
+# "${arr[@]}" is an unbound-variable error. Build forwarded argv with `set --`
+# only — never copy or expand an empty array.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MODULE_PATH="${ROOT}/src/fava_trails/jj_install.py"
 
-ARGS=()
-if [[ -n "${JJ_VERSION:-}" ]]; then
-  ARGS+=(--version "${JJ_VERSION}")
-fi
-if [[ "${FORCE:-0}" == "1" ]]; then
-  ARGS+=(--force)
-fi
-# INSTALL_DIR is read by the Python installer via env; also pass flag for the module CLI.
-MODULE_ARGS=("${ARGS[@]}")
-if [[ -n "${INSTALL_DIR:-}" ]]; then
-  MODULE_ARGS+=(--install-dir "${INSTALL_DIR}")
-fi
-# Allow callers to pass flags directly as well.
-MODULE_ARGS+=("$@")
-CLI_ARGS=("${ARGS[@]}")
-CLI_ARGS+=("$@")
-
 err() { printf '%s\n' "$*" >&2; }
+
+# $@ starts as the original script arguments (may be empty). Prepend env-derived
+# flags via `set --` so zero-arg invocation stays valid under Bash 3.2 + set -u.
+_run_module() {
+  local py="$1"
+  shift
+  if [[ -n "${INSTALL_DIR:-}" ]]; then
+    set -- --install-dir "${INSTALL_DIR}" "$@"
+  fi
+  if [[ "${FORCE:-0}" == "1" ]]; then
+    set -- --force "$@"
+  fi
+  if [[ -n "${JJ_VERSION:-}" ]]; then
+    set -- --version "${JJ_VERSION}" "$@"
+  fi
+  export PYTHONPATH="${ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}"
+  exec "${py}" -m fava_trails.jj_install "$@"
+}
+
+_run_cli() {
+  # INSTALL_DIR is honored by the packaged CLI via env; only forward flag-like env.
+  if [[ "${FORCE:-0}" == "1" ]]; then
+    set -- --force "$@"
+  fi
+  if [[ -n "${JJ_VERSION:-}" ]]; then
+    set -- --version "${JJ_VERSION}" "$@"
+  fi
+  exec fava-trails install-jj "$@"
+}
 
 # Prefer the in-tree canonical module when this script lives in a source checkout.
 # That keeps INSTALL_DIR / policy aligned with this revision (not a stale packaged CLI).
@@ -50,13 +66,12 @@ if [[ -f "${MODULE_PATH}" ]]; then
   else
     PY="$(command -v python)"
   fi
-  export PYTHONPATH="${ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}"
-  exec "${PY}" -m fava_trails.jj_install "${MODULE_ARGS[@]}"
+  _run_module "${PY}" "$@"
 fi
 
 # Packaged install: delegate to the CLI (INSTALL_DIR env is honored by the installer).
 if command -v fava-trails >/dev/null 2>&1; then
-  exec fava-trails install-jj "${CLI_ARGS[@]}"
+  _run_cli "$@"
 fi
 
 err "Could not find src/fava_trails/jj_install.py or the fava-trails CLI."

--- a/scripts/install-jj.sh
+++ b/scripts/install-jj.sh
@@ -1,38 +1,329 @@
 #!/usr/bin/env bash
-# Install Jujutsu (JJ) pre-built binary for linux-x86_64
-# Downloads to ~/.local/bin/jj
+# Install or select Jujutsu (JJ) for FAVA Trails.
+# Policy mirrors src/fava_trails/jj_install.py (issue #98):
+#   - Reuse any installed JJ >= JJ_MIN_VERSION (never silently downgrade).
+#   - Never overwrite a user-managed executable outside ~/.local/bin/jj.
+#   - When install is needed, resolve GitHub latest stable unless JJ_VERSION is set.
+#   - Verify SHA-256 when GitHub publishes asset digests; atomic install; restore on failure.
 set -euo pipefail
 
-JJ_VERSION="${JJ_VERSION:-0.28.0}"
-INSTALL_DIR="${HOME}/.local/bin"
-BINARY="${INSTALL_DIR}/jj"
+JJ_MIN_VERSION="${JJ_MIN_VERSION:-0.28.0}"
+INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
+MANAGED_BINARY="${INSTALL_DIR}/jj"
+GITHUB_API_LATEST="https://api.github.com/repos/jj-vcs/jj/releases/latest"
+NETWORK_TIMEOUT="${NETWORK_TIMEOUT:-30}"
 
-if command -v jj &>/dev/null; then
-    echo "JJ already installed: $(jj version)"
-    exit 0
+log() { printf '%s\n' "$*"; }
+err() { printf '%s\n' "$*" >&2; }
+
+report() {
+  local action="$1" path="${2:-}" version="${3:-}" reason="$4"
+  log "action:  ${action}"
+  log "path:    ${path:-'(none)'}"
+  log "version: ${version:-'(none)'}"
+  log "reason:  ${reason}"
+}
+
+version_ge() {
+  # Return 0 if $1 >= $2 (semver X.Y.Z)
+  local a b
+  IFS=. read -r a1 a2 a3 <<<"${1}"
+  IFS=. read -r b1 b2 b3 <<<"${2}"
+  a1=${a1:-0}; a2=${a2:-0}; a3=${a3:-0}
+  b1=${b1:-0}; b2=${b2:-0}; b3=${b3:-0}
+  if (( a1 != b1 )); then (( a1 > b1 )); return; fi
+  if (( a2 != b2 )); then (( a2 > b2 )); return; fi
+  (( a3 >= b3 ))
+}
+
+parse_jj_version() {
+  # stdin or $1 → prints X.Y.Z or empty
+  local text="${1:-}"
+  if [[ -z "${text}" ]]; then
+    text="$(cat || true)"
+  fi
+  if [[ "${text}" =~ [Jj][Jj][[:space:]]+([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+  fi
+}
+
+probe_jj() {
+  local bin="$1"
+  if [[ ! -x "${bin}" ]]; then
+    return 1
+  fi
+  local out
+  out="$("${bin}" --version 2>/dev/null || true)"
+  parse_jj_version "${out}"
+}
+
+is_managed() {
+  local bin="$1"
+  local managed resolved
+  managed="$(cd "$(dirname "${MANAGED_BINARY}")" 2>/dev/null && pwd)/$(basename "${MANAGED_BINARY}")" || true
+  resolved="$(cd "$(dirname "${bin}")" 2>/dev/null && pwd)/$(basename "${bin}")" || true
+  [[ -n "${managed}" && "${resolved}" == "${managed}" ]]
+}
+
+detect_suffix() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "${os}" in
+    Linux)
+      case "${arch}" in
+        x86_64) printf '%s\n' "x86_64-unknown-linux-musl" ;;
+        aarch64|arm64) printf '%s\n' "aarch64-unknown-linux-musl" ;;
+        *) err "Unsupported Linux architecture: ${arch}"; err "Install manually from: https://jj-vcs.github.io/jj/"; return 1 ;;
+      esac
+      ;;
+    Darwin)
+      case "${arch}" in
+        x86_64) printf '%s\n' "x86_64-apple-darwin" ;;
+        arm64|aarch64) printf '%s\n' "aarch64-apple-darwin" ;;
+        *) err "Unsupported macOS architecture: ${arch}"; err "Install manually from: https://jj-vcs.github.io/jj/"; return 1 ;;
+      esac
+      ;;
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+      err "Windows detected. Install JJ with:"
+      err "  winget install Jujutsu.Jujutsu"
+      err "Or manually from: https://jj-vcs.github.io/jj/"
+      return 1
+      ;;
+    *)
+      err "Unsupported OS: ${os}"
+      err "Install manually from: https://jj-vcs.github.io/jj/"
+      return 1
+      ;;
+  esac
+}
+
+api_get() {
+  local url="$1"
+  curl -fsSL --max-time "${NETWORK_TIMEOUT}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "User-Agent: fava-trails-install-jj.sh" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "${url}"
+}
+
+resolve_release() {
+  # Sets: RESOLVED_VERSION RESOLVED_URL RESOLVED_SHA256 RESOLVED_SOURCE
+  local suffix="$1"
+  local explicit="${JJ_VERSION:-}"
+  local json tag asset_name digest url api
+
+  if [[ -n "${explicit}" ]]; then
+    explicit="${explicit#v}"
+    api="https://api.github.com/repos/jj-vcs/jj/releases/tags/v${explicit}"
+    if ! json="$(api_get "${api}")"; then
+      err "Network error resolving JJ v${explicit}"
+      return 1
+    fi
+    RESOLVED_VERSION="${explicit}"
+    RESOLVED_SOURCE="explicit"
+  else
+    if ! json="$(api_get "${GITHUB_API_LATEST}")"; then
+      err "Network error resolving latest JJ release"
+      return 1
+    fi
+    tag="$(printf '%s' "${json}" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+    tag="${tag#v}"
+    if [[ -z "${tag}" ]]; then
+      err "GitHub latest release response missing tag_name"
+      return 1
+    fi
+    RESOLVED_VERSION="${tag}"
+    RESOLVED_SOURCE="latest"
+  fi
+
+  asset_name="jj-v${RESOLVED_VERSION}-${suffix}.tar.gz"
+  RESOLVED_URL="https://github.com/jj-vcs/jj/releases/download/v${RESOLVED_VERSION}/${asset_name}"
+  RESOLVED_SHA256=""
+
+  # Prefer browser_download_url + digest from assets when present (requires python or jq).
+  if command -v python3 >/dev/null 2>&1; then
+    local parsed
+    parsed="$(JJ_JSON="${json}" JJ_ASSET="${asset_name}" python3 - <<'PY'
+import json, os
+data = json.loads(os.environ["JJ_JSON"])
+name = os.environ["JJ_ASSET"]
+url = ""
+sha = ""
+for a in data.get("assets") or []:
+    if a.get("name") == name:
+        url = a.get("browser_download_url") or ""
+        d = a.get("digest") or ""
+        if isinstance(d, str) and d.startswith("sha256:"):
+            sha = d.split(":", 1)[1].strip().lower()
+        break
+print(url)
+print(sha)
+PY
+)"
+    local p_url p_sha
+    p_url="$(printf '%s\n' "${parsed}" | sed -n '1p')"
+    p_sha="$(printf '%s\n' "${parsed}" | sed -n '2p')"
+    [[ -n "${p_url}" ]] && RESOLVED_URL="${p_url}"
+    [[ -n "${p_sha}" ]] && RESOLVED_SHA256="${p_sha}"
+  fi
+}
+
+sha256_file() {
+  local f="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${f}" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${f}" | awk '{print $1}'
+  else
+    err "No sha256sum/shasum available to verify download"
+    return 1
+  fi
+}
+
+atomic_install() {
+  local extracted="$1"
+  local dest="$2"
+  local expected="$3"
+  local staged backup got
+  mkdir -p "$(dirname "${dest}")"
+  staged="${dest}.fava-new"
+  backup="${dest}.fava-prev"
+  rm -f "${staged}"
+  cp "${extracted}" "${staged}"
+  chmod +x "${staged}"
+  got="$(probe_jj "${staged}" || true)"
+  if [[ "${got}" != "${expected}" ]]; then
+    rm -f "${staged}"
+    err "version mismatch after extract: expected ${expected}, got ${got:-unknown}"
+    return 1
+  fi
+  if [[ -e "${dest}" || -L "${dest}" ]]; then
+    rm -f "${backup}"
+    mv "${dest}" "${backup}"
+  fi
+  if ! mv "${staged}" "${dest}"; then
+    if [[ -e "${backup}" ]]; then
+      mv "${backup}" "${dest}" || true
+    fi
+    err "failed to move staged binary into place"
+    return 1
+  fi
+  got="$(probe_jj "${dest}" || true)"
+  if [[ "${got}" != "${expected}" ]]; then
+    if [[ -e "${backup}" ]]; then
+      mv "${backup}" "${dest}" || true
+    fi
+    err "post-install version verification failed"
+    return 1
+  fi
+  rm -f "${backup}"
+}
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+SUFFIX="$(detect_suffix)" || exit 1
+
+EXISTING_BIN=""
+EXISTING_VER=""
+if command -v jj >/dev/null 2>&1; then
+  EXISTING_BIN="$(command -v jj)"
+elif [[ -x "${MANAGED_BINARY}" ]]; then
+  EXISTING_BIN="${MANAGED_BINARY}"
+fi
+if [[ -n "${EXISTING_BIN}" ]]; then
+  EXISTING_VER="$(probe_jj "${EXISTING_BIN}" || true)"
 fi
 
-mkdir -p "${INSTALL_DIR}"
+FORCE="${FORCE:-0}"
+EXPLICIT="${JJ_VERSION:-}"
 
-ARCH=$(uname -m)
-case "${ARCH}" in
-    x86_64) ARCH_SUFFIX="x86_64-unknown-linux-musl" ;;
-    aarch64) ARCH_SUFFIX="aarch64-unknown-linux-musl" ;;
-    *) echo "Unsupported architecture: ${ARCH}" >&2; exit 1 ;;
-esac
+if [[ -n "${EXISTING_BIN}" && -n "${EXISTING_VER}" && "${FORCE}" != "1" ]]; then
+  if [[ -n "${EXPLICIT}" ]]; then
+    want="${EXPLICIT#v}"
+    if [[ "${EXISTING_VER}" == "${want}" ]]; then
+      report "reuse" "${EXISTING_BIN}" "${EXISTING_VER}" \
+        "exact match for requested ${want} at ${EXISTING_BIN}"
+      exit 0
+    fi
+    if ! is_managed "${EXISTING_BIN}"; then
+      report "refuse" "${EXISTING_BIN}" "${EXISTING_VER}" \
+        "user-managed JJ ${EXISTING_VER} at ${EXISTING_BIN} differs from requested ${want}; refusing to overwrite"
+      exit 1
+    fi
+  elif version_ge "${EXISTING_VER}" "${JJ_MIN_VERSION}"; then
+    report "reuse" "${EXISTING_BIN}" "${EXISTING_VER}" \
+      "compatible installed JJ ${EXISTING_VER} (>= ${JJ_MIN_VERSION}) at ${EXISTING_BIN}; not downgrading or replacing"
+    exit 0
+  else
+    if ! is_managed "${EXISTING_BIN}"; then
+      report "refuse" "${EXISTING_BIN}" "${EXISTING_VER}" \
+        "user-managed JJ ${EXISTING_VER} at ${EXISTING_BIN} is below minimum ${JJ_MIN_VERSION}; refusing to overwrite"
+      exit 1
+    fi
+  fi
+fi
 
-URL="https://github.com/jj-vcs/jj/releases/download/v${JJ_VERSION}/jj-v${JJ_VERSION}-${ARCH_SUFFIX}.tar.gz"
+if ! resolve_release "${SUFFIX}"; then
+  if [[ -n "${EXISTING_BIN}" && -n "${EXISTING_VER}" ]] && version_ge "${EXISTING_VER}" "${JJ_MIN_VERSION}" && [[ -z "${EXPLICIT}" ]]; then
+    report "reuse" "${EXISTING_BIN}" "${EXISTING_VER}" \
+      "release resolution failed; reusing compatible installed JJ ${EXISTING_VER}"
+    exit 0
+  fi
+  report "error" "${EXISTING_BIN}" "${EXISTING_VER}" \
+    "could not resolve JJ release and no compatible install available"
+  exit 1
+fi
 
-echo "Downloading JJ v${JJ_VERSION} for ${ARCH}..."
-TMPDIR=$(mktemp -d)
+if [[ -n "${EXISTING_BIN}" && -n "${EXISTING_VER}" ]] && is_managed "${EXISTING_BIN}" && [[ "${EXISTING_VER}" == "${RESOLVED_VERSION}" ]]; then
+  report "reuse" "${EXISTING_BIN}" "${EXISTING_VER}" "managed JJ already at target ${RESOLVED_VERSION}"
+  exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
 trap 'rm -rf "${TMPDIR}"' EXIT
+TARBALL="${TMPDIR}/jj.tar.gz"
+log "Downloading JJ v${RESOLVED_VERSION} (${RESOLVED_SOURCE}) for ${SUFFIX}..."
+if ! curl -fsSL --max-time "${NETWORK_TIMEOUT}" -o "${TARBALL}" "${RESOLVED_URL}"; then
+  report "error" "${EXISTING_BIN}" "${EXISTING_VER}" "download failed; prior executable preserved if present"
+  exit 1
+fi
 
-curl -fsSL "${URL}" -o "${TMPDIR}/jj.tar.gz"
-tar -xzf "${TMPDIR}/jj.tar.gz" -C "${TMPDIR}"
+if [[ -n "${RESOLVED_SHA256}" ]]; then
+  actual="$(sha256_file "${TARBALL}")"
+  if [[ "${actual}" != "${RESOLVED_SHA256}" ]]; then
+    report "error" "${EXISTING_BIN}" "${EXISTING_VER}" "SHA-256 mismatch; prior executable preserved if present"
+    exit 1
+  fi
+fi
 
-# The binary is at the root of the tarball
-cp "${TMPDIR}/jj" "${BINARY}"
-chmod +x "${BINARY}"
+tar -xzf "${TARBALL}" -C "${TMPDIR}"
+if [[ ! -f "${TMPDIR}/jj" ]]; then
+  # Some archives nest the binary; find leaf named jj
+  found="$(find "${TMPDIR}" -type f -name jj | head -1 || true)"
+  if [[ -z "${found}" ]]; then
+    report "error" "${EXISTING_BIN}" "${EXISTING_VER}" "jj binary not found in tarball"
+    exit 1
+  fi
+  cp "${found}" "${TMPDIR}/jj"
+fi
+chmod +x "${TMPDIR}/jj"
 
-echo "Installed: $(${BINARY} version)"
-echo "Make sure ${INSTALL_DIR} is in your PATH"
+if ! atomic_install "${TMPDIR}/jj" "${MANAGED_BINARY}" "${RESOLVED_VERSION}"; then
+  report "error" "${EXISTING_BIN}" "${EXISTING_VER}" "install failed; prior executable preserved if present"
+  exit 1
+fi
+
+integrity_note="no official digest for this tag"
+[[ -n "${RESOLVED_SHA256}" ]] && integrity_note="sha256 verified"
+report "install" "${MANAGED_BINARY}" "${RESOLVED_VERSION}" \
+  "installed JJ ${RESOLVED_VERSION} to ${MANAGED_BINARY} (resolved via ${RESOLVED_SOURCE}, ${integrity_note})"
+
+if ! command -v jj >/dev/null 2>&1; then
+  log ""
+  log "Warning: ${INSTALL_DIR} is not in your PATH."
+  log "Add it with:"
+  log "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bashrc && source ~/.bashrc"
+fi
+
+exit 0

--- a/src/fava_trails/cli.py
+++ b/src/fava_trails/cli.py
@@ -749,10 +749,13 @@ def cmd_install_jj(args: argparse.Namespace) -> int:
         explicit = str(explicit).strip() or None
 
     force = bool(getattr(args, "force", False))
+    install_dir = _JJ_INSTALL_DIR
+    if os.environ.get("INSTALL_DIR"):
+        install_dir = Path(os.environ["INSTALL_DIR"])
     result = select_or_install(
         explicit_version=explicit,
         force_install=force,
-        install_dir=_JJ_INSTALL_DIR,
+        install_dir=install_dir,
     )
     print(format_selection_report(result))
 

--- a/src/fava_trails/cli.py
+++ b/src/fava_trails/cli.py
@@ -5,14 +5,11 @@ from __future__ import annotations
 import argparse
 import hashlib
 import os
-import platform
 import re
 import shutil
 import signal
 import subprocess
 import sys
-import tarfile
-import tempfile
 import time
 import urllib.error
 import urllib.request
@@ -23,7 +20,19 @@ import yaml
 
 from .config import get_data_repo_root, get_trails_dir, load_global_config, sanitize_scope_path, save_global_config
 from .credentials import load_trust_gate_api_key, trust_gate_credential_description
+from .jj_install import (
+    DEFAULT_INSTALL_DIR as _JJ_INSTALL_DIR,
+)
+from .jj_install import (
+    JJ_MIN_VERSION,
+    format_selection_report,
+    path_hint,
+    select_or_install,
+)
 from .models import HookEntry, ThoughtRecord
+
+# Historical alias: installers resolve GitHub latest unless --version / JJ_VERSION is set.
+JJ_DEFAULT_VERSION = JJ_MIN_VERSION
 
 # ─── JJ binary helper ─────────────────────────────────────────────────────────
 
@@ -726,117 +735,34 @@ def cmd_cleanup_empty_scopes(args: argparse.Namespace) -> int:
 
 # ─── install-jj ───────────────────────────────────────────────────────────────
 
-JJ_DEFAULT_VERSION = "0.28.0"
-_JJ_INSTALL_DIR = Path.home() / ".local" / "bin"
-
 
 def cmd_install_jj(args: argparse.Namespace) -> int:
-    """Download and install the Jujutsu (JJ) binary."""
-    version = getattr(args, "jj_version", None) or JJ_DEFAULT_VERSION
+    """Select or install a compatible Jujutsu (JJ) binary.
 
-    # Platform detection first — Windows requires a different installer
-    os_name = sys.platform  # "linux", "darwin", "win32"
-    machine = platform.machine().lower()
+    Reuses any installed JJ at or above the supported minimum. Never silently
+    downgrades or overwrites a user-managed executable. When installation is
+    needed, resolves the current official stable release unless --version /
+    JJ_VERSION is set for reproducible environments.
+    """
+    explicit = getattr(args, "jj_version", None) or os.environ.get("JJ_VERSION") or None
+    if explicit:
+        explicit = str(explicit).strip() or None
 
-    if os_name == "win32":
-        print("Windows detected. Install JJ with:")
-        print("  winget install Jujutsu.Jujutsu")
-        print("Or manually from: https://jj-vcs.github.io/jj/")
-        return 1
+    force = bool(getattr(args, "force", False))
+    result = select_or_install(
+        explicit_version=explicit,
+        force_install=force,
+        install_dir=_JJ_INSTALL_DIR,
+    )
+    print(format_selection_report(result))
 
-    # Check if JJ is already installed at the target version
-    existing = shutil.which("jj") or str(_JJ_INSTALL_DIR / "jj")
-    if Path(existing).exists():
-        try:
-            result = subprocess.run(
-                [existing, "--version"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            installed_output = result.stdout.strip()
-            if re.search(rf"jj {re.escape(version)}(\s|$)", installed_output):
-                print(f"JJ already installed: {installed_output}")
-                return 0
-        except (OSError, subprocess.TimeoutExpired):
-            pass
+    if result.exit_code != 0:
+        print(result.reason, file=sys.stderr)
+        return result.exit_code
 
-    if os_name == "linux":
-        if machine in ("x86_64", "amd64"):
-            suffix = "x86_64-unknown-linux-musl"
-        elif machine in ("aarch64", "arm64"):
-            suffix = "aarch64-unknown-linux-musl"
-        else:
-            print(f"Unsupported Linux architecture: {machine}", file=sys.stderr)
-            print("Install manually from: https://jj-vcs.github.io/jj/", file=sys.stderr)
-            return 1
-    elif os_name == "darwin":
-        if machine in ("x86_64", "amd64"):
-            suffix = "x86_64-apple-darwin"
-        elif machine in ("arm64", "aarch64"):
-            suffix = "aarch64-apple-darwin"
-        else:
-            print(f"Unsupported macOS architecture: {machine}", file=sys.stderr)
-            print("Install manually from: https://jj-vcs.github.io/jj/", file=sys.stderr)
-            return 1
-    else:
-        print(f"Unsupported OS: {os_name}", file=sys.stderr)
-        print("Install manually from: https://jj-vcs.github.io/jj/", file=sys.stderr)
-        return 1
-
-    url = f"https://github.com/jj-vcs/jj/releases/download/v{version}/jj-v{version}-{suffix}.tar.gz"
-    print(f"Downloading JJ v{version} for {suffix}...")
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tarball = Path(tmpdir) / "jj.tar.gz"
-        try:
-            with urllib.request.urlopen(url, timeout=30) as r, open(tarball, "wb") as f:
-                shutil.copyfileobj(r, f)
-        except (urllib.error.URLError, OSError) as e:
-            print(f"Error: download failed: {e}", file=sys.stderr)
-            return 1
-
-        with tarfile.open(tarball, "r:gz") as tf:
-            # Find the jj binary member
-            members = [m for m in tf.getmembers() if Path(m.name).name == "jj"]
-            if not members:
-                print("Error: jj binary not found in tarball", file=sys.stderr)
-                return 1
-            member = members[0]
-            if not member.isfile():
-                print("Error: jj entry in tarball is not a regular file", file=sys.stderr)
-                return 1
-            # Safe extraction: read via extractfile(), write manually (avoids path traversal)
-            src_f = tf.extractfile(member)
-            if src_f is None:
-                print("Error: failed to read jj from tarball", file=sys.stderr)
-                return 1
-            extracted = Path(tmpdir) / "jj"
-            with src_f, open(extracted, "wb") as dst_f:
-                shutil.copyfileobj(src_f, dst_f)
-
-        try:
-            _JJ_INSTALL_DIR.mkdir(parents=True, exist_ok=True)
-            dest = _JJ_INSTALL_DIR / "jj"
-            shutil.copy2(extracted, dest)
-            dest.chmod(0o755)
-        except OSError as e:
-            print(f"Error: failed to install JJ to {dest}: {e}", file=sys.stderr)
-            return 1
-
-    # Verify
-    try:
-        result = subprocess.run([str(dest), "--version"], capture_output=True, text=True, timeout=5)
-        print(f"Installed: {result.stdout.strip()}")
-    except Exception as e:
-        print(f"Warning: install completed but verification failed: {e}", file=sys.stderr)
-
-    # PATH check
-    if not shutil.which("jj"):
-        shell_rc = ".zshrc" if "zsh" in os.environ.get("SHELL", "") or sys.platform == "darwin" else ".bashrc"
-        print(f"\nWarning: {_JJ_INSTALL_DIR} is not in your PATH.")
-        print("Add it with:")
-        print(f"  echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/{shell_rc} && source ~/{shell_rc}")
+    if result.action == "install" and result.path and not shutil.which("jj"):
+        print()
+        print(path_hint())
 
     return 0
 
@@ -1722,13 +1648,24 @@ def build_parser() -> argparse.ArgumentParser:
     p_cleanup.set_defaults(func=cmd_cleanup_empty_scopes)
 
     # install-jj
-    p_install_jj = subparsers.add_parser("install-jj", help="Download and install the Jujutsu (JJ) binary")
+    p_install_jj = subparsers.add_parser(
+        "install-jj",
+        help="Select or install a compatible Jujutsu (JJ) binary (reuses >= min; resolves latest stable)",
+    )
     p_install_jj.add_argument(
         "--version",
         dest="jj_version",
         default=None,
         metavar="VERSION",
-        help=f"JJ version to install (default: {JJ_DEFAULT_VERSION})",
+        help=(
+            "Exact JJ version to install (also JJ_VERSION env). "
+            f"Default: current GitHub stable. Minimum supported: {JJ_MIN_VERSION}."
+        ),
+    )
+    p_install_jj.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace the managed ~/.local/bin/jj even when a compatible JJ is already on PATH",
     )
     p_install_jj.set_defaults(func=cmd_install_jj)
 

--- a/src/fava_trails/cli.py
+++ b/src/fava_trails/cli.py
@@ -765,7 +765,7 @@ def cmd_install_jj(args: argparse.Namespace) -> int:
 
     if result.action == "install" and result.path and not shutil.which("jj"):
         print()
-        print(path_hint())
+        print(path_hint(Path(result.path).parent))
 
     return 0
 

--- a/src/fava_trails/jj_install.py
+++ b/src/fava_trails/jj_install.py
@@ -341,21 +341,39 @@ def _sha256_file(path: Path) -> str:
 
 
 def extract_jj_from_tarball(tarball: Path, dest_dir: Path) -> Path:
-    """Safely extract the jj binary member into dest_dir/jj."""
+    """Safely extract the single regular jj binary member into dest_dir/jj.
+
+    Requires exactly one candidate whose basename is ``jj``. Rejects path
+    traversal, absolute paths, non-regular entries (symlinks/dirs), and
+    ambiguous archives with multiple ``jj`` members.
+    """
     with tarfile.open(tarball, "r:gz") as tf:
-        members = [m for m in tf.getmembers() if Path(m.name).name == "jj"]
-        if not members:
+        candidates: list[tarfile.TarInfo] = []
+        for member in tf.getmembers():
+            if Path(member.name).name != "jj":
+                continue
+            member_path = Path(member.name)
+            # Any jj-named member that is unsafe or non-regular fails the archive.
+            if member_path.is_absolute() or ".." in member_path.parts:
+                raise JjInstallError(f"refusing unsafe tarball member path: {member.name!r}")
+            if not member.isfile():
+                raise JjInstallError(
+                    f"jj entry in tarball is not a regular file: {member.name!r}"
+                )
+            candidates.append(member)
+        if not candidates:
             raise JjInstallError("jj binary not found in tarball")
-        member = members[0]
-        if not member.isfile():
-            raise JjInstallError("jj entry in tarball is not a regular file")
-        # Reject path traversal / absolute paths in member name
-        member_path = Path(member.name)
-        if member_path.is_absolute() or ".." in member_path.parts:
-            raise JjInstallError(f"refusing unsafe tarball member path: {member.name!r}")
+        if len(candidates) > 1:
+            names = ", ".join(repr(m.name) for m in candidates)
+            raise JjInstallError(
+                f"ambiguous tarball: expected exactly one regular 'jj' member, "
+                f"found {len(candidates)}: {names}"
+            )
+        member = candidates[0]
         src_f = tf.extractfile(member)
         if src_f is None:
             raise JjInstallError("failed to read jj from tarball")
+        dest_dir.mkdir(parents=True, exist_ok=True)
         extracted = dest_dir / "jj"
         with src_f, open(extracted, "wb") as dst_f:
             shutil.copyfileobj(src_f, dst_f)
@@ -427,13 +445,45 @@ def atomic_install(
         raise
 
 
-def path_hint() -> str:
+def path_hint(bin_dir: Path | str | None = None) -> str:
+    """Advise adding the install directory to PATH.
+
+    ``bin_dir`` should be the directory containing the installed binary (or the
+    binary path's parent). Defaults to the managed install dir. Custom
+    ``--install-dir`` / ``INSTALL_DIR`` results must not always point at
+    ``~/.local/bin``.
+    """
+    directory = Path(bin_dir) if bin_dir is not None else DEFAULT_INSTALL_DIR
+    directory = directory.expanduser()
     shell = os.environ.get("SHELL", "")
     shell_rc = ".zshrc" if "zsh" in shell or sys.platform == "darwin" else ".bashrc"
+
+    display = str(directory)
+    path_export = f'export PATH="{directory}:$PATH"'
+    try:
+        home = Path.home().resolve()
+        resolved = directory.resolve()
+        if resolved == (home / ".local" / "bin"):
+            display = "~/.local/bin"
+            path_export = 'export PATH="$HOME/.local/bin:$PATH"'
+        else:
+            try:
+                rel = resolved.relative_to(home)
+            except ValueError:
+                display = str(resolved)
+                path_export = f'export PATH="{resolved}:$PATH"'
+            else:
+                rel_s = rel.as_posix()
+                display = f"~/{rel_s}"
+                path_export = f'export PATH="$HOME/{rel_s}:$PATH"'
+    except OSError:
+        display = str(directory)
+        path_export = f'export PATH="{directory}:$PATH"'
+
     return (
-        f"Warning: {DEFAULT_INSTALL_DIR} is not in your PATH.\n"
+        f"Warning: {display} is not in your PATH.\n"
         "Add it with:\n"
-        f'  echo \'export PATH="$HOME/.local/bin:$PATH"\' >> ~/{shell_rc} && source ~/{shell_rc}'
+        f"  echo '{path_export}' >> ~/{shell_rc} && source ~/{shell_rc}"
     )
 
 
@@ -683,7 +733,7 @@ def main(argv: list[str] | None = None) -> int:
         return result.exit_code
     if result.action == "install" and result.path and not shutil.which("jj"):
         print()
-        print(path_hint())
+        print(path_hint(Path(result.path).parent))
     return 0
 
 

--- a/src/fava_trails/jj_install.py
+++ b/src/fava_trails/jj_install.py
@@ -17,6 +17,7 @@ import json
 import os
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -398,9 +399,16 @@ def atomic_install(
     *,
     expected_version: Version,
 ) -> ExistingJj:
-    """Install extracted binary at dest atomically; restore prior binary on failure."""
+    """Install extracted binary at dest atomically; restore prior binary on failure.
+
+    Once ``dest`` has been replaced, any failure (including post-replace
+    verification) either restores the prior managed binary from backup or, on a
+    fresh install with no prior, removes the failed destination so an invalid
+    unverified executable is not left behind.
+    """
     dest.parent.mkdir(parents=True, exist_ok=True)
     backup: Path | None = None
+    replaced = False
     staged = dest.with_name(dest.name + ".fava-new")
     try:
         # Stage next to dest so os.replace is same-filesystem atomic.
@@ -417,6 +425,7 @@ def atomic_install(
             os.replace(dest, backup)
 
         os.replace(staged, dest)
+        replaced = True
         final = verify_executable_version(dest, expected_version)
         if backup is not None and backup.exists():
             backup.unlink()
@@ -427,14 +436,22 @@ def atomic_install(
             managed=True,
         )
     except Exception:
-        # Best-effort restore of the prior managed binary after *any* failure once
-        # replacement began — including post-replace verification when dest already
-        # holds the failed new bytes (must not require `not dest.exists()`).
+        # Best-effort cleanup after *any* failure once replacement began —
+        # including post-replace verification when dest already holds the failed
+        # new bytes (must not require `not dest.exists()`).
         if backup is not None and backup.exists():
             try:
                 os.replace(backup, dest)
             except OSError:
                 # Best-effort restore only; the original install failure is re-raised.
+                pass
+        elif replaced:
+            # Fresh install: no prior binary to restore — remove failed dest.
+            try:
+                if dest.exists() or dest.is_symlink():
+                    dest.unlink()
+            except OSError:
+                # Best-effort removal only; the original install failure is re-raised.
                 pass
         if staged.exists():
             try:
@@ -451,7 +468,8 @@ def path_hint(bin_dir: Path | str | None = None) -> str:
     ``bin_dir`` should be the directory containing the installed binary (or the
     binary path's parent). Defaults to the managed install dir. Custom
     ``--install-dir`` / ``INSTALL_DIR`` results must not always point at
-    ``~/.local/bin``.
+    ``~/.local/bin``. Suggested shell commands use ``shlex.quote`` so paths with
+    apostrophes or other metacharacters remain literal.
     """
     directory = Path(bin_dir) if bin_dir is not None else DEFAULT_INSTALL_DIR
     directory = directory.expanduser()
@@ -459,6 +477,8 @@ def path_hint(bin_dir: Path | str | None = None) -> str:
     shell_rc = ".zshrc" if "zsh" in shell or sys.platform == "darwin" else ".bashrc"
 
     # Assign display/path_export once per control-flow path (no dead pre-init).
+    # Export always quotes the directory with shlex so shell-sensitive characters
+    # (apostrophes, spaces, $, etc.) stay literal; echo of the export is also quoted.
     try:
         home = Path.home().resolve()
         resolved = directory.resolve()
@@ -468,21 +488,19 @@ def path_hint(bin_dir: Path | str | None = None) -> str:
         else:
             try:
                 rel = resolved.relative_to(home)
+                display = f"~/{rel.as_posix()}"
             except ValueError:
                 display = str(resolved)
-                path_export = f'export PATH="{resolved}:$PATH"'
-            else:
-                rel_s = rel.as_posix()
-                display = f"~/{rel_s}"
-                path_export = f'export PATH="$HOME/{rel_s}:$PATH"'
+            path_export = f"export PATH={shlex.quote(str(resolved))}:\"$PATH\""
     except OSError:
         display = str(directory)
-        path_export = f'export PATH="{directory}:$PATH"'
+        path_export = f"export PATH={shlex.quote(str(directory))}:\"$PATH\""
 
+    echo_cmd = f"echo {shlex.quote(path_export)} >> ~/{shell_rc} && source ~/{shell_rc}"
     return (
         f"Warning: {display} is not in your PATH.\n"
         "Add it with:\n"
-        f"  echo '{path_export}' >> ~/{shell_rc} && source ~/{shell_rc}"
+        f"  {echo_cmd}"
     )
 
 

--- a/src/fava_trails/jj_install.py
+++ b/src/fava_trails/jj_install.py
@@ -1,0 +1,616 @@
+"""Install and select a Jujutsu (JJ) binary for FAVA Trails.
+
+Policy (issue #98):
+- Supported minimum is JJ_MIN_VERSION (integration-tested).
+- Reuse any installed JJ at or above the minimum; never silently downgrade.
+- Never overwrite a user-managed executable outside the managed install path.
+- When installation is needed, resolve the current official GitHub stable release
+  unless an explicit version override is provided (CLI --version / JJ_VERSION).
+- Validate downloads with official GitHub asset digests when available, install
+  atomically, verify the resulting binary, and restore the prior binary on failure.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+# Floor supported by FAVA Trails integration tests (see docs/jj-compatibility.md).
+JJ_MIN_VERSION = "0.28.0"
+
+# Managed install location — the only path installers will replace in-place.
+DEFAULT_INSTALL_DIR = Path.home() / ".local" / "bin"
+MANAGED_BINARY_NAME = "jj"
+
+GITHUB_API_LATEST = "https://api.github.com/repos/jj-vcs/jj/releases/latest"
+GITHUB_API_TAG = "https://api.github.com/repos/jj-vcs/jj/releases/tags/v{version}"
+GITHUB_ASSET_URL = (
+    "https://github.com/jj-vcs/jj/releases/download/v{version}/jj-v{version}-{suffix}.tar.gz"
+)
+
+_VERSION_RE = re.compile(r"\bjj\s+(\d+\.\d+\.\d+)\b", re.IGNORECASE)
+_NETWORK_TIMEOUT_S = 30
+
+
+class JjInstallError(Exception):
+    """User-facing installer failure (message already actionable)."""
+
+
+@dataclass(frozen=True)
+class Version:
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def parse(cls, text: str) -> Version:
+        parts = text.strip().lstrip("vV").split(".")
+        if len(parts) < 3:
+            raise ValueError(f"invalid version: {text!r}")
+        try:
+            return cls(int(parts[0]), int(parts[1]), int(parts[2]))
+        except ValueError as e:
+            raise ValueError(f"invalid version: {text!r}") from e
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+    def __ge__(self, other: Version) -> bool:
+        return (self.major, self.minor, self.patch) >= (other.major, other.minor, other.patch)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return NotImplemented
+        return (self.major, self.minor, self.patch) == (other.major, other.minor, other.patch)
+
+
+@dataclass(frozen=True)
+class ExistingJj:
+    path: Path
+    version: Version
+    raw_version_line: str
+    managed: bool
+
+
+@dataclass(frozen=True)
+class PlatformTarget:
+    os_name: str
+    machine: str
+    suffix: str
+
+
+@dataclass(frozen=True)
+class ReleaseAsset:
+    version: str
+    url: str
+    sha256: str | None
+    source: str  # "explicit" | "latest" | "override-env"
+
+
+@dataclass(frozen=True)
+class SelectionResult:
+    """Outcome of selecting or installing a JJ binary."""
+
+    action: str  # reuse | install | refuse | error
+    path: str | None
+    version: str | None
+    reason: str
+    exit_code: int = 0
+
+
+def managed_jj_path(install_dir: Path | None = None) -> Path:
+    return (install_dir or DEFAULT_INSTALL_DIR) / MANAGED_BINARY_NAME
+
+
+def parse_version_from_output(output: str) -> Version | None:
+    match = _VERSION_RE.search(output or "")
+    if not match:
+        return None
+    try:
+        return Version.parse(match.group(1))
+    except ValueError:
+        return None
+
+
+def is_compatible(version: Version, minimum: Version | None = None) -> bool:
+    floor = minimum or Version.parse(JJ_MIN_VERSION)
+    return version >= floor
+
+
+def detect_platform(
+    os_name: str | None = None,
+    machine: str | None = None,
+) -> PlatformTarget:
+    os_name = (os_name or sys.platform).lower()
+    machine = (machine or platform.machine()).lower()
+
+    if os_name.startswith("win"):
+        raise JjInstallError(
+            "Windows detected. Install JJ with:\n"
+            "  winget install Jujutsu.Jujutsu\n"
+            "Or manually from: https://jj-vcs.github.io/jj/"
+        )
+
+    if os_name.startswith("linux"):
+        if machine in ("x86_64", "amd64"):
+            suffix = "x86_64-unknown-linux-musl"
+        elif machine in ("aarch64", "arm64"):
+            suffix = "aarch64-unknown-linux-musl"
+        else:
+            raise JjInstallError(
+                f"Unsupported Linux architecture: {machine}\n"
+                "Install manually from: https://jj-vcs.github.io/jj/"
+            )
+        return PlatformTarget(os_name="linux", machine=machine, suffix=suffix)
+
+    if os_name == "darwin":
+        if machine in ("x86_64", "amd64"):
+            suffix = "x86_64-apple-darwin"
+        elif machine in ("arm64", "aarch64"):
+            suffix = "aarch64-apple-darwin"
+        else:
+            raise JjInstallError(
+                f"Unsupported macOS architecture: {machine}\n"
+                "Install manually from: https://jj-vcs.github.io/jj/"
+            )
+        return PlatformTarget(os_name="darwin", machine=machine, suffix=suffix)
+
+    raise JjInstallError(
+        f"Unsupported OS: {os_name}\nInstall manually from: https://jj-vcs.github.io/jj/"
+    )
+
+
+def find_jj_candidates(install_dir: Path | None = None) -> list[Path]:
+    """Return candidate jj paths in preference order (PATH first, then managed)."""
+    seen: set[str] = set()
+    out: list[Path] = []
+    which = shutil.which("jj")
+    if which:
+        p = Path(which).resolve()
+        key = str(p)
+        if key not in seen:
+            seen.add(key)
+            out.append(p)
+    managed = managed_jj_path(install_dir)
+    if managed.is_file():
+        p = managed.resolve()
+        key = str(p)
+        if key not in seen:
+            seen.add(key)
+            out.append(p)
+    return out
+
+
+def probe_jj(
+    path: Path,
+    *,
+    timeout: float = 5.0,
+    install_dir: Path | None = None,
+) -> ExistingJj | None:
+    try:
+        result = subprocess.run(
+            [str(path), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    line = (result.stdout or result.stderr or "").strip().splitlines()
+    raw = line[0] if line else ""
+    version = parse_version_from_output(raw) or parse_version_from_output(result.stdout or "")
+    if version is None:
+        return None
+    managed = _is_managed_path(path, install_dir=install_dir)
+    return ExistingJj(path=path, version=version, raw_version_line=raw or f"jj {version}", managed=managed)
+
+
+def _is_managed_path(path: Path, install_dir: Path | None = None) -> bool:
+    try:
+        return path.resolve() == managed_jj_path(install_dir).resolve()
+    except OSError:
+        return False
+
+
+def discover_existing(install_dir: Path | None = None) -> ExistingJj | None:
+    for candidate in find_jj_candidates(install_dir):
+        probed = probe_jj(candidate, install_dir=install_dir)
+        if probed is not None:
+            return probed
+    return None
+
+
+def _http_get_json(url: str, *, timeout: float = _NETWORK_TIMEOUT_S) -> dict:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "fava-trails-install-jj",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as e:
+        raise JjInstallError(f"GitHub API request failed ({e.code}) for {url}: {e.reason}") from e
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        raise JjInstallError(f"Network error resolving JJ release ({url}): {e}") from e
+    try:
+        return json.loads(body.decode("utf-8"))
+    except json.JSONDecodeError as e:
+        raise JjInstallError(f"Invalid JSON from GitHub API ({url})") from e
+
+
+def _http_download(url: str, dest: Path, *, timeout: float = _NETWORK_TIMEOUT_S) -> None:
+    req = urllib.request.Request(url, headers={"User-Agent": "fava-trails-install-jj"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp, open(dest, "wb") as f:
+            shutil.copyfileobj(resp, f)
+    except urllib.error.HTTPError as e:
+        raise JjInstallError(f"Download failed ({e.code}) for {url}: {e.reason}") from e
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        raise JjInstallError(f"Download failed for {url}: {e}") from e
+
+
+def resolve_release(
+    explicit_version: str | None,
+    *,
+    platform_target: PlatformTarget,
+    fetch_json=_http_get_json,
+) -> ReleaseAsset:
+    """Resolve which JJ release to install.
+
+    explicit_version wins (CLI --version or JJ_VERSION). Otherwise query GitHub
+    latest stable. Never freezes a permanent default patch version in code.
+    """
+    if explicit_version:
+        version = explicit_version.lstrip("vV")
+        # Validate shape early
+        Version.parse(version)
+        data = fetch_json(GITHUB_API_TAG.format(version=version))
+        return _asset_from_release_payload(
+            data,
+            version=version,
+            suffix=platform_target.suffix,
+            source="explicit",
+        )
+
+    data = fetch_json(GITHUB_API_LATEST)
+    tag = str(data.get("tag_name") or "")
+    version = tag.lstrip("vV")
+    if not version:
+        raise JjInstallError("GitHub latest release response missing tag_name")
+    Version.parse(version)
+    return _asset_from_release_payload(
+        data,
+        version=version,
+        suffix=platform_target.suffix,
+        source="latest",
+    )
+
+
+def _asset_from_release_payload(
+    data: dict,
+    *,
+    version: str,
+    suffix: str,
+    source: str,
+) -> ReleaseAsset:
+    asset_name = f"jj-v{version}-{suffix}.tar.gz"
+    sha256: str | None = None
+    url = GITHUB_ASSET_URL.format(version=version, suffix=suffix)
+    for asset in data.get("assets") or []:
+        if not isinstance(asset, dict):
+            continue
+        if asset.get("name") != asset_name:
+            continue
+        browser = asset.get("browser_download_url")
+        if isinstance(browser, str) and browser:
+            url = browser
+        digest = asset.get("digest")
+        if isinstance(digest, str) and digest.startswith("sha256:"):
+            sha256 = digest.split(":", 1)[1].strip().lower()
+        break
+    return ReleaseAsset(version=version, url=url, sha256=sha256, source=source)
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def extract_jj_from_tarball(tarball: Path, dest_dir: Path) -> Path:
+    """Safely extract the jj binary member into dest_dir/jj."""
+    with tarfile.open(tarball, "r:gz") as tf:
+        members = [m for m in tf.getmembers() if Path(m.name).name == "jj"]
+        if not members:
+            raise JjInstallError("jj binary not found in tarball")
+        member = members[0]
+        if not member.isfile():
+            raise JjInstallError("jj entry in tarball is not a regular file")
+        # Reject path traversal / absolute paths in member name
+        member_path = Path(member.name)
+        if member_path.is_absolute() or ".." in member_path.parts:
+            raise JjInstallError(f"refusing unsafe tarball member path: {member.name!r}")
+        src_f = tf.extractfile(member)
+        if src_f is None:
+            raise JjInstallError("failed to read jj from tarball")
+        extracted = dest_dir / "jj"
+        with src_f, open(extracted, "wb") as dst_f:
+            shutil.copyfileobj(src_f, dst_f)
+    extracted.chmod(0o755)
+    return extracted
+
+
+def verify_executable_version(path: Path, expected: Version | None = None) -> Version:
+    probed = probe_jj(path)
+    if probed is None:
+        raise JjInstallError(f"installed binary at {path} failed --version probe")
+    if expected is not None and probed.version != expected:
+        raise JjInstallError(
+            f"version mismatch after install: expected {expected}, got {probed.version}"
+        )
+    return probed.version
+
+
+def atomic_install(
+    extracted: Path,
+    dest: Path,
+    *,
+    expected_version: Version,
+) -> ExistingJj:
+    """Install extracted binary at dest atomically; restore prior binary on failure."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    backup: Path | None = None
+    staged = dest.with_name(dest.name + ".fava-new")
+    try:
+        # Stage next to dest so os.replace is same-filesystem atomic.
+        if staged.exists():
+            staged.unlink()
+        shutil.copy2(extracted, staged)
+        staged.chmod(0o755)
+        verify_executable_version(staged, expected_version)
+
+        if dest.exists() or dest.is_symlink():
+            backup = dest.with_name(dest.name + ".fava-prev")
+            if backup.exists():
+                backup.unlink()
+            os.replace(dest, backup)
+
+        os.replace(staged, dest)
+        final = verify_executable_version(dest, expected_version)
+        if backup is not None and backup.exists():
+            backup.unlink()
+        return ExistingJj(
+            path=dest,
+            version=final,
+            raw_version_line=f"jj {final}",
+            managed=True,
+        )
+    except Exception:
+        # Best-effort restore
+        if backup is not None and backup.exists() and not dest.exists():
+            try:
+                os.replace(backup, dest)
+            except OSError:
+                pass
+        if staged.exists():
+            try:
+                staged.unlink()
+            except OSError:
+                pass
+        raise
+
+
+def path_hint() -> str:
+    shell = os.environ.get("SHELL", "")
+    shell_rc = ".zshrc" if "zsh" in shell or sys.platform == "darwin" else ".bashrc"
+    return (
+        f"Warning: {DEFAULT_INSTALL_DIR} is not in your PATH.\n"
+        "Add it with:\n"
+        f'  echo \'export PATH="$HOME/.local/bin:$PATH"\' >> ~/{shell_rc} && source ~/{shell_rc}'
+    )
+
+
+def select_or_install(
+    *,
+    explicit_version: str | None = None,
+    install_dir: Path | None = None,
+    force_install: bool = False,
+    fetch_json=_http_get_json,
+    download=_http_download,
+    os_name: str | None = None,
+    machine: str | None = None,
+    which_jj: str | None | object = ...,  # test seam; ellipsis = live discovery
+) -> SelectionResult:
+    """Main entry: reuse compatible JJ or install current stable / override.
+
+    Returns SelectionResult with action, path, version, reason, exit_code.
+    Does not print; callers format user-facing messages.
+    """
+    install_dir = install_dir or DEFAULT_INSTALL_DIR
+    min_version = Version.parse(JJ_MIN_VERSION)
+
+    try:
+        platform_target = detect_platform(os_name=os_name, machine=machine)
+    except JjInstallError as e:
+        return SelectionResult(action="error", path=None, version=None, reason=str(e), exit_code=1)
+
+    # Discover existing
+    existing: ExistingJj | None = None
+    if which_jj is ...:
+        existing = discover_existing(install_dir)
+    elif which_jj is None:
+        existing = None
+    else:
+        existing = probe_jj(Path(str(which_jj)), install_dir=install_dir)
+
+    # Reuse rules
+    if existing is not None and not force_install:
+        if explicit_version:
+            want = Version.parse(explicit_version.lstrip("vV"))
+            if existing.version == want:
+                return SelectionResult(
+                    action="reuse",
+                    path=str(existing.path),
+                    version=str(existing.version),
+                    reason=(
+                        f"exact match for requested {want} at {existing.path} "
+                        f"({'managed' if existing.managed else 'user-managed'})"
+                    ),
+                    exit_code=0,
+                )
+            if not existing.managed:
+                return SelectionResult(
+                    action="refuse",
+                    path=str(existing.path),
+                    version=str(existing.version),
+                    reason=(
+                        f"user-managed JJ {existing.version} at {existing.path} differs from "
+                        f"requested {want}; refusing to overwrite. Uninstall/move it, or put "
+                        f"{managed_jj_path(install_dir)} first on PATH after installing there."
+                    ),
+                    exit_code=1,
+                )
+            # Managed path, wrong version → install override below
+        elif is_compatible(existing.version, min_version):
+            return SelectionResult(
+                action="reuse",
+                path=str(existing.path),
+                version=str(existing.version),
+                reason=(
+                    f"compatible installed JJ {existing.version} (>= {min_version}) at "
+                    f"{existing.path}; not downgrading or replacing"
+                ),
+                exit_code=0,
+            )
+        else:
+            # Incompatible older
+            if not existing.managed:
+                return SelectionResult(
+                    action="refuse",
+                    path=str(existing.path),
+                    version=str(existing.version),
+                    reason=(
+                        f"user-managed JJ {existing.version} at {existing.path} is below "
+                        f"minimum {min_version}; refusing to overwrite. Upgrade via your "
+                        f"package manager, or remove it from PATH and re-run install-jj."
+                    ),
+                    exit_code=1,
+                )
+            # Managed but too old → upgrade path below
+
+    # Resolve target release (needs network unless we already returned)
+    try:
+        release = resolve_release(
+            explicit_version,
+            platform_target=platform_target,
+            fetch_json=fetch_json,
+        )
+    except JjInstallError as e:
+        # Offline / API failure: if we still have something usable, say so clearly
+        if existing is not None and is_compatible(existing.version, min_version) and not explicit_version:
+            return SelectionResult(
+                action="reuse",
+                path=str(existing.path),
+                version=str(existing.version),
+                reason=(
+                    f"release resolution failed ({e}); reusing compatible installed "
+                    f"JJ {existing.version} at {existing.path}"
+                ),
+                exit_code=0,
+            )
+        return SelectionResult(
+            action="error",
+            path=str(existing.path) if existing else None,
+            version=str(existing.version) if existing else None,
+            reason=(
+                f"could not resolve JJ release and no compatible install available: {e}"
+            ),
+            exit_code=1,
+        )
+
+    expected = Version.parse(release.version)
+    dest = managed_jj_path(install_dir)
+
+    # If existing managed and already exact target, reuse
+    if existing is not None and existing.managed and existing.version == expected:
+        return SelectionResult(
+            action="reuse",
+            path=str(existing.path),
+            version=str(existing.version),
+            reason=f"managed JJ already at target {expected}",
+            exit_code=0,
+        )
+
+    # Download + install
+    try:
+        with tempfile.TemporaryDirectory(prefix="fava-jj-") as tmp:
+            tmp_path = Path(tmp)
+            tarball = tmp_path / "jj.tar.gz"
+            download(release.url, tarball)
+            if release.sha256:
+                actual = _sha256_file(tarball)
+                if actual != release.sha256:
+                    raise JjInstallError(
+                        f"SHA-256 mismatch for {release.url}: expected {release.sha256}, got {actual}"
+                    )
+            extracted = extract_jj_from_tarball(tarball, tmp_path)
+            installed = atomic_install(extracted, dest, expected_version=expected)
+    except JjInstallError as e:
+        return SelectionResult(
+            action="error",
+            path=str(existing.path) if existing else None,
+            version=str(existing.version) if existing else None,
+            reason=f"install failed (prior executable preserved if present): {e}",
+            exit_code=1,
+        )
+    except Exception as e:
+        return SelectionResult(
+            action="error",
+            path=str(existing.path) if existing else None,
+            version=str(existing.version) if existing else None,
+            reason=f"install failed (prior executable preserved if present): {e}",
+            exit_code=1,
+        )
+
+    reason = (
+        f"installed JJ {installed.version} to {installed.path} "
+        f"(resolved via {release.source}"
+        f"{', sha256 verified' if release.sha256 else ', no official digest for this tag'}"
+        f")"
+    )
+    return SelectionResult(
+        action="install",
+        path=str(installed.path),
+        version=str(installed.version),
+        reason=reason,
+        exit_code=0,
+    )
+
+
+def format_selection_report(result: SelectionResult) -> str:
+    parts = [
+        f"action:  {result.action}",
+        f"path:    {result.path or '(none)'}",
+        f"version: {result.version or '(none)'}",
+        f"reason:  {result.reason}",
+    ]
+    return "\n".join(parts)

--- a/src/fava_trails/jj_install.py
+++ b/src/fava_trails/jj_install.py
@@ -25,6 +25,7 @@ import tempfile
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
+from functools import total_ordering
 from pathlib import Path
 
 # Floor supported by FAVA Trails integration tests (see docs/jj-compatibility.md).
@@ -48,6 +49,7 @@ class JjInstallError(Exception):
     """User-facing installer failure (message already actionable)."""
 
 
+@total_ordering
 @dataclass(frozen=True)
 class Version:
     major: int
@@ -67,8 +69,10 @@ class Version:
     def __str__(self) -> str:
         return f"{self.major}.{self.minor}.{self.patch}"
 
-    def __ge__(self, other: Version) -> bool:
-        return (self.major, self.minor, self.patch) >= (other.major, other.minor, other.patch)
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return NotImplemented
+        return (self.major, self.minor, self.patch) < (other.major, other.minor, other.patch)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Version):
@@ -410,11 +414,13 @@ def atomic_install(
             try:
                 os.replace(backup, dest)
             except OSError:
+                # Best-effort restore only; the original install failure is re-raised.
                 pass
         if staged.exists():
             try:
                 staged.unlink()
             except OSError:
+                # Staged leftover cleanup is best-effort; original failure is re-raised.
                 pass
         raise
 

--- a/src/fava_trails/jj_install.py
+++ b/src/fava_trails/jj_install.py
@@ -458,8 +458,7 @@ def path_hint(bin_dir: Path | str | None = None) -> str:
     shell = os.environ.get("SHELL", "")
     shell_rc = ".zshrc" if "zsh" in shell or sys.platform == "darwin" else ".bashrc"
 
-    display = str(directory)
-    path_export = f'export PATH="{directory}:$PATH"'
+    # Assign display/path_export once per control-flow path (no dead pre-init).
     try:
         home = Path.home().resolve()
         resolved = directory.resolve()

--- a/src/fava_trails/jj_install.py
+++ b/src/fava_trails/jj_install.py
@@ -81,6 +81,14 @@ class Version:
         return (self.major, self.minor, self.patch) == (other.major, other.minor, other.patch)
 
 
+def require_version(text: str, *, what: str = "JJ version") -> Version:
+    """Parse a version string, raising JjInstallError on invalid input."""
+    try:
+        return Version.parse(text)
+    except ValueError as e:
+        raise JjInstallError(f"invalid {what}: {text!r}") from e
+
+
 @dataclass(frozen=True)
 class ExistingJj:
     path: Path
@@ -284,8 +292,8 @@ def resolve_release(
     """
     if explicit_version:
         version = explicit_version.lstrip("vV")
-        # Validate shape early
-        Version.parse(version)
+        # Validate shape early (JjInstallError, not bare ValueError).
+        require_version(version, what="JJ version override")
         data = fetch_json(GITHUB_API_TAG.format(version=version))
         return _asset_from_release_payload(
             data,
@@ -299,7 +307,7 @@ def resolve_release(
     version = tag.lstrip("vV")
     if not version:
         raise JjInstallError("GitHub latest release response missing tag_name")
-    Version.parse(version)
+    require_version(version, what="GitHub latest release tag")
     return _asset_from_release_payload(
         data,
         version=version,
@@ -523,6 +531,24 @@ def select_or_install(
     install_dir = install_dir or DEFAULT_INSTALL_DIR
     min_version = Version.parse(JJ_MIN_VERSION)
 
+    # Validate CLI / JJ_VERSION overrides once at the selection boundary so callers
+    # get a structured SelectionResult instead of a bare ValueError traceback.
+    want_explicit: Version | None = None
+    if explicit_version is not None:
+        try:
+            want_explicit = require_version(
+                explicit_version.lstrip("vV"),
+                what="JJ version override",
+            )
+        except JjInstallError as e:
+            return SelectionResult(
+                action="error",
+                path=None,
+                version=None,
+                reason=str(e),
+                exit_code=1,
+            )
+
     # Discover existing *before* platform/download checks so compatible reuse works
     # even on hosts with no FAVA-downloadable JJ asset (issue #98).
     existing: ExistingJj | None = None
@@ -535,8 +561,8 @@ def select_or_install(
 
     # Reuse rules
     if existing is not None and not force_install:
-        if explicit_version:
-            want = Version.parse(explicit_version.lstrip("vV"))
+        if want_explicit is not None:
+            want = want_explicit
             if existing.version == want:
                 return SelectionResult(
                     action="reuse",
@@ -630,7 +656,16 @@ def select_or_install(
             exit_code=1,
         )
 
-    expected = Version.parse(release.version)
+    try:
+        expected = require_version(release.version, what="resolved JJ release version")
+    except JjInstallError as e:
+        return SelectionResult(
+            action="error",
+            path=str(existing.path) if existing else None,
+            version=str(existing.version) if existing else None,
+            reason=str(e),
+            exit_code=1,
+        )
     dest = managed_jj_path(install_dir)
 
     # If existing managed and already exact target, reuse

--- a/src/fava_trails/jj_install.py
+++ b/src/fava_trails/jj_install.py
@@ -409,8 +409,10 @@ def atomic_install(
             managed=True,
         )
     except Exception:
-        # Best-effort restore
-        if backup is not None and backup.exists() and not dest.exists():
+        # Best-effort restore of the prior managed binary after *any* failure once
+        # replacement began — including post-replace verification when dest already
+        # holds the failed new bytes (must not require `not dest.exists()`).
+        if backup is not None and backup.exists():
             try:
                 os.replace(backup, dest)
             except OSError:
@@ -454,12 +456,8 @@ def select_or_install(
     install_dir = install_dir or DEFAULT_INSTALL_DIR
     min_version = Version.parse(JJ_MIN_VERSION)
 
-    try:
-        platform_target = detect_platform(os_name=os_name, machine=machine)
-    except JjInstallError as e:
-        return SelectionResult(action="error", path=None, version=None, reason=str(e), exit_code=1)
-
-    # Discover existing
+    # Discover existing *before* platform/download checks so compatible reuse works
+    # even on hosts with no FAVA-downloadable JJ asset (issue #98).
     existing: ExistingJj | None = None
     if which_jj is ...:
         existing = discover_existing(install_dir)
@@ -522,6 +520,18 @@ def select_or_install(
                     exit_code=1,
                 )
             # Managed but too old → upgrade path below
+
+    # Platform detection only when installation (download) is actually required.
+    try:
+        platform_target = detect_platform(os_name=os_name, machine=machine)
+    except JjInstallError as e:
+        return SelectionResult(
+            action="error",
+            path=str(existing.path) if existing else None,
+            version=str(existing.version) if existing else None,
+            reason=str(e),
+            exit_code=1,
+        )
 
     # Resolve target release (needs network unless we already returned)
     try:
@@ -620,3 +630,62 @@ def format_selection_report(result: SelectionResult) -> str:
         f"reason:  {result.reason}",
     ]
     return "\n".join(parts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry for `python -m fava_trails.jj_install` and scripts/install-jj.sh."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="fava-trails-jj-install",
+        description=(
+            "Select or install a compatible Jujutsu (JJ) binary for FAVA Trails. "
+            "Reuses any installed JJ at or above the supported minimum; never silently "
+            "downgrades or overwrites a user-managed executable."
+        ),
+    )
+    parser.add_argument(
+        "--version",
+        dest="jj_version",
+        default=None,
+        help="Install this exact JJ version (also via JJ_VERSION). Default: GitHub latest stable.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=f"Replace the managed {DEFAULT_INSTALL_DIR / MANAGED_BINARY_NAME} even when a compatible JJ is on PATH.",
+    )
+    parser.add_argument(
+        "--install-dir",
+        default=None,
+        help=f"Managed install directory (default: {DEFAULT_INSTALL_DIR}, or INSTALL_DIR env).",
+    )
+    args = parser.parse_args(argv)
+
+    explicit = args.jj_version or os.environ.get("JJ_VERSION") or None
+    if explicit:
+        explicit = str(explicit).strip() or None
+
+    install_dir: Path | None = None
+    if args.install_dir:
+        install_dir = Path(args.install_dir)
+    elif os.environ.get("INSTALL_DIR"):
+        install_dir = Path(os.environ["INSTALL_DIR"])
+
+    result = select_or_install(
+        explicit_version=explicit,
+        force_install=bool(args.force),
+        install_dir=install_dir,
+    )
+    print(format_selection_report(result))
+    if result.exit_code != 0:
+        print(result.reason, file=sys.stderr)
+        return result.exit_code
+    if result.action == "install" and result.path and not shutil.which("jj"):
+        print()
+        print(path_hint())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -846,48 +846,47 @@ def test_bootstrap_refuses_existing_config(tmp_path):
 # ─── install-jj tests ─────────────────────────────────────────────────────────
 
 
-def _make_install_jj_args(version=None):
+def _make_install_jj_args(version=None, force=False):
     args = MagicMock()
     args.jj_version = version
+    args.force = force
     return args
 
 
-def test_install_jj_skips_if_version_matches(tmp_path, capsys):
-    """install-jj exits 0 without downloading when the installed version matches."""
-    jj_bin = str(tmp_path / "jj")
-    Path(jj_bin).touch()
+def test_install_jj_reuses_compatible_version(tmp_path, capsys):
+    """install-jj exits 0 without downloading when installed JJ is >= minimum."""
+    jj_bin = tmp_path / "jj"
+    jj_bin.write_text("#!/bin/sh\necho 'jj 0.45.1'\n")
+    jj_bin.chmod(0o755)
 
-    mock_result = MagicMock()
-    mock_result.stdout = "jj 0.28.0\n"
-    mock_result.returncode = 0
-
-    with patch("shutil.which", return_value=jj_bin):
-        with patch("subprocess.run", return_value=mock_result):
+    with patch("fava_trails.jj_install.find_jj_candidates", return_value=[jj_bin]):
+        with patch("fava_trails.cli._JJ_INSTALL_DIR", tmp_path / "managed"):
             rc = cmd_install_jj(_make_install_jj_args())
 
     assert rc == 0
     out = capsys.readouterr().out
-    assert "already installed" in out
+    assert "reuse" in out
+    assert "0.45.1" in out
 
 
 def test_install_jj_unsupported_platform(capsys):
     """install-jj exits 1 on Windows and prints winget instructions."""
-    with patch("sys.platform", "win32"):
-        with patch("shutil.which", return_value=None):
-            rc = cmd_install_jj(_make_install_jj_args())
+    with patch("fava_trails.jj_install.sys.platform", "win32"):
+        with patch("fava_trails.jj_install.platform.machine", return_value="AMD64"):
+            with patch("fava_trails.jj_install.discover_existing", return_value=None):
+                rc = cmd_install_jj(_make_install_jj_args())
 
     assert rc == 1
-    out = capsys.readouterr().out
-    assert "winget" in out
+    err = capsys.readouterr().err
+    assert "winget" in err
 
 
 def test_install_jj_unsupported_arch(capsys):
     """install-jj exits 1 on unsupported Linux architecture."""
-    with patch("sys.platform", "linux"):
-        with patch("platform.machine", return_value="mips"):
-            with patch("shutil.which", return_value=None):
-                with patch("subprocess.run", side_effect=OSError("no jj")):
-                    rc = cmd_install_jj(_make_install_jj_args())
+    with patch("fava_trails.jj_install.sys.platform", "linux"):
+        with patch("fava_trails.jj_install.platform.machine", return_value="mips"):
+            with patch("fava_trails.jj_install.discover_existing", return_value=None):
+                rc = cmd_install_jj(_make_install_jj_args())
 
     assert rc == 1
     err = capsys.readouterr().err
@@ -903,71 +902,78 @@ def _make_fake_tarball(jj_data: bytes = b"#!/bin/sh\necho jj") -> bytes:
     with _tarfile.open(fileobj=buf, mode="w:gz") as tf:
         info = _tarfile.TarInfo(name="jj")
         info.size = len(jj_data)
+        info.mode = 0o755
         tf.addfile(info, io.BytesIO(jj_data))
     return buf.getvalue()
 
 
-def _fake_urlopen(fake_bytes: bytes):
-    """Return a context-manager mock for urllib.request.urlopen."""
-    import io
-
-    class FakeResponse:
-        def read(self, n=-1):
-            return self._buf.read(n)
-
-        def __enter__(self):
-            self._buf = io.BytesIO(fake_bytes)
-            return self
-
-        def __exit__(self, *a):
-            pass
-
-    return FakeResponse()
-
-
 def test_install_jj_downloads_and_installs(tmp_path, capsys):
     """install-jj downloads tarball, extracts binary, and verifies installation."""
-    fake_bytes = _make_fake_tarball(b"#!/bin/sh\necho jj 0.28.0")
+    import hashlib
+
+    from fava_trails.jj_install import select_or_install
+
+    version = "0.45.1"
+    fake_bytes = _make_fake_tarball(f"#!/bin/sh\necho 'jj {version}'\n".encode())
     install_dir = tmp_path / ".local" / "bin"
-    install_dir.mkdir(parents=True)
+    digest = hashlib.sha256(fake_bytes).hexdigest()
+    suffix = "x86_64-unknown-linux-musl"
+    payload = {
+        "tag_name": f"v{version}",
+        "assets": [
+            {
+                "name": f"jj-v{version}-{suffix}.tar.gz",
+                "browser_download_url": f"https://example.test/jj-v{version}.tar.gz",
+                "digest": f"sha256:{digest}",
+            }
+        ],
+    }
 
-    mock_run_result = MagicMock()
-    mock_run_result.stdout = "jj 0.28.0\n"
-    mock_run_result.returncode = 0
-
-    with patch("shutil.which", return_value=None):
-        with patch("fava_trails.cli._JJ_INSTALL_DIR", install_dir):
-            with patch("urllib.request.urlopen", return_value=_fake_urlopen(fake_bytes)):
-                with patch("subprocess.run", return_value=mock_run_result):
-                    rc = cmd_install_jj(_make_install_jj_args())
-
-    assert rc == 0
+    result = select_or_install(
+        install_dir=install_dir,
+        which_jj=None,
+        fetch_json=lambda _u: payload,
+        download=lambda _u, dest: dest.write_bytes(fake_bytes),
+        os_name="linux",
+        machine="x86_64",
+    )
+    assert result.exit_code == 0
+    assert result.action == "install"
     assert (install_dir / "jj").exists()
 
 
-def test_install_jj_custom_version(tmp_path, capsys):
-    """install-jj uses --version argument in the download URL."""
-    captured_urls = []
-    fake_bytes = _make_fake_tarball()
+def test_install_jj_custom_version(tmp_path):
+    """install-jj uses explicit version in the release tag API URL."""
+    captured_urls: list[str] = []
+    version = "0.29.0"
+    fake_bytes = _make_fake_tarball(f"#!/bin/sh\necho 'jj {version}'\n".encode())
     install_dir = tmp_path / ".local" / "bin"
-    install_dir.mkdir(parents=True)
 
-    def fake_urlopen(url, timeout=None):
+    def fetch_json(url: str):
         captured_urls.append(url)
-        return _fake_urlopen(fake_bytes)
+        return {
+            "tag_name": f"v{version}",
+            "assets": [
+                {
+                    "name": f"jj-v{version}-x86_64-unknown-linux-musl.tar.gz",
+                    "browser_download_url": f"https://example.test/{version}.tar.gz",
+                }
+            ],
+        }
 
-    mock_run_result = MagicMock()
-    mock_run_result.stdout = "jj 0.29.0\n"
+    from fava_trails.jj_install import select_or_install
 
-    with patch("shutil.which", return_value=None):
-        with patch("fava_trails.cli._JJ_INSTALL_DIR", install_dir):
-            with patch("urllib.request.urlopen", side_effect=fake_urlopen):
-                with patch("subprocess.run", return_value=mock_run_result):
-                    rc = cmd_install_jj(_make_install_jj_args(version="0.29.0"))
-
-    assert rc == 0
-    assert len(captured_urls) == 1
-    assert "0.29.0" in captured_urls[0]
+    result = select_or_install(
+        explicit_version=version,
+        install_dir=install_dir,
+        which_jj=None,
+        fetch_json=fetch_json,
+        download=lambda _u, dest: dest.write_bytes(fake_bytes),
+        os_name="linux",
+        machine="x86_64",
+    )
+    assert result.exit_code == 0
+    assert any("0.29.0" in u for u in captured_urls)
 
 
 def test_install_jj_in_help(capsys):

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -31,7 +31,10 @@ async def test_non_operator_gateway_lists_and_syncs_real_local_remote(trail_mana
     subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
     await trail_manager.vcs.add_remote("origin", str(remote))
     await trail_manager.vcs._run("bookmark", "set", "main", "-r", "@-")
-    await trail_manager.vcs._run("git", "push", "--allow-new", "-b", "main")
+    # Seed the bare remote with local bookmarks. Prefer --all over --allow-new:
+    # --allow-new was removed in JJ 0.42+; --all still creates new remote bookmarks
+    # on both the supported floor (0.28) and current stable.
+    await trail_manager.vcs._run("git", "push", "--allow-empty-description", "--all")
     monkeypatch.setenv("FAVA_TRAILS_AGENT_ID", "chatgpt-gateway")
     monkeypatch.delenv("FAVA_TRAILS_OPERATOR", raising=False)
     monkeypatch.setattr(server, "_trail_managers", {trail_manager.trail_name: trail_manager})

--- a/tests/test_jj_compat_matrix.py
+++ b/tests/test_jj_compat_matrix.py
@@ -1,0 +1,107 @@
+"""Real JJ lifecycle integration on a disposable data repo.
+
+Runs against whatever `jj` is on PATH (CI matrix covers min + current stable).
+Covers init, save, promote/reject freeze, supersede, status, and sync plumbing.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from fava_trails.jj_install import JJ_MIN_VERSION, Version, parse_version_from_output
+from fava_trails.models import SourceType, ValidationStatus
+from fava_trails.trail import TrailManager
+from fava_trails.trust_gate import TrustResult
+from fava_trails.vcs.jj_backend import JjBackend
+
+jj_bin = shutil.which("jj") or str(Path.home() / ".local" / "bin" / "jj")
+if not Path(jj_bin).exists():
+    pytest.skip("jj binary not found", allow_module_level=True)
+
+
+def _jj_version() -> Version:
+    out = subprocess.run([jj_bin, "--version"], capture_output=True, text=True, check=True)
+    ver = parse_version_from_output(out.stdout)
+    assert ver is not None, out.stdout
+    return ver
+
+
+def review_approval() -> TrustResult:
+    return TrustResult(verdict="approve", reasoning="compat matrix approval", reviewer="fixture")
+
+
+def test_jj_version_meets_minimum():
+    ver = _jj_version()
+    assert ver >= Version.parse(JJ_MIN_VERSION), f"jj {ver} below minimum {JJ_MIN_VERSION}"
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_init_save_promote_reject_supersede_status_sync(tmp_fava_home):
+    """End-to-end thought lifecycle on disposable repo with live JJ."""
+    trail_path = tmp_fava_home / "trails" / "mw" / "eng" / "jj-compat"
+    backend = JjBackend(repo_root=tmp_fava_home, trail_path=trail_path)
+    mgr = TrailManager("mw/eng/jj-compat", vcs=backend)
+    await mgr.init()
+
+    # status / current change
+    current = await backend.current_change()
+    assert current is not None
+
+    # save draft
+    saved = await mgr.save_thought(
+        content="compat observation",
+        source_type=SourceType.OBSERVATION,
+        confidence=0.7,
+        agent_id="test",
+    )
+    assert saved.thought_id
+    drafts_path = trail_path / "thoughts" / "drafts" / f"{saved.thought_id}.md"
+    assert drafts_path.exists()
+
+    # promote
+    promoted = await mgr.propose_truth(saved.thought_id)
+    assert promoted.frontmatter.validation_status.value == "proposed"
+    obs_path = trail_path / "thoughts" / "observations" / f"{saved.thought_id}.md"
+    assert obs_path.exists()
+    assert not drafts_path.exists()
+
+    # approve then supersede
+    approved = await mgr.propose_truth(saved.thought_id, review_approval())
+    assert approved.frontmatter.validation_status == ValidationStatus.APPROVED
+
+    successor = await mgr.supersede(
+        original_id=saved.thought_id,
+        new_content="corrected observation",
+        reason="integration evidence",
+        agent_id="test",
+    )
+    assert successor.thought_id != saved.thought_id
+    await mgr.propose_truth(successor.thought_id, review_approval())
+    refreshed = await mgr.get_thought(saved.thought_id)
+    assert refreshed is not None
+    assert refreshed.frontmatter.superseded_by == successor.thought_id
+
+    # rejection freeze path
+    other = await mgr.save_thought(content="to reject", agent_id="test")
+    path = mgr._find_thought_path(other.thought_id)
+    assert path is not None
+    from fava_trails.models import ThoughtRecord
+
+    loaded = ThoughtRecord.from_markdown(path.read_text())
+    loaded.frontmatter.validation_status = ValidationStatus.REJECTED
+    path.write_text(loaded.to_markdown())
+    with pytest.raises(ValueError, match="frozen"):
+        await mgr.update_thought(other.thought_id, "should fail")
+
+    # status
+    stdout, _ = await backend._run("status")
+    assert isinstance(stdout, str)
+
+    # sync plumbing without remote: dirty or clean result object
+    result = await backend.fetch_and_rebase()
+    assert result is not None
+    assert hasattr(result, "success")

--- a/tests/test_jj_install.py
+++ b/tests/test_jj_install.py
@@ -14,11 +14,14 @@ import pytest
 
 from fava_trails.jj_install import (
     JJ_MIN_VERSION,
+    JjInstallError,
     Version,
     detect_platform,
+    extract_jj_from_tarball,
     format_selection_report,
     is_compatible,
     parse_version_from_output,
+    path_hint,
     select_or_install,
 )
 
@@ -31,6 +34,34 @@ def _make_tarball(jj_script: str) -> bytes:
         info.size = len(data)
         info.mode = 0o755
         tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _make_tarball_from_members(members: list[tuple[str, bytes | None, str]]) -> bytes:
+    """Build a gzipped tar.
+
+    Each member is ``(name, content_or_none, kind)`` where kind is
+    ``file`` | ``symlink`` | ``dir``.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, content, kind in members:
+            info = tarfile.TarInfo(name=name)
+            if kind == "dir":
+                info.type = tarfile.DIRTYPE
+                info.mode = 0o755
+                tf.addfile(info)
+            elif kind == "symlink":
+                info.type = tarfile.SYMTYPE
+                info.linkname = content.decode() if isinstance(content, bytes) else (content or "x")
+                info.mode = 0o777
+                tf.addfile(info)
+            else:
+                data = content or b""
+                info.size = len(data)
+                info.mode = 0o755
+                info.type = tarfile.REGTYPE
+                tf.addfile(info, io.BytesIO(data))
     return buf.getvalue()
 
 
@@ -331,7 +362,100 @@ def test_shell_install_jj_is_thin_delegate():
     assert "tar -xzf" not in text
     assert "RESOLVED_SHA256" not in text
     assert "exec" in text
+    # Bash 3.2 + set -u forbids expanding empty arrays; wrapper must not do that.
+    assert "ARGS=()" not in text
+    assert '("${ARGS[@]}")' not in text
+    assert "Bash 3.2" in text
 
+
+def test_shell_install_jj_bash32_empty_argv_safe(tmp_path):
+    """No-arg path must not trip set -u (macOS Bash 3.2 empty-array footgun).
+
+    Bash 3.2 treats ``\"${empty[@]}\"`` under ``set -u`` as unbound; Bash 4.4+
+    does not. CI may only have modern Bash, so we (1) forbid the historical
+    pattern in the script, (2) prove the ``set --`` rebuild works with zero
+    args under ``set -u``, and (3) run the live no-arg wrapper path.
+    """
+    import os
+    import shutil
+    import subprocess
+    import textwrap
+
+    bash = shutil.which("bash")
+    assert bash
+
+    # Pattern used by install-jj.sh: set -- rebuild with zero incoming args.
+    safe = textwrap.dedent(
+        r"""
+        set -euo pipefail
+        _run() {
+          shift
+          if [[ -n "${INSTALL_DIR:-}" ]]; then
+            set -- --install-dir "${INSTALL_DIR}" "$@"
+          fi
+          if [[ "${FORCE:-0}" == "1" ]]; then
+            set -- --force "$@"
+          fi
+          if [[ -n "${JJ_VERSION:-}" ]]; then
+            set -- --version "${JJ_VERSION}" "$@"
+          fi
+          printf 'argc=%s\n' "$#"
+          printf 'ok\n'
+        }
+        _run python3
+        """
+    )
+    good = subprocess.run([bash, "-c", safe], capture_output=True, text=True)
+    assert good.returncode == 0, good.stderr + good.stdout
+    assert "argc=0" in good.stdout
+    assert "ok" in good.stdout
+
+    # On Bash < 4.4, also prove the old empty-array copy fails under set -u.
+    ver = subprocess.run(
+        [bash, "-c", 'printf "%s.%s\\n" "${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}"'],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    major_s, _, minor_s = ver.partition(".")
+    try:
+        major, minor = int(major_s), int(minor_s or "0")
+    except ValueError:
+        major, minor = 99, 0
+    if (major, minor) < (4, 4):
+        footgun = textwrap.dedent(
+            r"""
+            set -euo pipefail
+            ARGS=()
+            MODULE_ARGS=("${ARGS[@]}")
+            printf 'should-not-reach\n'
+            """
+        )
+        bad = subprocess.run([bash, "-c", footgun], capture_output=True, text=True)
+        assert bad.returncode != 0, "empty-array expand must fail under Bash 3.2 set -u"
+
+    # Live wrapper: documented no-argument path (reuse).
+    jj = _write_executable(tmp_path / "bin" / "jj", "0.45.1")
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    script = Path(__file__).resolve().parents[1] / "scripts" / "install-jj.sh"
+    py = shutil.which("python3") or shutil.which("python")
+    assert py
+    env = os.environ.copy()
+    env["PATH"] = f"{jj.parent}:{Path(py).parent}:{Path(bash).parent}"
+    env["INSTALL_DIR"] = str(managed)
+    # Explicitly clear optional flag env so this is a pure no-arg invocation.
+    env.pop("JJ_VERSION", None)
+    env.pop("FORCE", None)
+    result = subprocess.run(
+        [bash, str(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(script.parent.parent),
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "reuse" in result.stdout
 
 def test_shell_install_jj_reuses_via_python(tmp_path):
     """Thin shell entrypoint delegates reuse to the Python installer."""
@@ -363,6 +487,71 @@ def test_shell_install_jj_reuses_via_python(tmp_path):
     assert result.returncode == 0, result.stderr + result.stdout
     assert "reuse" in result.stdout
     assert "0.45.1" in result.stdout
+
+
+def test_extract_jj_accepts_single_nested_regular_member(tmp_path):
+    blob = _make_tarball_from_members(
+        [("prefix/jj", b"#!/bin/sh\necho ok\n", "file")]
+    )
+    tar_path = tmp_path / "jj.tar.gz"
+    tar_path.write_bytes(blob)
+    out = extract_jj_from_tarball(tar_path, tmp_path / "out")
+    assert out.name == "jj"
+    assert out.read_bytes().startswith(b"#!/bin/sh")
+
+
+@pytest.mark.parametrize(
+    "members, match",
+    [
+        (
+            [("jj", b"a", "file"), ("other/jj", b"b", "file")],
+            "ambiguous",
+        ),
+        (
+            [("jj", None, "symlink")],
+            "not a regular file",
+        ),
+        (
+            [("jj", None, "dir")],
+            "not a regular file",
+        ),
+        (
+            [("../jj", b"x", "file")],
+            "unsafe",
+        ),
+        (
+            [("/tmp/jj", b"x", "file")],
+            "unsafe",
+        ),
+        (
+            [("bin/not-jj", b"x", "file")],
+            "not found",
+        ),
+    ],
+)
+def test_extract_jj_rejects_adversarial_members(tmp_path, members, match):
+    blob = _make_tarball_from_members(members)
+    tar_path = tmp_path / "jj.tar.gz"
+    tar_path.write_bytes(blob)
+    with pytest.raises(JjInstallError, match=match):
+        extract_jj_from_tarball(tar_path, tmp_path / "out")
+
+
+def test_path_hint_default_mentions_local_bin():
+    text = path_hint()
+    assert "~/.local/bin" in text
+    assert "$HOME/.local/bin" in text
+
+
+def test_path_hint_uses_custom_install_dir(tmp_path):
+    custom = tmp_path / "custom" / "bin"
+    custom.mkdir(parents=True)
+    text = path_hint(custom)
+    assert str(custom.resolve()) in text or str(custom) in text
+    assert "~/.local/bin" not in text
+    # Export line should reference the custom directory, not the default.
+    assert ".local/bin:$PATH" not in text
+
 
 def test_sha256_mismatch_aborts(tmp_path):
     install_dir = tmp_path / "managed"

--- a/tests/test_jj_install.py
+++ b/tests/test_jj_install.py
@@ -62,7 +62,14 @@ def test_parse_and_compare_versions():
     assert is_compatible(Version.parse("0.28.0"))
     assert is_compatible(Version.parse("0.45.1"))
     assert not is_compatible(Version.parse("0.27.9"))
-    assert Version.parse("0.45.1") >= Version.parse(JJ_MIN_VERSION)
+    lo = Version.parse(JJ_MIN_VERSION)
+    hi = Version.parse("0.45.1")
+    assert hi >= lo
+    assert lo < hi
+    assert hi > lo
+    assert lo <= hi
+    assert hi == Version(0, 45, 1)
+    assert not (hi < lo)
 
 
 def test_detect_platform_linux_and_windows():

--- a/tests/test_jj_install.py
+++ b/tests/test_jj_install.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import operator
 import stat
 import tarfile
 from pathlib import Path
@@ -62,14 +63,26 @@ def test_parse_and_compare_versions():
     assert is_compatible(Version.parse("0.28.0"))
     assert is_compatible(Version.parse("0.45.1"))
     assert not is_compatible(Version.parse("0.27.9"))
-    lo = Version.parse(JJ_MIN_VERSION)
-    hi = Version.parse("0.45.1")
-    assert hi >= lo
-    assert lo < hi
-    assert hi > lo
-    assert lo <= hi
-    assert hi == Version(0, 45, 1)
-    assert not (hi < lo)
+    assert Version.parse("0.45.1") == Version(0, 45, 1)
+
+
+@pytest.mark.parametrize(
+    "left, right, op, expected",
+    [
+        # Independent cases so each operator is exercised without chained tautologies.
+        (Version(0, 28, 0), Version(0, 45, 1), operator.lt, True),
+        (Version(0, 45, 1), Version(0, 28, 0), operator.gt, True),
+        (Version(0, 28, 0), Version(0, 45, 1), operator.le, True),
+        (Version(0, 45, 1), Version(0, 28, 0), operator.ge, True),
+        (Version(0, 45, 1), Version(0, 45, 1), operator.le, True),
+        (Version(0, 45, 1), Version(0, 45, 1), operator.ge, True),
+        (Version(0, 45, 1), Version(0, 28, 0), operator.lt, False),
+        (Version(0, 28, 0), Version(0, 45, 1), operator.gt, False),
+        (Version(0, 28, 0), Version.parse(JJ_MIN_VERSION), operator.eq, True),
+    ],
+)
+def test_version_ordering_operators(left, right, op, expected):
+    assert op(left, right) is expected
 
 
 def test_detect_platform_linux_and_windows():

--- a/tests/test_jj_install.py
+++ b/tests/test_jj_install.py
@@ -95,6 +95,12 @@ def test_parse_and_compare_versions():
     assert is_compatible(Version.parse("0.45.1"))
     assert not is_compatible(Version.parse("0.27.9"))
     assert Version.parse("0.45.1") == Version(0, 45, 1)
+    with pytest.raises(ValueError, match="invalid version"):
+        Version.parse("invalid")
+    with pytest.raises(JjInstallError, match="invalid JJ version override"):
+        from fava_trails.jj_install import require_version
+
+        require_version("not-a-version", what="JJ version override")
 
 
 @pytest.mark.parametrize(
@@ -681,6 +687,92 @@ def test_format_selection_report_includes_fields():
     )
     assert "action:  reuse" in text
     assert "0.45.1" in text
+
+
+def test_invalid_explicit_version_returns_structured_error(tmp_path):
+    """CLI/env overrides must not raise ValueError through the selection boundary."""
+    result = select_or_install(
+        explicit_version="invalid",
+        install_dir=tmp_path / "managed",
+        which_jj=None,
+        os_name="linux",
+        machine="x86_64",
+        fetch_json=lambda *_: (_ for _ in ()).throw(AssertionError("must not fetch")),
+    )
+    assert result.exit_code == 1
+    assert result.action == "error"
+    assert result.path is None
+    assert result.version is None
+    assert "invalid JJ version override" in result.reason
+    report = format_selection_report(result)
+    assert "action:  error" in report
+    assert "version: (none)" in report
+
+
+def test_invalid_explicit_version_with_existing_still_structured(tmp_path):
+    jj = _write_executable(tmp_path / "bin" / "jj", "0.45.1")
+    result = select_or_install(
+        explicit_version="1.2",
+        install_dir=tmp_path / "managed",
+        which_jj=str(jj),
+        os_name="linux",
+        machine="x86_64",
+    )
+    assert result.exit_code == 1
+    assert result.action == "error"
+    assert "invalid JJ version override" in result.reason
+    # Must not touch disk on bad override
+    assert not (tmp_path / "managed" / "jj").exists()
+
+
+def test_module_main_invalid_version_no_traceback(capsys, monkeypatch):
+    from fava_trails.jj_install import main
+
+    monkeypatch.delenv("JJ_VERSION", raising=False)
+    rc = main(["--version", "invalid"])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "Traceback" not in captured.out
+    assert "Traceback" not in captured.err
+    assert "action:  error" in captured.out
+    assert "invalid JJ version override" in captured.err
+
+
+def test_module_main_invalid_jj_version_env(capsys, monkeypatch, tmp_path):
+    from fava_trails.jj_install import main
+
+    monkeypatch.setenv("JJ_VERSION", "not.semver")
+    monkeypatch.setenv("INSTALL_DIR", str(tmp_path / "managed"))
+    rc = main([])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "Traceback" not in captured.out + captured.err
+    assert "action:  error" in captured.out
+    assert "invalid JJ version override" in captured.err
+
+
+def test_cli_install_jj_invalid_version(capsys, monkeypatch):
+    from fava_trails.cli import cmd_install_jj
+
+    monkeypatch.delenv("JJ_VERSION", raising=False)
+    rc = cmd_install_jj(type("A", (), {"jj_version": "bogus", "force": False})())
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "Traceback" not in captured.out + captured.err
+    assert "action:  error" in captured.out
+    assert "invalid JJ version override" in captured.err
+
+
+def test_cli_install_jj_invalid_jj_version_env(capsys, monkeypatch):
+    from fava_trails.cli import cmd_install_jj
+
+    monkeypatch.setenv("JJ_VERSION", "v")
+    rc = cmd_install_jj(type("A", (), {"jj_version": None, "force": False})())
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "Traceback" not in captured.out + captured.err
+    assert "action:  error" in captured.out
+    assert "invalid JJ version override" in captured.err
 
 
 def test_cli_install_jj_reuses(tmp_path, capsys, monkeypatch):

--- a/tests/test_jj_install.py
+++ b/tests/test_jj_install.py
@@ -259,6 +259,111 @@ def test_failed_install_preserves_prior_managed(tmp_path):
     assert prior.read_bytes() == prior_bytes
 
 
+def test_failed_post_replace_verify_restores_prior(tmp_path):
+    """Regression: restore prior managed bytes even when dest already has the failed new file."""
+    from fava_trails.jj_install import JjInstallError, verify_executable_version
+
+    install_dir = tmp_path / "managed"
+    prior = _write_executable(install_dir / "jj", "0.28.0")
+    prior_bytes = prior.read_bytes()
+    version = "0.45.1"
+    suffix = "x86_64-unknown-linux-musl"
+    # Staged verification succeeds; only the *second* (post-replace) verify fails.
+    blob = _make_tarball(_fake_jj_script(version))
+    payload = _release_payload(version, suffix, blob, with_digest=False)
+
+    real_verify = verify_executable_version
+    calls = {"n": 0}
+
+    def flaky_verify(path, expected=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return real_verify(path, expected)
+        raise JjInstallError("post-replace verification failed (injected)")
+
+    with patch("fava_trails.jj_install.verify_executable_version", side_effect=flaky_verify):
+        result = select_or_install(
+            explicit_version=version,
+            force_install=True,
+            install_dir=install_dir,
+            which_jj=str(prior),
+            fetch_json=lambda _u: payload,
+            download=lambda u, d: d.write_bytes(blob),
+            os_name="linux",
+            machine="x86_64",
+        )
+
+    assert result.exit_code == 1
+    assert result.action == "error"
+    assert prior.exists()
+    assert prior.read_bytes() == prior_bytes
+    # Backup must not strand the prior binary
+    assert not (install_dir / "jj.fava-prev").exists()
+    assert calls["n"] >= 2
+
+
+def test_reuse_compatible_on_unsupported_download_platform(tmp_path):
+    """Reuse must not require a FAVA-downloadable platform asset."""
+    jj = _write_executable(tmp_path / "bin" / "jj", "0.45.1")
+
+    def boom(*_a, **_k):
+        raise AssertionError("must not hit network when reusing")
+
+    result = select_or_install(
+        install_dir=tmp_path / "managed",
+        which_jj=str(jj),
+        fetch_json=boom,
+        download=boom,
+        os_name="linux",
+        machine="mips",  # no downloadable asset for this arch
+    )
+    assert result.exit_code == 0
+    assert result.action == "reuse"
+    assert result.version == "0.45.1"
+    assert "compatible" in result.reason
+
+
+def test_shell_install_jj_is_thin_delegate():
+    """scripts/install-jj.sh must not reimplement installer policy."""
+    script = Path(__file__).resolve().parents[1] / "scripts" / "install-jj.sh"
+    text = script.read_text()
+    assert "fava_trails.jj_install" in text
+    assert "tar -xzf" not in text
+    assert "RESOLVED_SHA256" not in text
+    assert "exec" in text
+
+
+def test_shell_install_jj_reuses_via_python(tmp_path):
+    """Thin shell entrypoint delegates reuse to the Python installer."""
+    import os
+    import shutil
+    import subprocess
+
+    jj = _write_executable(tmp_path / "bin" / "jj", "0.45.1")
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    script = Path(__file__).resolve().parents[1] / "scripts" / "install-jj.sh"
+    # Keep system python/bash on PATH; put fake jj first; omit fava-trails by using a
+    # minimal PATH prefix without a fava-trails shim.
+    py = shutil.which("python3") or shutil.which("python")
+    bash = shutil.which("bash")
+    assert py and bash
+    py_dir = str(Path(py).parent)
+    bash_dir = str(Path(bash).parent)
+    env = os.environ.copy()
+    env["PATH"] = f"{jj.parent}:{py_dir}:{bash_dir}"
+    env["INSTALL_DIR"] = str(managed)
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(script.parent.parent),
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "reuse" in result.stdout
+    assert "0.45.1" in result.stdout
+
 def test_sha256_mismatch_aborts(tmp_path):
     install_dir = tmp_path / "managed"
     version = "0.45.1"

--- a/tests/test_jj_install.py
+++ b/tests/test_jj_install.py
@@ -1,0 +1,333 @@
+"""Unit tests for JJ installer selection / install policy (issue #98)."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import stat
+import tarfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fava_trails.jj_install import (
+    JJ_MIN_VERSION,
+    Version,
+    detect_platform,
+    format_selection_report,
+    is_compatible,
+    parse_version_from_output,
+    select_or_install,
+)
+
+
+def _make_tarball(jj_script: str) -> bytes:
+    data = jj_script.encode()
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        info = tarfile.TarInfo(name="jj")
+        info.size = len(data)
+        info.mode = 0o755
+        tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _fake_jj_script(version: str) -> str:
+    # Portable enough for Linux CI; reports via --version
+    return f"#!/bin/sh\necho 'jj {version}'\n"
+
+
+def _write_executable(path: Path, version: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_fake_jj_script(version))
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _release_payload(version: str, suffix: str, blob: bytes, *, with_digest: bool = True) -> dict:
+    digest = f"sha256:{hashlib.sha256(blob).hexdigest()}" if with_digest else None
+    name = f"jj-v{version}-{suffix}.tar.gz"
+    asset = {
+        "name": name,
+        "browser_download_url": f"https://example.test/{name}",
+    }
+    if digest:
+        asset["digest"] = digest
+    return {"tag_name": f"v{version}", "assets": [asset]}
+
+
+def test_parse_and_compare_versions():
+    assert parse_version_from_output("jj 0.45.1-abcdef") == Version(0, 45, 1)
+    assert is_compatible(Version.parse("0.28.0"))
+    assert is_compatible(Version.parse("0.45.1"))
+    assert not is_compatible(Version.parse("0.27.9"))
+    assert Version.parse("0.45.1") >= Version.parse(JJ_MIN_VERSION)
+
+
+def test_detect_platform_linux_and_windows():
+    t = detect_platform(os_name="linux", machine="x86_64")
+    assert "linux-musl" in t.suffix
+    with pytest.raises(Exception, match="Windows"):
+        detect_platform(os_name="win32", machine="x86_64")
+
+
+def test_reuse_compatible_newer(tmp_path):
+    jj = _write_executable(tmp_path / "bin" / "jj", "0.45.1")
+    install_dir = tmp_path / "managed"
+
+    def boom(*_a, **_k):
+        raise AssertionError("must not hit network when reusing")
+
+    result = select_or_install(
+        install_dir=install_dir,
+        which_jj=str(jj),
+        fetch_json=boom,
+        download=boom,
+        os_name="linux",
+        machine="x86_64",
+    )
+    assert result.exit_code == 0
+    assert result.action == "reuse"
+    assert result.version == "0.45.1"
+    assert "compatible" in result.reason
+    assert "not downgrading" in result.reason
+
+
+def test_reuse_exact_min(tmp_path):
+    jj = _write_executable(tmp_path / "jj", JJ_MIN_VERSION)
+    result = select_or_install(
+        install_dir=tmp_path / "managed",
+        which_jj=str(jj),
+        fetch_json=lambda *_: (_ for _ in ()).throw(RuntimeError("no")),
+        os_name="linux",
+        machine="x86_64",
+    )
+    assert result.action == "reuse"
+    assert result.version == JJ_MIN_VERSION
+
+
+def test_refuse_user_managed_incompatible(tmp_path):
+    jj = _write_executable(tmp_path / "usr" / "bin" / "jj", "0.20.0")
+    result = select_or_install(
+        install_dir=tmp_path / "managed",
+        which_jj=str(jj),
+        fetch_json=lambda *_: {"tag_name": "v0.45.1", "assets": []},
+        os_name="linux",
+        machine="x86_64",
+    )
+    assert result.exit_code == 1
+    assert result.action == "refuse"
+    assert "user-managed" in result.reason
+    assert "refusing to overwrite" in result.reason
+    # Must not have written managed binary
+    assert not (tmp_path / "managed" / "jj").exists()
+
+
+def test_refuse_user_managed_when_explicit_differs(tmp_path):
+    jj = _write_executable(tmp_path / "usr" / "bin" / "jj", "0.45.1")
+    result = select_or_install(
+        explicit_version="0.28.0",
+        install_dir=tmp_path / "managed",
+        which_jj=str(jj),
+        os_name="linux",
+        machine="x86_64",
+    )
+    assert result.action == "refuse"
+    assert result.exit_code == 1
+
+
+def test_install_when_absent(tmp_path):
+    install_dir = tmp_path / "managed"
+    version = "0.45.1"
+    suffix = "x86_64-unknown-linux-musl"
+    blob = _make_tarball(_fake_jj_script(version))
+    payload = _release_payload(version, suffix, blob)
+
+    def fetch_json(url: str):
+        assert "releases/latest" in url
+        return payload
+
+    def download(url: str, dest: Path):
+        dest.write_bytes(blob)
+
+    result = select_or_install(
+        install_dir=install_dir,
+        which_jj=None,
+        fetch_json=fetch_json,
+        download=download,
+        os_name="linux",
+        machine="x86_64",
+    )
+    assert result.exit_code == 0
+    assert result.action == "install"
+    assert result.version == version
+    assert (install_dir / "jj").exists()
+    assert "sha256 verified" in result.reason
+
+
+def test_explicit_override_installs_exact(tmp_path):
+    install_dir = tmp_path / "managed"
+    version = "0.28.0"
+    suffix = "x86_64-unknown-linux-musl"
+    blob = _make_tarball(_fake_jj_script(version))
+    # Old tags may lack digest
+    payload = _release_payload(version, suffix, blob, with_digest=False)
+
+    def fetch_json(url: str):
+        assert f"tags/v{version}" in url
+        return payload
+
+    result = select_or_install(
+        explicit_version=version,
+        install_dir=install_dir,
+        which_jj=None,
+        fetch_json=fetch_json,
+        download=lambda url, dest: dest.write_bytes(blob),
+        os_name="linux",
+        machine="x86_64",
+    )
+    assert result.action == "install"
+    assert result.version == version
+    assert "no official digest" in result.reason
+
+
+def test_network_failure_without_existing(tmp_path):
+    def fetch_json(_url: str):
+        from fava_trails.jj_install import JjInstallError
+
+        raise JjInstallError("Network error resolving JJ release")
+
+    result = select_or_install(
+        install_dir=tmp_path / "managed",
+        which_jj=None,
+        fetch_json=fetch_json,
+        os_name="linux",
+        machine="x86_64",
+    )
+    assert result.exit_code == 1
+    assert result.action == "error"
+    assert "could not resolve" in result.reason
+
+
+def test_failed_install_preserves_prior_managed(tmp_path):
+    install_dir = tmp_path / "managed"
+    prior = _write_executable(install_dir / "jj", "0.28.0")
+    prior_bytes = prior.read_bytes()
+    version = "0.45.1"
+    suffix = "x86_64-unknown-linux-musl"
+    # Tarball claims 0.45.1 but script reports wrong version → verify fails
+    blob = _make_tarball(_fake_jj_script("0.0.0"))
+    payload = _release_payload(version, suffix, blob, with_digest=False)
+
+    # Force reinstall of managed (below would reuse 0.28; force_install)
+    result = select_or_install(
+        explicit_version=version,
+        force_install=True,
+        install_dir=install_dir,
+        which_jj=str(prior),
+        fetch_json=lambda _u: payload,
+        download=lambda u, d: d.write_bytes(blob),
+        os_name="linux",
+        machine="x86_64",
+    )
+    assert result.exit_code == 1
+    assert result.action == "error"
+    assert "preserved" in result.reason
+    # Prior binary still present and unchanged
+    assert prior.exists()
+    assert prior.read_bytes() == prior_bytes
+
+
+def test_sha256_mismatch_aborts(tmp_path):
+    install_dir = tmp_path / "managed"
+    version = "0.45.1"
+    suffix = "x86_64-unknown-linux-musl"
+    blob = _make_tarball(_fake_jj_script(version))
+    payload = _release_payload(version, suffix, blob)
+    payload["assets"][0]["digest"] = "sha256:" + ("0" * 64)
+
+    result = select_or_install(
+        install_dir=install_dir,
+        which_jj=None,
+        fetch_json=lambda _u: payload,
+        download=lambda u, d: d.write_bytes(blob),
+        os_name="linux",
+        machine="x86_64",
+    )
+    assert result.exit_code == 1
+    assert "SHA-256 mismatch" in result.reason
+    assert not (install_dir / "jj").exists()
+
+
+def test_upgrade_managed_incompatible(tmp_path):
+    install_dir = tmp_path / "managed"
+    old = _write_executable(install_dir / "jj", "0.20.0")
+    version = "0.45.1"
+    suffix = "x86_64-unknown-linux-musl"
+    blob = _make_tarball(_fake_jj_script(version))
+    payload = _release_payload(version, suffix, blob)
+
+    result = select_or_install(
+        install_dir=install_dir,
+        which_jj=str(old),
+        fetch_json=lambda _u: payload,
+        download=lambda u, d: d.write_bytes(blob),
+        os_name="linux",
+        machine="x86_64",
+    )
+    assert result.action == "install"
+    assert result.version == version
+
+
+def test_format_selection_report_includes_fields():
+    from fava_trails.jj_install import SelectionResult
+
+    text = format_selection_report(
+        SelectionResult(action="reuse", path="/x/jj", version="0.45.1", reason="ok")
+    )
+    assert "action:  reuse" in text
+    assert "0.45.1" in text
+
+
+def test_cli_install_jj_reuses(tmp_path, capsys, monkeypatch):
+    from fava_trails.cli import cmd_install_jj
+
+    jj = _write_executable(tmp_path / "jj", "0.45.1")
+    install_dir = tmp_path / "managed"
+    monkeypatch.setattr("fava_trails.cli._JJ_INSTALL_DIR", install_dir)
+
+    with patch("fava_trails.jj_install.shutil.which", return_value=str(jj)):
+        with patch("fava_trails.jj_install.find_jj_candidates", return_value=[jj]):
+            rc = cmd_install_jj(type("A", (), {"jj_version": None, "force": False})())
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "reuse" in out
+    assert "0.45.1" in out
+
+
+def test_cli_install_jj_unsupported_windows(capsys):
+    from fava_trails.cli import cmd_install_jj
+
+    with patch("fava_trails.jj_install.sys.platform", "win32"):
+        with patch("fava_trails.jj_install.platform.machine", return_value="AMD64"):
+            with patch("fava_trails.jj_install.discover_existing", return_value=None):
+                rc = cmd_install_jj(type("A", (), {"jj_version": None, "force": False})())
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "winget" in err
+
+
+def test_cli_install_jj_help_mentions_latest():
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "fava_trails.cli", "install-jj", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "stable" in result.stdout.lower() or "version" in result.stdout.lower()

--- a/tests/test_jj_install.py
+++ b/tests/test_jj_install.py
@@ -333,6 +333,47 @@ def test_failed_post_replace_verify_restores_prior(tmp_path):
     assert calls["n"] >= 2
 
 
+def test_failed_post_replace_verify_removes_dest_when_no_prior(tmp_path):
+    """Fresh install: post-replace verify failure must not leave invalid dest bytes."""
+    from fava_trails.jj_install import JjInstallError, verify_executable_version
+
+    install_dir = tmp_path / "managed"
+    dest = install_dir / "jj"
+    version = "0.45.1"
+    suffix = "x86_64-unknown-linux-musl"
+    blob = _make_tarball(_fake_jj_script(version))
+    payload = _release_payload(version, suffix, blob, with_digest=False)
+
+    real_verify = verify_executable_version
+    calls = {"n": 0}
+
+    def flaky_verify(path, expected=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return real_verify(path, expected)
+        raise JjInstallError("post-replace verification failed (injected)")
+
+    assert not dest.exists()
+    with patch("fava_trails.jj_install.verify_executable_version", side_effect=flaky_verify):
+        result = select_or_install(
+            explicit_version=version,
+            force_install=True,
+            install_dir=install_dir,
+            which_jj=None,
+            fetch_json=lambda _u: payload,
+            download=lambda u, d: d.write_bytes(blob),
+            os_name="linux",
+            machine="x86_64",
+        )
+
+    assert result.exit_code == 1
+    assert result.action == "error"
+    assert not dest.exists(), "failed fresh install must not leave unverified dest"
+    assert not (install_dir / "jj.fava-prev").exists()
+    assert not (install_dir / "jj.fava-new").exists()
+    assert calls["n"] >= 2
+
+
 def test_reuse_compatible_on_unsupported_download_platform(tmp_path):
     """Reuse must not require a FAVA-downloadable platform asset."""
     jj = _write_executable(tmp_path / "bin" / "jj", "0.45.1")
@@ -551,6 +592,44 @@ def test_path_hint_uses_custom_install_dir(tmp_path):
     assert "~/.local/bin" not in text
     # Export line should reference the custom directory, not the default.
     assert ".local/bin:$PATH" not in text
+
+
+def test_path_hint_quotes_shell_sensitive_custom_dir(tmp_path):
+    """Apostrophes and shell metacharacters must not break suggested shell commands."""
+    import os
+    import shlex
+    import subprocess
+
+    # Path with apostrophe, space, dollar, backtick, and double-quote.
+    custom = tmp_path / "o'brien bin" / 'x$y`z"w'
+    custom.mkdir(parents=True)
+    text = path_hint(custom)
+    resolved = str(custom.resolve())
+    assert resolved in text or "o'brien" in text
+    assert "~/.local/bin" not in text
+
+    lines = text.splitlines()
+    cmd_line = next(line.strip() for line in lines if line.strip().startswith("echo "))
+    echo_part = cmd_line.split(" >> ", 1)[0]
+    tokens = shlex.split(echo_part)
+    assert tokens[0] == "echo"
+    export_stmt = tokens[1]
+    assert export_stmt.startswith("export PATH=")
+
+    # Evaluate the export in bash; the directory must be PATH's first entry literally.
+    probe = subprocess.run(
+        [
+            "bash",
+            "-c",
+            export_stmt + '; python3 -c "import os; print(os.environ[\'PATH\'].split(\':\')[0])"',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": "/usr/bin:/bin"},
+    )
+    assert probe.returncode == 0, probe.stderr
+    assert probe.stdout.strip() == resolved
 
 
 def test_sha256_mismatch_aborts(tmp_path):


### PR DESCRIPTION
## Summary
- Shared installer policy in `src/fava_trails/jj_install.py` + aligned `scripts/install-jj.sh`
- Reuse any installed JJ `>= 0.28.0` (including newer); never silently downgrade or overwrite a user-managed executable
- When install is needed, resolve current GitHub stable (explicit `--version` / `JJ_VERSION` retained) with bounded network handling
- SHA-256 via official GitHub asset digests when present; atomic install; restore prior managed binary on failure
- Report `action` / `path` / `version` / `reason` for every outcome
- CI matrix: JJ **0.28.0** and **0.45.1**; docs in `docs/jj-compatibility.md`

## Test plan
- [x] `uv run ruff check src/ tests/`
- [x] `uv run pytest -q` (869 passed on JJ 0.28.0)
- [x] `tests/test_jj_backend.py` + compat matrix on JJ 0.45.1
- [x] Installer unit cases: absent, compatible newer, incompatible user-managed, explicit override, network failure, SHA mismatch, failed install preserves prior
- [x] Shell + Python `install-jj` reuse path smoke

Closes #98