### PR TITLE
feat: verify 0.6.1 release candidate runtime and upgrade surfaces

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,13 @@ name: Release
 #
 # Recoverability: stage a *draft* GitHub Release after candidate validation, publish
 # the same dist/ to PyPI, then undraft the Release only after PyPI succeeds. Reruns
-# may resume a matching draft; a published Release refuses republish.
+# may resume a matching draft; a published Release refuses republish. Before undraft,
+# published PyPI wheel/sdist SHA-256 must match candidate-SHA256SUMS (fail closed).
+#
+# Provenance env vars (CANDIDATE_*) are written once to $GITHUB_ENV and inherited by
+# later steps as runner environment variables. Do NOT redeclare them via
+# ${{ env.CANDIDATE_* }} — the workflow expression env context is not updated by
+# GITHUB_ENV writes and would overwrite valid values with empty strings.
 on:
   workflow_dispatch:
     inputs:
@@ -95,19 +101,20 @@ jobs:
 
           # Provenance comes from the verified checkout HEAD — not workflow GITHUB_SHA
           # (which names the ref that *started* workflow_dispatch and can differ).
+          # Later steps inherit these as runner env vars via GITHUB_ENV. Do not map
+          # them again with ${{ env.* }} expression context (that context stays empty).
           {
             echo "CANDIDATE_COMMIT=${HEAD_COMMIT}"
             echo "CANDIDATE_TAG=${TAG_INPUT}"
+            echo "CANDIDATE_VERSION=${EXPECTED}"
             echo "RESUME_DRAFT=${RESUME_DRAFT}"
           } >> "${GITHUB_ENV}"
 
           echo "Candidate tag=${TAG_INPUT} commit=${HEAD_COMMIT} resume_draft=${RESUME_DRAFT}"
 
       # Build once. Every later step must consume these exact files — never rebuild.
+      # CANDIDATE_* come from GITHUB_ENV inheritance (not expression-context remaps).
       - name: Build immutable candidate artifacts
-        env:
-          CANDIDATE_COMMIT: ${{ env.CANDIDATE_COMMIT }}
-          CANDIDATE_TAG: ${{ env.CANDIDATE_TAG }}
         run: |
           set -euo pipefail
           test -n "${CANDIDATE_COMMIT}"
@@ -172,13 +179,11 @@ jobs:
           test "$(ls dist/*.whl)" = "$WHEEL"
           test "$(ls dist/*.tar.gz)" = "$SDIST"
 
-      # Public surfaces: draft Release first, PyPI second, undraft only after PyPI OK.
+      # Public surfaces: draft Release first, PyPI second, undraft only after PyPI OK
+      # and after published PyPI bytes match candidate-SHA256SUMS.
       - name: Stage or resume draft GitHub Release with candidate provenance
         env:
           GH_TOKEN: ${{ github.token }}
-          CANDIDATE_TAG: ${{ env.CANDIDATE_TAG }}
-          CANDIDATE_COMMIT: ${{ env.CANDIDATE_COMMIT }}
-          RESUME_DRAFT: ${{ env.RESUME_DRAFT }}
         run: |
           set -euo pipefail
           TAG="${CANDIDATE_TAG}"
@@ -194,6 +199,8 @@ jobs:
               exit 1
             fi
             # Replace draft assets with the freshly validated candidate set.
+            # If a prior run already published PyPI, the undraft step fails closed
+            # unless these bytes match the public package hashes.
             gh release upload "$TAG" \
               --repo "${GITHUB_REPOSITORY}" \
               --clobber \
@@ -206,7 +213,7 @@ jobs:
             printf '%s\n' \
               "Candidate commit: \`${COMMIT}\`" \
               "" \
-              "Pre-publication gate validated wheel + sdist (packaged MCP, sdist install, 0.6.0 upgrade). PyPI publish of these exact artifacts runs next; this Release stays draft until PyPI succeeds." \
+              "Pre-publication gate validated wheel + sdist (packaged MCP, sdist install, 0.6.0 upgrade). PyPI publish of these exact artifacts runs next; this Release stays draft until PyPI succeeds and published hashes match \`candidate-SHA256SUMS\`." \
               "" \
               "See attached \`candidate-SHA256SUMS\` for provenance." \
               > "${NOTES_FILE}"
@@ -229,13 +236,102 @@ jobs:
           packages-dir: dist
           attestations: true
           # Resume-safe: a prior run may have published PyPI before undraft failed.
+          # skip-existing alone is NOT proof of byte identity — the next step verifies.
           skip-existing: true
 
-      - name: Publish GitHub Release (undraft after PyPI success)
+      - name: Verify published PyPI artifacts match candidate-SHA256SUMS
+        run: |
+          set -euo pipefail
+          test -n "${CANDIDATE_VERSION}"
+          test -f "${RUNNER_TEMP}/candidate-SHA256SUMS"
+
+          PYPI_DIR="${RUNNER_TEMP}/pypi-published"
+          mkdir -p "${PYPI_DIR}"
+
+          # Download the exact version's wheel + sdist from the public index and
+          # compare SHA-256 to the candidate set. skip-existing can leave prior
+          # PyPI bytes in place while a resume rebuilds different draft assets;
+          # fail closed on any mismatch before undrafting the GitHub Release.
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          import sys
+          import urllib.request
+          from pathlib import Path
+
+          version = os.environ["CANDIDATE_VERSION"]
+          sums_path = Path(os.environ["RUNNER_TEMP"]) / "candidate-SHA256SUMS"
+          out_dir = Path(os.environ["RUNNER_TEMP"]) / "pypi-published"
+
+          expected: dict[str, str] = {}
+          for line in sums_path.read_text(encoding="utf-8").splitlines():
+              parts = line.split()
+              if len(parts) >= 2 and (
+                  parts[1].endswith(".whl") or parts[1].endswith(".tar.gz")
+              ):
+                  # sha256sum lines: "<hash>  <path>"; normalize to basename
+                  expected[Path(parts[1]).name] = parts[0].lower()
+
+          if len(expected) < 2:
+              print(
+                  f"::error::candidate-SHA256SUMS must list wheel and sdist; got {sorted(expected)}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          url = f"https://pypi.org/pypi/fava-trails/{version}/json"
+          with urllib.request.urlopen(url, timeout=60) as resp:
+              meta = json.load(resp)
+
+          files = meta.get("urls") or []
+          by_name = {f["filename"]: f for f in files if f.get("filename")}
+          missing = sorted(set(expected) - set(by_name))
+          if missing:
+              print(
+                  f"::error::PyPI fava-trails=={version} missing required artifacts: {missing}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          mismatches = []
+          for name, want in sorted(expected.items()):
+              info = by_name[name]
+              dest = out_dir / name
+              print(f"Downloading {info['url']} -> {dest}")
+              urllib.request.urlretrieve(info["url"], dest)
+              got = hashlib.sha256(dest.read_bytes()).hexdigest().lower()
+              digests = info.get("digests") or {}
+              pypi_sha = (digests.get("sha256") or "").lower()
+              if pypi_sha and pypi_sha != got:
+                  mismatches.append(
+                      f"{name}: downloaded sha256 {got} != PyPI metadata sha256 {pypi_sha}"
+                  )
+              if got != want:
+                  mismatches.append(
+                      f"{name}: published sha256 {got} != candidate sha256 {want}"
+                  )
+              else:
+                  print(f"OK {name} sha256={got}")
+
+          if mismatches:
+              for msg in mismatches:
+                  print(f"::error::{msg}", file=sys.stderr)
+              print(
+                  "::error::Published PyPI artifacts diverge from candidate-SHA256SUMS; "
+                  "refusing to undraft GitHub Release (fail closed).",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          print(
+              f"Verified PyPI fava-trails=={version} wheel+sdist match candidate-SHA256SUMS"
+          )
+          PY
+
+      - name: Publish GitHub Release (undraft after PyPI hash proof)
         env:
           GH_TOKEN: ${{ github.token }}
-          CANDIDATE_TAG: ${{ env.CANDIDATE_TAG }}
-          CANDIDATE_COMMIT: ${{ env.CANDIDATE_COMMIT }}
         run: |
           set -euo pipefail
           TAG="${CANDIDATE_TAG}"
@@ -246,7 +342,7 @@ jobs:
             gh release edit "$TAG" \
               --repo "${GITHUB_REPOSITORY}" \
               --draft=false
-            echo "Published GitHub Release ${TAG} (undrafted after PyPI)"
+            echo "Published GitHub Release ${TAG} (undrafted after PyPI hash proof)"
           else
             echo "Release ${TAG} already public (idempotent undraft)"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,8 @@ name: Release
 # any public GitHub Release or PyPI upload exists. Owner-gated via:
 #   - workflow_dispatch on an already-pushed tag
 #   - GitHub Environment `fava-release` (required reviewer: owner)
-#   - peeled tag commit must equal current origin/main (reviewed default branch)
+#   - first publication: peeled tag commit must equal current origin/main
+#   - draft resume: peeled tag commit must be an ancestor of origin/main
 # Never triggers from `release: published`.
 #
 # Recoverability: stage a *draft* GitHub Release after candidate validation, publish
@@ -12,6 +13,8 @@ name: Release
 # may resume a matching draft; a published Release refuses republish. Before undraft,
 # published PyPI wheel/sdist SHA-256 must match candidate-SHA256SUMS (fail closed).
 # Resume normalizes draft title/notes/target to the verified candidate (not isDraft alone).
+# Draft-resume state is resolved *before* the main relationship check so a post-PyPI
+# retry is not stranded when protected main advances after the tag was cut.
 #
 # Provenance env vars (CANDIDATE_*) are written once to $GITHUB_ENV and inherited by
 # later steps as runner environment variables. Do NOT redeclare them via
@@ -76,38 +79,14 @@ jobs:
             exit 1
           fi
 
-          # 3) Fetch current reviewed default branch and peel tag to commit.
-          #    Issue #99 requires an immutable *reviewed* commit: the tag must name
-          #    the same commit as protected origin/main at dispatch time.
+          # 3) Fetch protected main and peel the tag (relationship checked after draft state).
           git fetch --no-tags origin "refs/heads/main:refs/remotes/origin/main"
           MAIN_COMMIT="$(git rev-parse "refs/remotes/origin/main")"
           TAG_COMMIT="$(git rev-parse "refs/tags/${TAG_INPUT}^{commit}")"
-          if [ "$TAG_COMMIT" != "$MAIN_COMMIT" ]; then
-            echo "::error::Peeled tag commit ${TAG_COMMIT} is not current origin/main ${MAIN_COMMIT}. Tag only the reviewed main tip before release."
-            exit 1
-          fi
 
-          # 4) Detach HEAD at the peeled tag and assert equality.
-          git checkout --detach "refs/tags/${TAG_INPUT}"
-          HEAD_COMMIT="$(git rev-parse HEAD)"
-          if [ "$HEAD_COMMIT" != "$TAG_COMMIT" ]; then
-            echo "::error::HEAD ${HEAD_COMMIT} does not equal peeled tag commit ${TAG_COMMIT}"
-            exit 1
-          fi
-          if [ "$HEAD_COMMIT" != "$MAIN_COMMIT" ]; then
-            echo "::error::HEAD ${HEAD_COMMIT} does not equal origin/main ${MAIN_COMMIT}"
-            exit 1
-          fi
-
-          # 5) Package version must match the tag (strip leading v).
-          PKG="$(grep '^version' pyproject.toml | head -1 | cut -d'"' -f2)"
-          EXPECTED="${TAG_INPUT#v}"
-          if [ "$EXPECTED" != "$PKG" ]; then
-            echo "::error::Tag ${TAG_INPUT} does not match pyproject.toml version ${PKG}"
-            exit 1
-          fi
-
-          # 6) Release recoverability: resume matching draft; refuse published Release.
+          # 4) Release recoverability state *before* the main relationship check.
+          #    If PyPI already published and undraft/hash-proof failed, main may have
+          #    advanced; requiring tip equality first would strand a valid tagged draft.
           #    Draft acceptance is not isDraft alone — later steps also normalize and
           #    verify target/title/notes against the verified candidate.
           RESUME_DRAFT=false
@@ -121,6 +100,53 @@ jobs:
             RESUME_DRAFT=true
           fi
 
+          # 5) Main relationship:
+          #    - first publication: tag must equal current protected origin/main tip
+          #    - draft resume: tag must be an ancestor of protected origin/main
+          #      (includes equality; allows main to advance after a partial publish)
+          if [ "$RESUME_DRAFT" = "true" ]; then
+            if ! git merge-base --is-ancestor "$TAG_COMMIT" "$MAIN_COMMIT"; then
+              echo "::error::Resume draft: peeled tag commit ${TAG_COMMIT} is not an ancestor of origin/main ${MAIN_COMMIT}"
+              exit 1
+            fi
+            if [ "$TAG_COMMIT" = "$MAIN_COMMIT" ]; then
+              MAIN_RELATION=exact
+            else
+              MAIN_RELATION=ancestor
+            fi
+            echo "Draft resume main relation=${MAIN_RELATION}: tag ${TAG_COMMIT} ⊆ origin/main ${MAIN_COMMIT}"
+          else
+            if [ "$TAG_COMMIT" != "$MAIN_COMMIT" ]; then
+              echo "::error::First publication: peeled tag commit ${TAG_COMMIT} is not current origin/main ${MAIN_COMMIT}. Tag only the reviewed main tip before release."
+              exit 1
+            fi
+            MAIN_RELATION=exact
+          fi
+
+          # 6) Detach HEAD at the peeled tag and assert checkout identity.
+          git checkout --detach "refs/tags/${TAG_INPUT}"
+          HEAD_COMMIT="$(git rev-parse HEAD)"
+          if [ "$HEAD_COMMIT" != "$TAG_COMMIT" ]; then
+            echo "::error::HEAD ${HEAD_COMMIT} does not equal peeled tag commit ${TAG_COMMIT}"
+            exit 1
+          fi
+          if [ "$RESUME_DRAFT" != "true" ] && [ "$HEAD_COMMIT" != "$MAIN_COMMIT" ]; then
+            echo "::error::First publication: HEAD ${HEAD_COMMIT} does not equal origin/main ${MAIN_COMMIT}"
+            exit 1
+          fi
+          if [ "$RESUME_DRAFT" = "true" ] && ! git merge-base --is-ancestor "$HEAD_COMMIT" "$MAIN_COMMIT"; then
+            echo "::error::Resume draft: HEAD ${HEAD_COMMIT} is not an ancestor of origin/main ${MAIN_COMMIT}"
+            exit 1
+          fi
+
+          # 7) Package version must match the tag (strip leading v).
+          PKG="$(grep '^version' pyproject.toml | head -1 | cut -d'"' -f2)"
+          EXPECTED="${TAG_INPUT#v}"
+          if [ "$EXPECTED" != "$PKG" ]; then
+            echo "::error::Tag ${TAG_INPUT} does not match pyproject.toml version ${PKG}"
+            exit 1
+          fi
+
           # Provenance comes from the verified checkout HEAD — not workflow GITHUB_SHA
           # (which names the ref that *started* workflow_dispatch and can differ).
           # Later steps inherit these as runner env vars via GITHUB_ENV. Do not map
@@ -130,10 +156,11 @@ jobs:
             echo "CANDIDATE_TAG=${TAG_INPUT}"
             echo "CANDIDATE_VERSION=${EXPECTED}"
             echo "CANDIDATE_MAIN=${MAIN_COMMIT}"
+            echo "CANDIDATE_MAIN_RELATION=${MAIN_RELATION}"
             echo "RESUME_DRAFT=${RESUME_DRAFT}"
           } >> "${GITHUB_ENV}"
 
-          echo "Candidate tag=${TAG_INPUT} commit=${HEAD_COMMIT} main=${MAIN_COMMIT} resume_draft=${RESUME_DRAFT}"
+          echo "Candidate tag=${TAG_INPUT} commit=${HEAD_COMMIT} main=${MAIN_COMMIT} relation=${MAIN_RELATION} resume_draft=${RESUME_DRAFT}"
 
       # Build once. Every later step must consume these exact files — never rebuild.
       # CANDIDATE_* come from GITHUB_ENV inheritance (not expression-context remaps).
@@ -143,8 +170,22 @@ jobs:
           test -n "${CANDIDATE_COMMIT}"
           test -n "${CANDIDATE_TAG}"
           test -n "${CANDIDATE_MAIN}"
+          test -n "${CANDIDATE_MAIN_RELATION}"
           test "$(git rev-parse HEAD)" = "${CANDIDATE_COMMIT}"
-          test "${CANDIDATE_COMMIT}" = "${CANDIDATE_MAIN}"
+          # First publication requires tip equality; draft resume allows ancestor.
+          if [ "${RESUME_DRAFT}" = "true" ]; then
+            git merge-base --is-ancestor "${CANDIDATE_COMMIT}" "${CANDIDATE_MAIN}"
+            case "${CANDIDATE_MAIN_RELATION}" in
+              exact|ancestor) ;;
+              *)
+                echo "::error::Unexpected CANDIDATE_MAIN_RELATION=${CANDIDATE_MAIN_RELATION}"
+                exit 1
+                ;;
+            esac
+          else
+            test "${CANDIDATE_COMMIT}" = "${CANDIDATE_MAIN}"
+            test "${CANDIDATE_MAIN_RELATION}" = "exact"
+          fi
 
           uv build
           ls -la dist
@@ -153,13 +194,17 @@ jobs:
             echo "CANDIDATE_COMMIT=${CANDIDATE_COMMIT}"
             echo "CANDIDATE_TAG=${CANDIDATE_TAG}"
             echo "CANDIDATE_MAIN=${CANDIDATE_MAIN}"
+            echo "CANDIDATE_MAIN_RELATION=${CANDIDATE_MAIN_RELATION}"
             echo "CANDIDATE_REF=$(git rev-parse HEAD)"
+            echo "RESUME_DRAFT=${RESUME_DRAFT}"
           } | tee "${RUNNER_TEMP}/candidate-SHA256SUMS"
 
-          # Sanity: provenance commit in the sums file must match verified HEAD/main.
+          # Sanity: provenance fields match the verified checkout (MAIN may differ
+          # from COMMIT on draft resume after protected main advanced).
           grep -qx "CANDIDATE_COMMIT=${CANDIDATE_COMMIT}" "${RUNNER_TEMP}/candidate-SHA256SUMS"
           grep -qx "CANDIDATE_REF=${CANDIDATE_COMMIT}" "${RUNNER_TEMP}/candidate-SHA256SUMS"
-          grep -qx "CANDIDATE_MAIN=${CANDIDATE_COMMIT}" "${RUNNER_TEMP}/candidate-SHA256SUMS"
+          grep -qx "CANDIDATE_MAIN=${CANDIDATE_MAIN}" "${RUNNER_TEMP}/candidate-SHA256SUMS"
+          grep -qx "CANDIDATE_MAIN_RELATION=${CANDIDATE_MAIN_RELATION}" "${RUNNER_TEMP}/candidate-SHA256SUMS"
 
       - name: Install jj (packaged gate dependency)
         run: |
@@ -217,16 +262,25 @@ jobs:
           COMMIT="${CANDIDATE_COMMIT}"
           test -n "$TAG"
           test -n "$COMMIT"
+          test -n "${CANDIDATE_MAIN}"
+          test -n "${CANDIDATE_MAIN_RELATION}"
           test "$(git rev-parse HEAD)" = "$COMMIT"
-          test "$COMMIT" = "${CANDIDATE_MAIN}"
+          if [ "${RESUME_DRAFT}" = "true" ]; then
+            git merge-base --is-ancestor "$COMMIT" "${CANDIDATE_MAIN}"
+          else
+            test "$COMMIT" = "${CANDIDATE_MAIN}"
+            test "${CANDIDATE_MAIN_RELATION}" = "exact"
+          fi
 
           # Canonical notes for both create and resume paths (never leave stale notes).
           NOTES_FILE="${RUNNER_TEMP}/release-notes.md"
           {
             printf '%s\n' "Candidate commit: \`${COMMIT}\`"
-            printf '%s\n' "Reviewed main: \`${CANDIDATE_MAIN}\`"
+            printf '%s\n' "Protected main at dispatch: \`${CANDIDATE_MAIN}\`"
+            printf '%s\n' "Main relation: \`${CANDIDATE_MAIN_RELATION}\` (exact tip for first publish; ancestor allowed on draft resume)"
+            printf '%s\n' "Resume draft: \`${RESUME_DRAFT}\`"
             printf '%s\n' ""
-            printf '%s\n' "Pre-publication gate validated wheel + sdist (packaged MCP, sdist install, 0.6.0 upgrade) on the immutable reviewed main tip via the \`fava-release\` environment. PyPI publish of these exact artifacts runs next; this Release stays draft until PyPI succeeds and published hashes match \`candidate-SHA256SUMS\`."
+            printf '%s\n' "Pre-publication gate validated wheel + sdist (packaged MCP, sdist install, 0.6.0 upgrade) on the immutable tagged candidate via the \`fava-release\` environment. PyPI publish of these exact artifacts runs next; this Release stays draft until PyPI succeeds and published hashes match \`candidate-SHA256SUMS\`."
             printf '%s\n' ""
             printf '%s\n' "See attached \`candidate-SHA256SUMS\` for provenance."
           } > "${NOTES_FILE}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,17 @@
 name: Release
 
 # Pre-publication gate (issue #99): validate immutable tag artifacts *before*
-# any public GitHub Release or PyPI upload exists. Owner-gated via workflow_dispatch
-# on an already-pushed tag — never triggers from `release: published`.
+# any public GitHub Release or PyPI upload exists. Owner-gated via:
+#   - workflow_dispatch on an already-pushed tag
+#   - GitHub Environment `fava-release` (required reviewer: owner)
+#   - peeled tag commit must equal current origin/main (reviewed default branch)
+# Never triggers from `release: published`.
 #
 # Recoverability: stage a *draft* GitHub Release after candidate validation, publish
 # the same dist/ to PyPI, then undraft the Release only after PyPI succeeds. Reruns
 # may resume a matching draft; a published Release refuses republish. Before undraft,
 # published PyPI wheel/sdist SHA-256 must match candidate-SHA256SUMS (fail closed).
+# Resume normalizes draft title/notes/target to the verified candidate (not isDraft alone).
 #
 # Provenance env vars (CANDIDATE_*) are written once to $GITHUB_ENV and inherited by
 # later steps as runner environment variables. Do NOT redeclare them via
@@ -29,6 +33,8 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Owner gate: environment requires explicit approval by configured reviewer.
+    environment: fava-release
 
     steps:
       # Resolve refs/tags/* only after shell-side validation — do not let checkout
@@ -49,7 +55,7 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Validate tag ref, peel commit, and check out candidate
+      - name: Validate tag ref, peel commit, bind main, and check out candidate
         env:
           # Pass dispatch input only via env — never interpolate into shell source.
           TAG_INPUT: ${{ inputs.tag }}
@@ -70,16 +76,30 @@ jobs:
             exit 1
           fi
 
-          # 3) Peel annotated/lightweight tag to commit and detach HEAD there.
+          # 3) Fetch current reviewed default branch and peel tag to commit.
+          #    Issue #99 requires an immutable *reviewed* commit: the tag must name
+          #    the same commit as protected origin/main at dispatch time.
+          git fetch --no-tags origin "refs/heads/main:refs/remotes/origin/main"
+          MAIN_COMMIT="$(git rev-parse "refs/remotes/origin/main")"
           TAG_COMMIT="$(git rev-parse "refs/tags/${TAG_INPUT}^{commit}")"
+          if [ "$TAG_COMMIT" != "$MAIN_COMMIT" ]; then
+            echo "::error::Peeled tag commit ${TAG_COMMIT} is not current origin/main ${MAIN_COMMIT}. Tag only the reviewed main tip before release."
+            exit 1
+          fi
+
+          # 4) Detach HEAD at the peeled tag and assert equality.
           git checkout --detach "refs/tags/${TAG_INPUT}"
           HEAD_COMMIT="$(git rev-parse HEAD)"
           if [ "$HEAD_COMMIT" != "$TAG_COMMIT" ]; then
             echo "::error::HEAD ${HEAD_COMMIT} does not equal peeled tag commit ${TAG_COMMIT}"
             exit 1
           fi
+          if [ "$HEAD_COMMIT" != "$MAIN_COMMIT" ]; then
+            echo "::error::HEAD ${HEAD_COMMIT} does not equal origin/main ${MAIN_COMMIT}"
+            exit 1
+          fi
 
-          # 4) Package version must match the tag (strip leading v).
+          # 5) Package version must match the tag (strip leading v).
           PKG="$(grep '^version' pyproject.toml | head -1 | cut -d'"' -f2)"
           EXPECTED="${TAG_INPUT#v}"
           if [ "$EXPECTED" != "$PKG" ]; then
@@ -87,7 +107,9 @@ jobs:
             exit 1
           fi
 
-          # 5) Release recoverability: resume matching draft; refuse published Release.
+          # 6) Release recoverability: resume matching draft; refuse published Release.
+          #    Draft acceptance is not isDraft alone — later steps also normalize and
+          #    verify target/title/notes against the verified candidate.
           RESUME_DRAFT=false
           if gh release view "$TAG_INPUT" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             IS_DRAFT="$(gh release view "$TAG_INPUT" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft)"
@@ -107,10 +129,11 @@ jobs:
             echo "CANDIDATE_COMMIT=${HEAD_COMMIT}"
             echo "CANDIDATE_TAG=${TAG_INPUT}"
             echo "CANDIDATE_VERSION=${EXPECTED}"
+            echo "CANDIDATE_MAIN=${MAIN_COMMIT}"
             echo "RESUME_DRAFT=${RESUME_DRAFT}"
           } >> "${GITHUB_ENV}"
 
-          echo "Candidate tag=${TAG_INPUT} commit=${HEAD_COMMIT} resume_draft=${RESUME_DRAFT}"
+          echo "Candidate tag=${TAG_INPUT} commit=${HEAD_COMMIT} main=${MAIN_COMMIT} resume_draft=${RESUME_DRAFT}"
 
       # Build once. Every later step must consume these exact files — never rebuild.
       # CANDIDATE_* come from GITHUB_ENV inheritance (not expression-context remaps).
@@ -119,7 +142,9 @@ jobs:
           set -euo pipefail
           test -n "${CANDIDATE_COMMIT}"
           test -n "${CANDIDATE_TAG}"
+          test -n "${CANDIDATE_MAIN}"
           test "$(git rev-parse HEAD)" = "${CANDIDATE_COMMIT}"
+          test "${CANDIDATE_COMMIT}" = "${CANDIDATE_MAIN}"
 
           uv build
           ls -la dist
@@ -127,12 +152,14 @@ jobs:
             sha256sum dist/*.whl dist/*.tar.gz
             echo "CANDIDATE_COMMIT=${CANDIDATE_COMMIT}"
             echo "CANDIDATE_TAG=${CANDIDATE_TAG}"
+            echo "CANDIDATE_MAIN=${CANDIDATE_MAIN}"
             echo "CANDIDATE_REF=$(git rev-parse HEAD)"
           } | tee "${RUNNER_TEMP}/candidate-SHA256SUMS"
 
-          # Sanity: provenance commit in the sums file must match verified HEAD.
+          # Sanity: provenance commit in the sums file must match verified HEAD/main.
           grep -qx "CANDIDATE_COMMIT=${CANDIDATE_COMMIT}" "${RUNNER_TEMP}/candidate-SHA256SUMS"
           grep -qx "CANDIDATE_REF=${CANDIDATE_COMMIT}" "${RUNNER_TEMP}/candidate-SHA256SUMS"
+          grep -qx "CANDIDATE_MAIN=${CANDIDATE_COMMIT}" "${RUNNER_TEMP}/candidate-SHA256SUMS"
 
       - name: Install jj (packaged gate dependency)
         run: |
@@ -191,13 +218,84 @@ jobs:
           test -n "$TAG"
           test -n "$COMMIT"
           test "$(git rev-parse HEAD)" = "$COMMIT"
+          test "$COMMIT" = "${CANDIDATE_MAIN}"
+
+          # Canonical notes for both create and resume paths (never leave stale notes).
+          NOTES_FILE="${RUNNER_TEMP}/release-notes.md"
+          {
+            printf '%s\n' "Candidate commit: \`${COMMIT}\`"
+            printf '%s\n' "Reviewed main: \`${CANDIDATE_MAIN}\`"
+            printf '%s\n' ""
+            printf '%s\n' "Pre-publication gate validated wheel + sdist (packaged MCP, sdist install, 0.6.0 upgrade) on the immutable reviewed main tip via the \`fava-release\` environment. PyPI publish of these exact artifacts runs next; this Release stays draft until PyPI succeeds and published hashes match \`candidate-SHA256SUMS\`."
+            printf '%s\n' ""
+            printf '%s\n' "See attached \`candidate-SHA256SUMS\` for provenance."
+          } > "${NOTES_FILE}"
+
+          resolve_target_commit() {
+            local raw="$1"
+            if git rev-parse -q --verify "${raw}^{commit}" >/dev/null 2>&1; then
+              git rev-parse "${raw}^{commit}"
+              return 0
+            fi
+            if git rev-parse -q --verify "refs/remotes/origin/${raw}^{commit}" >/dev/null 2>&1; then
+              git rev-parse "refs/remotes/origin/${raw}^{commit}"
+              return 0
+            fi
+            if git rev-parse -q --verify "refs/heads/${raw}^{commit}" >/dev/null 2>&1; then
+              git rev-parse "refs/heads/${raw}^{commit}"
+              return 0
+            fi
+            echo ""
+          }
 
           if [ "${RESUME_DRAFT}" = "true" ]; then
-            IS_DRAFT="$(gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft)"
+            META="$(gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" \
+              --json isDraft,tagName,targetCommitish,name)"
+            IS_DRAFT="$(printf '%s' "$META" | jq -r .isDraft)"
+            REL_TAG="$(printf '%s' "$META" | jq -r .tagName)"
+            REL_TARGET_RAW="$(printf '%s' "$META" | jq -r .targetCommitish)"
             if [ "$IS_DRAFT" != "true" ]; then
               echo "::error::Release ${TAG} is no longer a draft; refusing to mutate a public Release"
               exit 1
             fi
+            if [ "$REL_TAG" != "$TAG" ]; then
+              echo "::error::Draft tagName ${REL_TAG} does not match candidate tag ${TAG}"
+              exit 1
+            fi
+            REL_TARGET="$(resolve_target_commit "$REL_TARGET_RAW")"
+            if [ -z "$REL_TARGET" ]; then
+              echo "::error::Unable to resolve draft targetCommitish '${REL_TARGET_RAW}' to a commit"
+              exit 1
+            fi
+            if [ "$REL_TARGET" != "$COMMIT" ]; then
+              echo "::error::Draft target ${REL_TARGET_RAW} resolves to ${REL_TARGET}, not candidate ${COMMIT}; normalizing via gh release edit --target"
+            fi
+
+            # Normalize title, notes, and target to the verified candidate before assets/PyPI.
+            gh release edit "$TAG" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --draft \
+              --title "$TAG" \
+              --notes-file "${NOTES_FILE}" \
+              --target "$COMMIT"
+
+            # Re-read and require target/title/tag match after edit.
+            META="$(gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" \
+              --json isDraft,tagName,targetCommitish,name)"
+            IS_DRAFT="$(printf '%s' "$META" | jq -r .isDraft)"
+            REL_TAG="$(printf '%s' "$META" | jq -r .tagName)"
+            REL_NAME="$(printf '%s' "$META" | jq -r .name)"
+            REL_TARGET_RAW="$(printf '%s' "$META" | jq -r .targetCommitish)"
+            REL_TARGET="$(resolve_target_commit "$REL_TARGET_RAW")"
+            if [ "$IS_DRAFT" != "true" ] || [ "$REL_TAG" != "$TAG" ] || [ "$REL_NAME" != "$TAG" ]; then
+              echo "::error::Draft metadata mismatch after normalize (isDraft=${IS_DRAFT} tag=${REL_TAG} name=${REL_NAME})"
+              exit 1
+            fi
+            if [ -z "$REL_TARGET" ] || [ "$REL_TARGET" != "$COMMIT" ]; then
+              echo "::error::Draft target after normalize is '${REL_TARGET_RAW}' -> '${REL_TARGET}', expected ${COMMIT}"
+              exit 1
+            fi
+
             # Replace draft assets with the freshly validated candidate set.
             # If a prior run already published PyPI, the undraft step fails closed
             # unless these bytes match the public package hashes.
@@ -207,16 +305,8 @@ jobs:
               dist/*.whl \
               dist/*.tar.gz \
               "${RUNNER_TEMP}/candidate-SHA256SUMS"
-            echo "Updated draft release assets for ${TAG} at ${COMMIT}"
+            echo "Normalized and updated draft release ${TAG} targeting ${COMMIT}"
           else
-            NOTES_FILE="${RUNNER_TEMP}/release-notes.md"
-            printf '%s\n' \
-              "Candidate commit: \`${COMMIT}\`" \
-              "" \
-              "Pre-publication gate validated wheel + sdist (packaged MCP, sdist install, 0.6.0 upgrade). PyPI publish of these exact artifacts runs next; this Release stays draft until PyPI succeeds and published hashes match \`candidate-SHA256SUMS\`." \
-              "" \
-              "See attached \`candidate-SHA256SUMS\` for provenance." \
-              > "${NOTES_FILE}"
             gh release create "$TAG" \
               --repo "${GITHUB_REPOSITORY}" \
               --draft \
@@ -229,6 +319,21 @@ jobs:
               "${RUNNER_TEMP}/candidate-SHA256SUMS"
             echo "Created draft release ${TAG} targeting ${COMMIT}"
           fi
+
+          # Common post-condition for create and resume.
+          META="$(gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" \
+            --json isDraft,tagName,targetCommitish,name)"
+          IS_DRAFT="$(printf '%s' "$META" | jq -r .isDraft)"
+          REL_TAG="$(printf '%s' "$META" | jq -r .tagName)"
+          REL_NAME="$(printf '%s' "$META" | jq -r .name)"
+          REL_TARGET_RAW="$(printf '%s' "$META" | jq -r .targetCommitish)"
+          REL_TARGET="$(resolve_target_commit "$REL_TARGET_RAW")"
+          test "$IS_DRAFT" = "true"
+          test "$REL_TAG" = "$TAG"
+          test "$REL_NAME" = "$TAG"
+          test -n "$REL_TARGET"
+          test "$REL_TARGET" = "$COMMIT"
+          echo "Draft release metadata verified: tag=${REL_TAG} title=${REL_NAME} target=${REL_TARGET}"
 
       - name: Publish the same candidate artifacts to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -335,9 +440,44 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${CANDIDATE_TAG}"
+          COMMIT="${CANDIDATE_COMMIT}"
           test -n "$TAG"
+          test -n "$COMMIT"
 
-          IS_DRAFT="$(gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft)"
+          META="$(gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" \
+            --json isDraft,tagName,targetCommitish,name)"
+          IS_DRAFT="$(printf '%s' "$META" | jq -r .isDraft)"
+          REL_TAG="$(printf '%s' "$META" | jq -r .tagName)"
+          REL_NAME="$(printf '%s' "$META" | jq -r .name)"
+          REL_TARGET_RAW="$(printf '%s' "$META" | jq -r .targetCommitish)"
+
+          resolve_target_commit() {
+            local raw="$1"
+            if git rev-parse -q --verify "${raw}^{commit}" >/dev/null 2>&1; then
+              git rev-parse "${raw}^{commit}"
+              return 0
+            fi
+            if git rev-parse -q --verify "refs/remotes/origin/${raw}^{commit}" >/dev/null 2>&1; then
+              git rev-parse "refs/remotes/origin/${raw}^{commit}"
+              return 0
+            fi
+            if git rev-parse -q --verify "refs/heads/${raw}^{commit}" >/dev/null 2>&1; then
+              git rev-parse "refs/heads/${raw}^{commit}"
+              return 0
+            fi
+            echo ""
+          }
+          REL_TARGET="$(resolve_target_commit "$REL_TARGET_RAW")"
+
+          if [ "$REL_TAG" != "$TAG" ] || [ "$REL_NAME" != "$TAG" ]; then
+            echo "::error::Release metadata mismatch before undraft (tag=${REL_TAG} name=${REL_NAME})"
+            exit 1
+          fi
+          if [ -z "$REL_TARGET" ] || [ "$REL_TARGET" != "$COMMIT" ]; then
+            echo "::error::Release target before undraft is '${REL_TARGET_RAW}' -> '${REL_TARGET}', expected ${COMMIT}"
+            exit 1
+          fi
+
           if [ "$IS_DRAFT" = "true" ]; then
             gh release edit "$TAG" \
               --repo "${GITHUB_REPOSITORY}" \
@@ -349,5 +489,5 @@ jobs:
 
           # Final state: public Release + candidate provenance asset present.
           gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" \
-            --json isDraft,tagName,targetCommitish,assets \
-            --jq '{isDraft,tagName,targetCommitish,assets:[.assets[].name]}'
+            --json isDraft,tagName,targetCommitish,name,assets \
+            --jq '{isDraft,tagName,targetCommitish,name,assets:[.assets[].name]}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,19 @@
 name: Release
 
+# Pre-publication gate (issue #99): validate immutable tag artifacts *before*
+# any public GitHub Release or PyPI upload exists. Owner-gated via workflow_dispatch
+# on an already-pushed tag — never triggers from `release: published` (which would
+# leave a public Release if candidate validation failed).
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing immutable tag to validate and publish (e.g. v0.6.1)"
+        required: true
+        type: string
 
 permissions:
-  contents: write       # Attach candidate SHA256SUMS to the GitHub Release
+  contents: write       # Create the GitHub Release + attach candidate SHA256SUMS
   id-token: write       # Required for OIDC Trusted Publishing
   attestations: write   # Required for SLSA provenance attestations
 
@@ -14,21 +22,38 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the immutable tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.11"
 
+      - name: Setup Node (native MCP client registration evidence)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Verify version matches tag
         run: |
-          TAG=${GITHUB_REF#refs/tags/v}
+          set -euo pipefail
+          TAG_INPUT="${{ inputs.tag }}"
+          TAG="${TAG_INPUT#v}"
           PKG=$(grep '^version' pyproject.toml | cut -d'"' -f2)
           if [ "$TAG" != "$PKG" ]; then
             echo "::error::Tag v$TAG does not match pyproject.toml version $PKG"
             exit 1
           fi
+          # Refuse if a public GitHub Release already exists for this tag.
+          if gh release view "$TAG_INPUT" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "::error::GitHub Release $TAG_INPUT already exists. Refusing split-state republish."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       # Build once. Every later step must consume these exact files — never rebuild.
       - name: Build immutable candidate artifacts
@@ -36,11 +61,11 @@ jobs:
           set -euo pipefail
           uv build
           ls -la dist
-          # Manifest of the exact bytes that will be tested and published.
           {
             sha256sum dist/*.whl dist/*.tar.gz
             echo "CANDIDATE_COMMIT=${GITHUB_SHA}"
-            echo "CANDIDATE_TAG=${GITHUB_REF_NAME}"
+            echo "CANDIDATE_TAG=${{ inputs.tag }}"
+            echo "CANDIDATE_REF=$(git rev-parse HEAD)"
           } | tee "${RUNNER_TEMP}/candidate-SHA256SUMS"
 
       - name: Install jj (packaged gate dependency)
@@ -50,10 +75,11 @@ jobs:
           if ! command -v jj >/dev/null 2>&1; then
             uv run fava-trails install-jj
           fi
-          command -v jj
-          jj --version
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          command -v jj || true
+          "$HOME/.local/bin/jj" --version
 
-      - name: Verify the exact candidate wheel (packaged gates)
+      - name: Verify the exact candidate wheel + sdist (packaged gates)
         run: |
           set -euo pipefail
           WHEEL=$(ls dist/*.whl)
@@ -66,44 +92,42 @@ jobs:
           }
           verify_candidate_hashes
 
-          uv venv "${RUNNER_TEMP}/candidate-venv"
-          # Install the exact built wheel — not a rebuild and not PyPI.
-          uv pip install --python "${RUNNER_TEMP}/candidate-venv/bin/python" "$WHEEL"
-          uv pip install --python "${RUNNER_TEMP}/candidate-venv/bin/python" \
-            "pytest>=9,<10" "pytest-asyncio>=1.3,<2" "jsonschema>=4.26,<5"
-
+          export FAVA_CANDIDATE_WHEEL="$WHEEL"
+          export FAVA_CANDIDATE_SDIST="$SDIST"
           export FAVA_EXPECT_WHEEL=1
-          export PATH="${RUNNER_TEMP}/candidate-venv/bin:${PATH}"
-          "${RUNNER_TEMP}/candidate-venv/bin/fava-trails" version
-          "${RUNNER_TEMP}/candidate-venv/bin/python" - <<'PY'
-          import pathlib
-          import fava_trails
-          path = pathlib.Path(fava_trails.__file__)
-          assert "site-packages" in path.parts, path
-          print("loaded", path)
-          PY
+          export PATH="$HOME/.local/bin:${PATH}"
+          export JJ_CONFIG=/dev/null
 
-          # Direct stdio + native registration + two-process identity (#99/#83)
-          # plus governed recall isolation (#72) against the installed wheel.
-          "${RUNNER_TEMP}/candidate-venv/bin/pytest" \
-            tests/test_mcp_protocol.py \
-            tests/test_runtime_info.py \
-            tests/test_governance.py \
+          # Bind verification to the already-built candidates:
+          # - fresh wheel install + fava-trails version
+          # - real 0.6.0 → candidate wheel upgrade
+          # - fresh sdist install
+          # - installed-wheel MCP (direct stdio + native Inspector registration + two-process)
+          # - governed recall isolation (#72) + runtime_info
+          uv run pytest \
+            tests/test_packaged_mcp.py \
             -v --tb=short
 
-          # Confirm we still publish the same bytes that were just tested.
+          # Confirm we still hold the same bytes that were just tested.
           verify_candidate_hashes
           test "$(ls dist/*.whl)" = "$WHEEL"
           test "$(ls dist/*.tar.gz)" = "$SDIST"
 
-      - name: Attach candidate provenance to the GitHub Release
+      # Public surfaces are created only after validation succeeds.
+      - name: Create GitHub Release with candidate provenance
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${GITHUB_REF_NAME}" \
-            "${RUNNER_TEMP}/candidate-SHA256SUMS" \
-            --clobber \
-            --repo "${GITHUB_REPOSITORY}"
+          set -euo pipefail
+          TAG="${{ inputs.tag }}"
+          gh release create "$TAG" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "$TAG" \
+            --generate-notes \
+            --verify-tag \
+            dist/*.whl \
+            dist/*.tar.gz \
+            "${RUNNER_TEMP}/candidate-SHA256SUMS"
 
       - name: Publish the same candidate artifacts to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,9 @@ on:
     types: [published]
 
 permissions:
-  contents: read
-  id-token: write      # Required for OIDC Trusted Publishing
-  attestations: write  # Required for SLSA provenance attestations
+  contents: write       # Attach candidate SHA256SUMS to the GitHub Release
+  id-token: write       # Required for OIDC Trusted Publishing
+  attestations: write   # Required for SLSA provenance attestations
 
 jobs:
   publish:
@@ -30,10 +30,83 @@ jobs:
             exit 1
           fi
 
-      - name: Build package
-        run: uv build
+      # Build once. Every later step must consume these exact files — never rebuild.
+      - name: Build immutable candidate artifacts
+        run: |
+          set -euo pipefail
+          uv build
+          ls -la dist
+          # Manifest of the exact bytes that will be tested and published.
+          {
+            sha256sum dist/*.whl dist/*.tar.gz
+            echo "CANDIDATE_COMMIT=${GITHUB_SHA}"
+            echo "CANDIDATE_TAG=${GITHUB_REF_NAME}"
+          } | tee "${RUNNER_TEMP}/candidate-SHA256SUMS"
 
-      - name: Publish to PyPI
+      - name: Install jj (packaged gate dependency)
+        run: |
+          set -euo pipefail
+          uv sync --frozen
+          if ! command -v jj >/dev/null 2>&1; then
+            uv run fava-trails install-jj
+          fi
+          command -v jj
+          jj --version
+
+      - name: Verify the exact candidate wheel (packaged gates)
+        run: |
+          set -euo pipefail
+          WHEEL=$(ls dist/*.whl)
+          SDIST=$(ls dist/*.tar.gz)
+          test -f "$WHEEL"
+          test -f "$SDIST"
+
+          verify_candidate_hashes() {
+            awk '/\.(whl|tar\.gz)$/ {print $1"  "$2}' "${RUNNER_TEMP}/candidate-SHA256SUMS" | sha256sum -c -
+          }
+          verify_candidate_hashes
+
+          uv venv "${RUNNER_TEMP}/candidate-venv"
+          # Install the exact built wheel — not a rebuild and not PyPI.
+          uv pip install --python "${RUNNER_TEMP}/candidate-venv/bin/python" "$WHEEL"
+          uv pip install --python "${RUNNER_TEMP}/candidate-venv/bin/python" \
+            "pytest>=9,<10" "pytest-asyncio>=1.3,<2" "jsonschema>=4.26,<5"
+
+          export FAVA_EXPECT_WHEEL=1
+          export PATH="${RUNNER_TEMP}/candidate-venv/bin:${PATH}"
+          "${RUNNER_TEMP}/candidate-venv/bin/fava-trails" version
+          "${RUNNER_TEMP}/candidate-venv/bin/python" - <<'PY'
+          import pathlib
+          import fava_trails
+          path = pathlib.Path(fava_trails.__file__)
+          assert "site-packages" in path.parts, path
+          print("loaded", path)
+          PY
+
+          # Direct stdio + native registration + two-process identity (#99/#83)
+          # plus governed recall isolation (#72) against the installed wheel.
+          "${RUNNER_TEMP}/candidate-venv/bin/pytest" \
+            tests/test_mcp_protocol.py \
+            tests/test_runtime_info.py \
+            tests/test_governance.py \
+            -v --tb=short
+
+          # Confirm we still publish the same bytes that were just tested.
+          verify_candidate_hashes
+          test "$(ls dist/*.whl)" = "$WHEEL"
+          test "$(ls dist/*.tar.gz)" = "$SDIST"
+
+      - name: Attach candidate provenance to the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${GITHUB_REF_NAME}" \
+            "${RUNNER_TEMP}/candidate-SHA256SUMS" \
+            --clobber \
+            --repo "${GITHUB_REPOSITORY}"
+
+      - name: Publish the same candidate artifacts to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          packages-dir: dist
           attestations: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,11 @@ name: Release
 
 # Pre-publication gate (issue #99): validate immutable tag artifacts *before*
 # any public GitHub Release or PyPI upload exists. Owner-gated via workflow_dispatch
-# on an already-pushed tag — never triggers from `release: published` (which would
-# leave a public Release if candidate validation failed).
+# on an already-pushed tag — never triggers from `release: published`.
+#
+# Recoverability: stage a *draft* GitHub Release after candidate validation, publish
+# the same dist/ to PyPI, then undraft the Release only after PyPI succeeds. Reruns
+# may resume a matching draft; a published Release refuses republish.
 on:
   workflow_dispatch:
     inputs:
@@ -13,7 +16,7 @@ on:
         type: string
 
 permissions:
-  contents: write       # Create the GitHub Release + attach candidate SHA256SUMS
+  contents: write       # Draft/publish GitHub Release + attach candidate SHA256SUMS
   id-token: write       # Required for OIDC Trusted Publishing
   attestations: write   # Required for SLSA provenance attestations
 
@@ -22,10 +25,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout the immutable tag
+      # Resolve refs/tags/* only after shell-side validation — do not let checkout
+      # pick an ambiguous same-named branch/tag via `ref: ${{ inputs.tag }}`.
+      - name: Checkout repository (full history for tag peel)
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -37,36 +43,89 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Verify version matches tag
+      - name: Validate tag ref, peel commit, and check out candidate
+        env:
+          # Pass dispatch input only via env — never interpolate into shell source.
+          TAG_INPUT: ${{ inputs.tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          TAG_INPUT="${{ inputs.tag }}"
-          TAG="${TAG_INPUT#v}"
-          PKG=$(grep '^version' pyproject.toml | cut -d'"' -f2)
-          if [ "$TAG" != "$PKG" ]; then
-            echo "::error::Tag v$TAG does not match pyproject.toml version $PKG"
+
+          # 1) Strict tag grammar (vMAJOR.MINOR.PATCH only).
+          if ! [[ "$TAG_INPUT" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag must match ^v[0-9]+.[0-9]+.[0-9]+$ (got: $TAG_INPUT)"
             exit 1
           fi
-          # Refuse if a public GitHub Release already exists for this tag.
+
+          # 2) Ensure the exact tag ref exists on origin (not a branch of the same name).
+          git fetch --no-tags origin "refs/tags/${TAG_INPUT}:refs/tags/${TAG_INPUT}"
+          if ! git rev-parse -q --verify "refs/tags/${TAG_INPUT}" >/dev/null; then
+            echo "::error::refs/tags/${TAG_INPUT} does not exist after fetch"
+            exit 1
+          fi
+
+          # 3) Peel annotated/lightweight tag to commit and detach HEAD there.
+          TAG_COMMIT="$(git rev-parse "refs/tags/${TAG_INPUT}^{commit}")"
+          git checkout --detach "refs/tags/${TAG_INPUT}"
+          HEAD_COMMIT="$(git rev-parse HEAD)"
+          if [ "$HEAD_COMMIT" != "$TAG_COMMIT" ]; then
+            echo "::error::HEAD ${HEAD_COMMIT} does not equal peeled tag commit ${TAG_COMMIT}"
+            exit 1
+          fi
+
+          # 4) Package version must match the tag (strip leading v).
+          PKG="$(grep '^version' pyproject.toml | head -1 | cut -d'"' -f2)"
+          EXPECTED="${TAG_INPUT#v}"
+          if [ "$EXPECTED" != "$PKG" ]; then
+            echo "::error::Tag ${TAG_INPUT} does not match pyproject.toml version ${PKG}"
+            exit 1
+          fi
+
+          # 5) Release recoverability: resume matching draft; refuse published Release.
+          RESUME_DRAFT=false
           if gh release view "$TAG_INPUT" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            echo "::error::GitHub Release $TAG_INPUT already exists. Refusing split-state republish."
-            exit 1
+            IS_DRAFT="$(gh release view "$TAG_INPUT" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft)"
+            if [ "$IS_DRAFT" != "true" ]; then
+              echo "::error::GitHub Release ${TAG_INPUT} is already published. Refusing split-state republish."
+              exit 1
+            fi
+            echo "Resuming existing draft GitHub Release for ${TAG_INPUT}"
+            RESUME_DRAFT=true
           fi
-        env:
-          GH_TOKEN: ${{ github.token }}
+
+          # Provenance comes from the verified checkout HEAD — not workflow GITHUB_SHA
+          # (which names the ref that *started* workflow_dispatch and can differ).
+          {
+            echo "CANDIDATE_COMMIT=${HEAD_COMMIT}"
+            echo "CANDIDATE_TAG=${TAG_INPUT}"
+            echo "RESUME_DRAFT=${RESUME_DRAFT}"
+          } >> "${GITHUB_ENV}"
+
+          echo "Candidate tag=${TAG_INPUT} commit=${HEAD_COMMIT} resume_draft=${RESUME_DRAFT}"
 
       # Build once. Every later step must consume these exact files — never rebuild.
       - name: Build immutable candidate artifacts
+        env:
+          CANDIDATE_COMMIT: ${{ env.CANDIDATE_COMMIT }}
+          CANDIDATE_TAG: ${{ env.CANDIDATE_TAG }}
         run: |
           set -euo pipefail
+          test -n "${CANDIDATE_COMMIT}"
+          test -n "${CANDIDATE_TAG}"
+          test "$(git rev-parse HEAD)" = "${CANDIDATE_COMMIT}"
+
           uv build
           ls -la dist
           {
             sha256sum dist/*.whl dist/*.tar.gz
-            echo "CANDIDATE_COMMIT=${GITHUB_SHA}"
-            echo "CANDIDATE_TAG=${{ inputs.tag }}"
+            echo "CANDIDATE_COMMIT=${CANDIDATE_COMMIT}"
+            echo "CANDIDATE_TAG=${CANDIDATE_TAG}"
             echo "CANDIDATE_REF=$(git rev-parse HEAD)"
           } | tee "${RUNNER_TEMP}/candidate-SHA256SUMS"
+
+          # Sanity: provenance commit in the sums file must match verified HEAD.
+          grep -qx "CANDIDATE_COMMIT=${CANDIDATE_COMMIT}" "${RUNNER_TEMP}/candidate-SHA256SUMS"
+          grep -qx "CANDIDATE_REF=${CANDIDATE_COMMIT}" "${RUNNER_TEMP}/candidate-SHA256SUMS"
 
       - name: Install jj (packaged gate dependency)
         run: |
@@ -113,24 +172,86 @@ jobs:
           test "$(ls dist/*.whl)" = "$WHEEL"
           test "$(ls dist/*.tar.gz)" = "$SDIST"
 
-      # Public surfaces are created only after validation succeeds.
-      - name: Create GitHub Release with candidate provenance
+      # Public surfaces: draft Release first, PyPI second, undraft only after PyPI OK.
+      - name: Stage or resume draft GitHub Release with candidate provenance
         env:
           GH_TOKEN: ${{ github.token }}
+          CANDIDATE_TAG: ${{ env.CANDIDATE_TAG }}
+          CANDIDATE_COMMIT: ${{ env.CANDIDATE_COMMIT }}
+          RESUME_DRAFT: ${{ env.RESUME_DRAFT }}
         run: |
           set -euo pipefail
-          TAG="${{ inputs.tag }}"
-          gh release create "$TAG" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --title "$TAG" \
-            --generate-notes \
-            --verify-tag \
-            dist/*.whl \
-            dist/*.tar.gz \
-            "${RUNNER_TEMP}/candidate-SHA256SUMS"
+          TAG="${CANDIDATE_TAG}"
+          COMMIT="${CANDIDATE_COMMIT}"
+          test -n "$TAG"
+          test -n "$COMMIT"
+          test "$(git rev-parse HEAD)" = "$COMMIT"
+
+          if [ "${RESUME_DRAFT}" = "true" ]; then
+            IS_DRAFT="$(gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft)"
+            if [ "$IS_DRAFT" != "true" ]; then
+              echo "::error::Release ${TAG} is no longer a draft; refusing to mutate a public Release"
+              exit 1
+            fi
+            # Replace draft assets with the freshly validated candidate set.
+            gh release upload "$TAG" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --clobber \
+              dist/*.whl \
+              dist/*.tar.gz \
+              "${RUNNER_TEMP}/candidate-SHA256SUMS"
+            echo "Updated draft release assets for ${TAG} at ${COMMIT}"
+          else
+            NOTES_FILE="${RUNNER_TEMP}/release-notes.md"
+            printf '%s\n' \
+              "Candidate commit: \`${COMMIT}\`" \
+              "" \
+              "Pre-publication gate validated wheel + sdist (packaged MCP, sdist install, 0.6.0 upgrade). PyPI publish of these exact artifacts runs next; this Release stays draft until PyPI succeeds." \
+              "" \
+              "See attached \`candidate-SHA256SUMS\` for provenance." \
+              > "${NOTES_FILE}"
+            gh release create "$TAG" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --draft \
+              --title "$TAG" \
+              --notes-file "${NOTES_FILE}" \
+              --verify-tag \
+              --target "$COMMIT" \
+              dist/*.whl \
+              dist/*.tar.gz \
+              "${RUNNER_TEMP}/candidate-SHA256SUMS"
+            echo "Created draft release ${TAG} targeting ${COMMIT}"
+          fi
 
       - name: Publish the same candidate artifacts to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
           attestations: true
+          # Resume-safe: a prior run may have published PyPI before undraft failed.
+          skip-existing: true
+
+      - name: Publish GitHub Release (undraft after PyPI success)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_TAG: ${{ env.CANDIDATE_TAG }}
+          CANDIDATE_COMMIT: ${{ env.CANDIDATE_COMMIT }}
+        run: |
+          set -euo pipefail
+          TAG="${CANDIDATE_TAG}"
+          test -n "$TAG"
+
+          IS_DRAFT="$(gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft)"
+          if [ "$IS_DRAFT" = "true" ]; then
+            gh release edit "$TAG" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --draft=false
+            echo "Published GitHub Release ${TAG} (undrafted after PyPI)"
+          else
+            echo "Release ${TAG} already public (idempotent undraft)"
+          fi
+
+          # Final state: public Release + candidate provenance asset present.
+          gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" \
+            --json isDraft,tagName,targetCommitish,assets \
+            --jq '{isDraft,tagName,targetCommitish,assets:[.assets[].name]}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,13 @@ All notable changes to FAVA Trails are documented here.
   processes for authoring isolation + spoof rejection on the installed wheel;
   packaged verifier binds to `FAVA_CANDIDATE_WHEEL`/`FAVA_CANDIDATE_SDIST` for
   fresh wheel install, sdist install, and 0.6.0→candidate upgrade; `release.yml`
-  is a pre-publication `workflow_dispatch` on an existing tag that proves
-  `refs/tags/*` peel equals verified `HEAD` (env-passed tag input; provenance from
-  that commit via `$GITHUB_ENV` inheritance, not dispatch `GITHUB_SHA` or empty
-  expression-context remaps), validates exact artifacts, stages a **draft**
-  GitHub Release, publishes the same `dist/` to PyPI, requires published PyPI
+  is a pre-publication `workflow_dispatch` on an existing tag under the
+  `fava-release` environment that proves `refs/tags/*` peel equals both verified
+  `HEAD` and current protected `origin/main` (env-passed tag input; provenance
+  from that commit via `$GITHUB_ENV` inheritance, not dispatch `GITHUB_SHA` or
+  empty expression-context remaps), validates exact artifacts, stages or
+  normalizes a **draft** GitHub Release (title/notes/target bound to the
+  candidate), publishes the same `dist/` to PyPI, requires published PyPI
   SHA-256 to match `candidate-SHA256SUMS` before undraft (still owner-gated; no
   automatic publication from this PR).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,11 @@ All notable changes to FAVA Trails are documented here.
   fresh wheel install, sdist install, and 0.6.0→candidate upgrade; `release.yml`
   is a pre-publication `workflow_dispatch` on an existing tag that proves
   `refs/tags/*` peel equals verified `HEAD` (env-passed tag input; provenance from
-  that commit, not dispatch `GITHUB_SHA`), validates exact artifacts, stages a
-  **draft** GitHub Release, publishes the same `dist/` to PyPI, then undrafts only
-  after PyPI succeeds (still owner-gated; no automatic publication from this PR).
+  that commit via `$GITHUB_ENV` inheritance, not dispatch `GITHUB_SHA` or empty
+  expression-context remaps), validates exact artifacts, stages a **draft**
+  GitHub Release, publishes the same `dist/` to PyPI, requires published PyPI
+  SHA-256 to match `candidate-SHA256SUMS` before undraft (still owner-gated; no
+  automatic publication from this PR).
 
 ### Changed
 - Support MCP SDK 2.2 with explicit low-level handlers, preserving tool schemas, annotations, input/output validation, structured results, and Markdown usage guidance over stdio and Streamable HTTP. Adds installed-wheel protocol tests for legacy initialization and current SDK clients. Resolves #83.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,15 @@ All notable changes to FAVA Trails are documented here.
   packaged verifier binds to `FAVA_CANDIDATE_WHEEL`/`FAVA_CANDIDATE_SDIST` for
   fresh wheel install, sdist install, and 0.6.0→candidate upgrade; `release.yml`
   is a pre-publication `workflow_dispatch` on an existing tag under the
-  `fava-release` environment that proves `refs/tags/*` peel equals both verified
-  `HEAD` and current protected `origin/main` (env-passed tag input; provenance
-  from that commit via `$GITHUB_ENV` inheritance, not dispatch `GITHUB_SHA` or
-  empty expression-context remaps), validates exact artifacts, stages or
-  normalizes a **draft** GitHub Release (title/notes/target bound to the
-  candidate), publishes the same `dist/` to PyPI, requires published PyPI
-  SHA-256 to match `candidate-SHA256SUMS` before undraft (still owner-gated; no
-  automatic publication from this PR).
+  `fava-release` environment that resolves draft-resume before the main check
+  (first publish: tag peel == protected `origin/main`; draft resume: tag peel is
+  an ancestor of `origin/main`), peels to verified `HEAD` (env-passed tag input;
+  provenance via `$GITHUB_ENV` inheritance, not dispatch `GITHUB_SHA` or empty
+  expression-context remaps), validates exact artifacts, stages or normalizes a
+  **draft** GitHub Release (title/notes/target bound to the candidate), publishes
+  the same `dist/` to PyPI, requires published PyPI SHA-256 to match
+  `candidate-SHA256SUMS` before undraft (still owner-gated; no automatic
+  publication from this PR).
 
 ### Changed
 - Support MCP SDK 2.2 with explicit low-level handlers, preserving tool schemas, annotations, input/output validation, structured results, and Markdown usage guidance over stdio and Streamable HTTP. Adds installed-wheel protocol tests for legacy initialization and current SDK clients. Resolves #83.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,15 @@ All notable changes to FAVA Trails are documented here.
   tests cover fresh install, upgrade from published 0.6.0, installed-entrypoint
   MCP protocol (#83), and governed recall isolation (#72). Prepares #99; **0.6.1
   remains merged but unreleased on PyPI until an authorized tag is published.**
-- Issue #99 verification depth: native-client `mcpServers` registration load
-  (distinct from direct stdio probes), two separately configured ordinary server
-  processes for authoring isolation + spoof rejection on the installed wheel, and
-  `release.yml` gates that hash/build once, test those exact artifacts, attach
-  `candidate-SHA256SUMS` to the GitHub Release, then publish the same `dist/`
-  files (still owner-gated; no automatic publication from this PR).
+- Issue #99 verification depth: real native MCP client registration via
+  `@modelcontextprotocol/inspector` loading Claude-shaped `mcpServers` config
+  (distinct from direct stdio probes); two separately configured ordinary server
+  processes for authoring isolation + spoof rejection on the installed wheel;
+  packaged verifier binds to `FAVA_CANDIDATE_WHEEL`/`FAVA_CANDIDATE_SDIST` for
+  fresh wheel install, sdist install, and 0.6.0→candidate upgrade; `release.yml`
+  is a pre-publication `workflow_dispatch` on an existing tag that validates
+  those exact artifacts **before** creating the GitHub Release or publishing to
+  PyPI (still owner-gated; no automatic publication from this PR).
 
 ### Changed
 - Support MCP SDK 2.2 with explicit low-level handlers, preserving tool schemas, annotations, input/output validation, structured results, and Markdown usage guidance over stdio and Streamable HTTP. Adds installed-wheel protocol tests for legacy initialization and current SDK clients. Resolves #83.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to FAVA Trails are documented here.
   tests cover fresh install, upgrade from published 0.6.0, installed-entrypoint
   MCP protocol (#83), and governed recall isolation (#72). Prepares #99; **0.6.1
   remains merged but unreleased on PyPI until an authorized tag is published.**
+- Issue #99 verification depth: native-client `mcpServers` registration load
+  (distinct from direct stdio probes), two separately configured ordinary server
+  processes for authoring isolation + spoof rejection on the installed wheel, and
+  `release.yml` gates that hash/build once, test those exact artifacts, attach
+  `candidate-SHA256SUMS` to the GitHub Release, then publish the same `dist/`
+  files (still owner-gated; no automatic publication from this PR).
 
 ### Changed
 - Support MCP SDK 2.2 with explicit low-level handlers, preserving tool schemas, annotations, input/output validation, structured results, and Markdown usage guidance over stdio and Streamable HTTP. Adds installed-wheel protocol tests for legacy initialization and current SDK clients. Resolves #83.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ All notable changes to FAVA Trails are documented here.
   processes for authoring isolation + spoof rejection on the installed wheel;
   packaged verifier binds to `FAVA_CANDIDATE_WHEEL`/`FAVA_CANDIDATE_SDIST` for
   fresh wheel install, sdist install, and 0.6.0→candidate upgrade; `release.yml`
-  is a pre-publication `workflow_dispatch` on an existing tag that validates
-  those exact artifacts **before** creating the GitHub Release or publishing to
-  PyPI (still owner-gated; no automatic publication from this PR).
+  is a pre-publication `workflow_dispatch` on an existing tag that proves
+  `refs/tags/*` peel equals verified `HEAD` (env-passed tag input; provenance from
+  that commit, not dispatch `GITHUB_SHA`), validates exact artifacts, stages a
+  **draft** GitHub Release, publishes the same `dist/` to PyPI, then undrafts only
+  after PyPI succeeds (still owner-gated; no automatic publication from this PR).
 
 ### Changed
 - Support MCP SDK 2.2 with explicit low-level handlers, preserving tool schemas, annotations, input/output validation, structured results, and Markdown usage guidance over stdio and Streamable HTTP. Adds installed-wheel protocol tests for legacy initialization and current SDK clients. Resolves #83.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,27 @@ All notable changes to FAVA Trails are documented here.
 
 ## Unreleased
 
+### Added
+- `fava-trails version` (and a matching preamble on `fava-trails doctor`) reports
+  the loaded product package/module version, module path/source kind, and the
+  MCP SDK distribution version separately, without credentials. MCP
+  `serverInfo.version` now carries the FAVA product version. Documents identity
+  configuration, local runtime selectors that can keep an old checkout active,
+  and release-candidate install/upgrade verification. Wheel/sdist packaging
+  tests cover fresh install, upgrade from published 0.6.0, installed-entrypoint
+  MCP protocol (#83), and governed recall isolation (#72). Prepares #99; **0.6.1
+  remains merged but unreleased on PyPI until an authorized tag is published.**
+
 ### Changed
 - Support MCP SDK 2.2 with explicit low-level handlers, preserving tool schemas, annotations, input/output validation, structured results, and Markdown usage guidance over stdio and Streamable HTTP. Adds installed-wheel protocol tests for legacy initialization and current SDK clients. Resolves #83.
 - **JJ installer policy (issue #98):** `fava-trails install-jj` (canonical `jj_install.py`; `scripts/install-jj.sh` is a thin Bash 3.2-safe delegate) reuses any installed JJ `>= 0.28.0` before platform checks, never silently downgrades or overwrites a user-managed binary, resolves current GitHub stable when install is needed (explicit `--version` / `JJ_VERSION` override retained), verifies GitHub asset SHA-256 digests when published, requires exactly one safe regular `jj` archive member, installs atomically with restore of the prior managed binary after any post-replacement failure, and PATH-hints the selected install directory. CI matrix covers JJ **0.28.0** and **0.45.1**. See `docs/jj-compatibility.md`.
 
-## [0.6.1] — 2026-08-01
+## [0.6.1] — merged on main, not published (candidate)
+
+> **Publication status:** GitHub/PyPI latest remain **0.6.0**. Main identifies as
+> **0.6.1** and includes governed-read and MCP registration fixes. A normal
+> `pip install fava-trails` does **not** receive those fixes until an authorized
+> release. See [docs/runtime-and-upgrade.md](docs/runtime-and-upgrade.md).
 
 ### Fixed
 - Raised direct MCP (`>=1.28.1`) and Starlette (`>=1.3.1`) floors and refreshed the lockfile to clear open Dependabot advisories (including high-severity transitive updates such as NLTK and Transformers). Supersedes #81.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,11 +92,15 @@ without printing credentials. See
 [docs/runtime-and-upgrade.md](docs/runtime-and-upgrade.md).
 
 Before tagging, build candidate artifacts from the immutable reviewed commit and
-run the packaging gates:
+run the packaging gates against **those exact files**:
 
 ```bash
 uv build
+export FAVA_CANDIDATE_WHEEL=$(ls dist/*.whl)
+export FAVA_CANDIDATE_SDIST=$(ls dist/*.tar.gz)
+sha256sum dist/*.whl dist/*.tar.gz | tee candidate-SHA256SUMS
 uv run pytest tests/test_packaged_mcp.py tests/test_governance.py tests/test_mcp_protocol.py tests/test_runtime_info.py -v
+sha256sum -c candidate-SHA256SUMS
 ```
 
 Until PyPI/GitHub release metadata match that candidate, label the work **merged
@@ -108,8 +112,14 @@ Once dog-fooding confirms the changes work:
 
 1. Bump version in `pyproject.toml`
 2. Push the version bump via PR, merge to `main`
-3. Create a GitHub Release: `gh release create vX.Y.Z --generate-notes`
-4. CI builds, verifies the tag matches `pyproject.toml`, and publishes to PyPI
+3. Create and push an immutable tag on the reviewed commit:
+   `git tag vX.Y.Z <sha> && git push origin vX.Y.Z`
+   Do **not** create the GitHub Release yet — validation must run first.
+4. Owner runs the **Release** workflow (`workflow_dispatch`) with input
+   `tag=vX.Y.Z`. CI checks out the tag, builds once, runs packaged gates on the
+   exact wheel+sdist (including sdist install and 0.6.0 upgrade), then — only on
+   success — creates the GitHub Release (with `candidate-SHA256SUMS`) and
+   publishes those same artifacts to PyPI.
 5. Update the vendor copy:
    ```bash
    cd ~/git/vendor/fava-trails

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,14 +115,16 @@ Once dog-fooding confirms the changes work:
 3. Create and push an immutable tag on the reviewed commit:
    `git tag vX.Y.Z <sha> && git push origin vX.Y.Z`
    Do **not** create the GitHub Release yet — validation must run first.
-4. Owner runs the **Release** workflow (`workflow_dispatch`) with input
-   `tag=vX.Y.Z`. CI proves `refs/tags/vX.Y.Z` peels to the checked-out `HEAD`,
-   builds once, runs packaged gates on the exact wheel+sdist (including sdist
-   install and 0.6.0 upgrade), stages a **draft** GitHub Release (with
-   `candidate-SHA256SUMS`), publishes those same artifacts to PyPI, verifies
-   published PyPI SHA-256 against `candidate-SHA256SUMS` (fail closed), then
-   undrafts the Release only after that proof (reruns may resume a matching
-   draft; provenance env is `$GITHUB_ENV`-inherited, not expression-remapped).
+4. Owner runs the **Release** workflow (`workflow_dispatch`, GitHub Environment
+   `fava-release`) with input `tag=vX.Y.Z`. CI proves `refs/tags/vX.Y.Z` peels to
+   current protected `origin/main` and the checked-out `HEAD`, builds once, runs
+   packaged gates on the exact wheel+sdist (including sdist install and 0.6.0
+   upgrade), stages or normalizes a **draft** GitHub Release (with
+   `candidate-SHA256SUMS` and verified title/notes/target), publishes those same
+   artifacts to PyPI, verifies published PyPI SHA-256 against
+   `candidate-SHA256SUMS` (fail closed), then undrafts the Release only after
+   that proof (reruns may resume a matching draft after metadata normalize;
+   provenance env is `$GITHUB_ENV`-inherited, not expression-remapped).
 5. Update the vendor copy:
    ```bash
    cd ~/git/vendor/fava-trails

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,15 +116,17 @@ Once dog-fooding confirms the changes work:
    `git tag vX.Y.Z <sha> && git push origin vX.Y.Z`
    Do **not** create the GitHub Release yet — validation must run first.
 4. Owner runs the **Release** workflow (`workflow_dispatch`, GitHub Environment
-   `fava-release`) with input `tag=vX.Y.Z`. CI proves `refs/tags/vX.Y.Z` peels to
-   current protected `origin/main` and the checked-out `HEAD`, builds once, runs
-   packaged gates on the exact wheel+sdist (including sdist install and 0.6.0
-   upgrade), stages or normalizes a **draft** GitHub Release (with
-   `candidate-SHA256SUMS` and verified title/notes/target), publishes those same
-   artifacts to PyPI, verifies published PyPI SHA-256 against
-   `candidate-SHA256SUMS` (fail closed), then undrafts the Release only after
-   that proof (reruns may resume a matching draft after metadata normalize;
-   provenance env is `$GITHUB_ENV`-inherited, not expression-remapped).
+   `fava-release`) with input `tag=vX.Y.Z`. CI resolves draft-resume state first,
+   then proves `refs/tags/vX.Y.Z` peels to checked-out `HEAD` and either equals
+   current protected `origin/main` (first publish) or is an ancestor of it
+   (draft resume after main may have advanced), builds once, runs packaged gates
+   on the exact wheel+sdist (including sdist install and 0.6.0 upgrade), stages
+   or normalizes a **draft** GitHub Release (with `candidate-SHA256SUMS` and
+   verified title/notes/target), publishes those same artifacts to PyPI,
+   verifies published PyPI SHA-256 against `candidate-SHA256SUMS` (fail closed),
+   then undrafts the Release only after that proof (reruns may resume a matching
+   draft after metadata normalize; provenance env is `$GITHUB_ENV`-inherited, not
+   expression-remapped).
 5. Update the vendor copy:
    ```bash
    cd ~/git/vendor/fava-trails

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,24 @@ After merging to `main`, point your MCP server at the dev copy to test with real
 
 Restart your MCP client (e.g., Claude Code) and use it for real work. Test the specific changes you made — save thoughts, recall, sync, etc. Use it for at least a working session before releasing.
 
+**Important:** a client config that uses `uv run --directory <checkout>` or a
+vendor path keeps that tree active even after `pip install -U fava-trails`.
+Run `fava-trails version` (or `fava-trails doctor`) in the same environment the
+client launches to see package/module version, module path, and MCP SDK version
+without printing credentials. See
+[docs/runtime-and-upgrade.md](docs/runtime-and-upgrade.md).
+
+Before tagging, build candidate artifacts from the immutable reviewed commit and
+run the packaging gates:
+
+```bash
+uv build
+uv run pytest tests/test_packaged_mcp.py tests/test_governance.py tests/test_mcp_protocol.py tests/test_runtime_info.py -v
+```
+
+Until PyPI/GitHub release metadata match that candidate, label the work **merged
+but unreleased**.
+
 ### 3. Release to PyPI
 
 Once dog-fooding confirms the changes work:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,10 +116,11 @@ Once dog-fooding confirms the changes work:
    `git tag vX.Y.Z <sha> && git push origin vX.Y.Z`
    Do **not** create the GitHub Release yet — validation must run first.
 4. Owner runs the **Release** workflow (`workflow_dispatch`) with input
-   `tag=vX.Y.Z`. CI checks out the tag, builds once, runs packaged gates on the
-   exact wheel+sdist (including sdist install and 0.6.0 upgrade), then — only on
-   success — creates the GitHub Release (with `candidate-SHA256SUMS`) and
-   publishes those same artifacts to PyPI.
+   `tag=vX.Y.Z`. CI proves `refs/tags/vX.Y.Z` peels to the checked-out `HEAD`,
+   builds once, runs packaged gates on the exact wheel+sdist (including sdist
+   install and 0.6.0 upgrade), stages a **draft** GitHub Release (with
+   `candidate-SHA256SUMS`), publishes those same artifacts to PyPI, then undrafts
+   the Release only after PyPI succeeds (reruns may resume a matching draft).
 5. Update the vendor copy:
    ```bash
    cd ~/git/vendor/fava-trails

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,8 +119,10 @@ Once dog-fooding confirms the changes work:
    `tag=vX.Y.Z`. CI proves `refs/tags/vX.Y.Z` peels to the checked-out `HEAD`,
    builds once, runs packaged gates on the exact wheel+sdist (including sdist
    install and 0.6.0 upgrade), stages a **draft** GitHub Release (with
-   `candidate-SHA256SUMS`), publishes those same artifacts to PyPI, then undrafts
-   the Release only after PyPI succeeds (reruns may resume a matching draft).
+   `candidate-SHA256SUMS`), publishes those same artifacts to PyPI, verifies
+   published PyPI SHA-256 against `candidate-SHA256SUMS` (fail closed), then
+   undrafts the Release only after that proof (reruns may resume a matching
+   draft; provenance env is `$GITHUB_ENV`-inherited, not expression-remapped).
 5. Update the vendor copy:
    ```bash
    cd ~/git/vendor/fava-trails

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ This reuses any already-installed JJ at or above the supported minimum (**0.28.0
 pip install fava-trails
 ```
 
+**Publication note:** PyPI and GitHub Releases still list **0.6.0** as latest.
+Main identifies as **0.6.1** with governed-recall and MCP registration fixes
+**merged but unreleased**. Confirm what you actually loaded with
+`fava-trails version` (see [docs/runtime-and-upgrade.md](docs/runtime-and-upgrade.md)).
+Local `uv run --directory …` or vendor checkout selectors can keep an older tree
+active after a package upgrade — restart the MCP client registration after
+changing the install.
+
 ### From source (for development)
 
 ```bash
@@ -89,6 +97,16 @@ configuration and the private Streamable HTTP endpoint remain supported, includi
 legacy `initialize` clients. Tool input/output schemas, annotations, and structured
 responses are preserved. Restart a configured server after updating its package;
 installing the package alone does not update a running process.
+
+`initialize` advertises FAVA's **product** version in `serverInfo.version`. That
+value is not the MCP SDK distribution version. Use `fava-trails version` to print
+both, plus the loaded module path, without credentials.
+
+Set `FAVA_TRAILS_AGENT_ID` on each ordinary authoring process. A shared endpoint
+is one identity boundary; `FAVA_TRAILS_OPERATOR=1` belongs only on a separate
+operator endpoint. Details:
+[docs/governed-recall.md](docs/governed-recall.md) and
+[docs/runtime-and-upgrade.md](docs/runtime-and-upgrade.md).
 
 Add to your MCP client config:
 - **Claude Code CLI**: `~/.claude.json` (top-level `mcpServers` key)

--- a/docs/governed-recall.md
+++ b/docs/governed-recall.md
@@ -50,6 +50,11 @@ turning on authoring; this change does not migrate files or assume old `agent_id
 claims were authenticated. Existing draft ownership needs operator review before
 reusing an old identity for private authoring.
 
+After package upgrades, confirm the process your MCP client launches is the
+intended install with `fava-trails version` (module path and product vs MCP SDK
+versions). Local `uv run --directory` / vendor selectors can keep an older
+checkout active; see [runtime-and-upgrade.md](runtime-and-upgrade.md).
+
 ## Replacement lifecycle
 
 `supersede` and `change_scope` create a draft successor with `supersedes_id` and

--- a/docs/runtime-and-upgrade.md
+++ b/docs/runtime-and-upgrade.md
@@ -113,17 +113,21 @@ Publication is **owner-gated** via `.github/workflows/release.yml`
 
 1. Accepts `tag` only via job `env` (never raw shell interpolation). Validates
    strict `vMAJOR.MINOR.PATCH` grammar, fetches `refs/tags/<tag>` only (not a
-   same-named branch), fetches `refs/heads/main`, requires the peeled tag commit
-   to equal current `origin/main` (protected reviewed tip), detaches `HEAD` at
-   that commit, and asserts `git rev-parse HEAD` equals both the tag peel and
-   `origin/main` before any build. Package version must match the tag.
-   Provenance uses that verified `HEAD` SHA — not workflow `GITHUB_SHA` from the
-   dispatch ref.
+   same-named branch), and fetches `refs/heads/main`. **Draft-resume state is
+   resolved before the main relationship check** so a post-PyPI retry is not
+   stranded when protected `main` advances after the tag was cut. First
+   publication requires the peeled tag commit to equal current `origin/main`;
+   an existing **draft** requires the tag commit to be an **ancestor** of
+   protected `origin/main` (including equality). Detaches `HEAD` at the tag and
+   asserts `git rev-parse HEAD` equals the tag peel (and equals `origin/main` on
+   first publish). Package version must match the tag. Provenance uses that
+   verified `HEAD` SHA — not workflow `GITHUB_SHA` from the dispatch ref.
 2. Refuses a **published** GitHub Release for the tag; a **draft** Release may be
    resumed on rerun only after canonical title/notes/target are regenerated and
    verified against the candidate (not `isDraft` alone).
 3. **Builds once**, records SHA-256 hashes plus `CANDIDATE_COMMIT` /
-   `CANDIDATE_TAG` / `CANDIDATE_MAIN` for the wheel and sdist.
+   `CANDIDATE_TAG` / `CANDIDATE_MAIN` / `CANDIDATE_MAIN_RELATION` for the wheel
+   and sdist.
 4. Sets `FAVA_CANDIDATE_WHEEL` / `FAVA_CANDIDATE_SDIST` to those exact files and
    runs `tests/test_packaged_mcp.py` — fresh wheel install, fresh sdist install,
    real `0.6.0` → candidate upgrade, installed-entrypoint MCP (direct stdio **and**

--- a/docs/runtime-and-upgrade.md
+++ b/docs/runtime-and-upgrade.md
@@ -110,17 +110,25 @@ Checklist after an upgrade:
 Publication is **owner-gated** via `.github/workflows/release.yml`
 (`workflow_dispatch` on an **already-pushed** immutable tag). The job:
 
-1. Checks out the tag and refuses to proceed if a public GitHub Release for that
-   tag already exists (avoids split state).
-2. **Builds once**, records SHA-256 hashes for the wheel and sdist.
-3. Sets `FAVA_CANDIDATE_WHEEL` / `FAVA_CANDIDATE_SDIST` to those exact files and
+1. Accepts `tag` only via job `env` (never raw shell interpolation). Validates
+   strict `vMAJOR.MINOR.PATCH` grammar, fetches `refs/tags/<tag>` only (not a
+   same-named branch), detaches `HEAD` at the peeled tag commit, and asserts
+   `git rev-parse HEAD` equals that commit before any build. Package version must
+   match the tag. Provenance uses that verified `HEAD` SHA — not workflow
+   `GITHUB_SHA` from the dispatch ref.
+2. Refuses a **published** GitHub Release for the tag; a **draft** Release may be
+   resumed safely on rerun.
+3. **Builds once**, records SHA-256 hashes plus `CANDIDATE_COMMIT` /
+   `CANDIDATE_TAG` for the wheel and sdist.
+4. Sets `FAVA_CANDIDATE_WHEEL` / `FAVA_CANDIDATE_SDIST` to those exact files and
    runs `tests/test_packaged_mcp.py` — fresh wheel install, fresh sdist install,
    real `0.6.0` → candidate upgrade, installed-entrypoint MCP (direct stdio **and**
    native Inspector registration), two-process identity isolation, and governed
    recall (#72).
-4. **Only after validation succeeds**, creates the GitHub Release (with wheel,
-   sdist, and `candidate-SHA256SUMS`) and publishes **the same** `dist/` artifacts
-   to PyPI (with attestations).
+5. **Only after validation succeeds**, stages a **draft** GitHub Release (wheel,
+   sdist, `candidate-SHA256SUMS`), publishes **the same** `dist/` artifacts to
+   PyPI (with attestations; `skip-existing` for resume), then undrafts the
+   Release so it becomes public only after PyPI succeeds.
 
 Validation therefore runs **before** any public GitHub Release or PyPI upload
 exists. The workflow no longer triggers on `release: published`.

--- a/docs/runtime-and-upgrade.md
+++ b/docs/runtime-and-upgrade.md
@@ -52,15 +52,22 @@ client UI that shows a single "server version" may be reading either product
 metadata or its own SDK/client field. Do not assume every version string shares
 one meaning. Use `fava-trails version` for the loaded product and SDK pair.
 
-Direct stdio probes (raw JSON-RPC over the `fava-trails-server` entrypoint)
-exercise the process binary. A native client registration also loads that same
-entrypoint from the client's config; installing a wheel does not update a
-running client until the registration is restarted. Coverage for both paths
-lives in `tests/test_mcp_protocol.py` and `tests/test_packaged_mcp.py` (#83).
+### Direct stdio probe vs native client registration
+
+These are two different evidence paths and must not be conflated:
+
+| Path | What it proves | Automated coverage |
+| --- | --- | --- |
+| **Direct stdio probe** | The installed `fava-trails-server` binary speaks MCP over stdio when launched by absolute path | `tests/test_mcp_protocol.py::test_installed_stdio_initialize_list_and_call` |
+| **Native client registration** | A Claude-style `mcpServers` config is **loaded**, the registration's `command`/`env` are resolved, and that entrypoint completes `initialize` + a tool call | `tests/test_mcp_protocol.py::test_native_client_registration_loads_and_initializes` |
+
+Installing a wheel does not update a running client until the registration is
+restarted. `tests/test_packaged_mcp.py` re-runs the MCP suite against the built
+wheel so both paths are checked on the installed artifact (#83 / #99).
 
 ## Identity configuration
 
-Governed read isolation is process-scoped. See
+Governed read isolation is **process-scoped**. See
 [governed-recall.md](governed-recall.md) for the full model. Operators must:
 
 1. Set `FAVA_TRAILS_AGENT_ID` on each ordinary authoring MCP process.
@@ -70,9 +77,15 @@ Governed read isolation is process-scoped. See
 4. Reject caller `agent_id` values that do not match the configured identity.
 
 Default `recall` / `get_thought` remain approved-current only. Authoring is
-explicit and owner-scoped; history is operator-only. Acceptance coverage for
-these behaviors is `tests/test_governance.py` (#72), also executed against the
-built wheel in `tests/test_packaged_mcp.py`.
+explicit and owner-scoped; history is operator-only.
+
+Coverage:
+
+- Source-tree lifecycle and spoof rejection: `tests/test_governance.py` (#72)
+- **Two separately configured ordinary server processes** on one data repo
+  (own-draft visibility + cross-process spoof rejection), including under the
+  installed wheel: `tests/test_mcp_protocol.py::test_two_ordinary_server_processes_isolate_authoring`
+- Packaged re-run of governance + MCP suites: `tests/test_packaged_mcp.py`
 
 ## Upgrade behavior and local runtime selectors
 
@@ -93,18 +106,35 @@ Checklist after an upgrade:
 
 ## Release candidate verification (pre-publish)
 
-Publication is tag-driven (`release.yml` on a GitHub Release). Before
-authorization:
+Publication is tag-driven (`.github/workflows/release.yml` on a GitHub Release).
+The release job **builds once**, records SHA-256 hashes for the wheel and sdist,
+runs packaged gates against **those exact files**, attaches the hash manifest to
+the GitHub Release, and only then publishes **the same** `dist/` artifacts to
+PyPI (with attestations). It does not rebuild between test and publish.
+
+Local pre-authorization check (binds what you test to files you could tag):
 
 ```bash
 # From an immutable reviewed commit on main / the release branch:
 uv build
-uv run pytest tests/test_packaged_mcp.py tests/test_governance.py tests/test_mcp_protocol.py tests/test_runtime_info.py -v
+sha256sum dist/*.whl dist/*.tar.gz | tee candidate-SHA256SUMS
+uv run pytest \
+  tests/test_packaged_mcp.py \
+  tests/test_governance.py \
+  tests/test_mcp_protocol.py \
+  tests/test_runtime_info.py -v
+# After the suite: confirm hashes still match (no rebuild sneaked in)
+sha256sum -c candidate-SHA256SUMS
 ```
 
 `tests/test_packaged_mcp.py` builds wheel + sdist, verifies a fresh install,
 upgrades an isolated env from published `fava-trails==0.6.0`, and re-runs the
-installed-entrypoint MCP and governed-recall suites against the wheel.
+installed-entrypoint MCP (direct stdio **and** native registration), two-process
+identity isolation, and governed-recall suites against the wheel.
+
+Post-publication proof: download the published wheel/sdist (or use the Release
+asset `candidate-SHA256SUMS`) and confirm SHA-256 matches the tested candidate
+set before trusting install instructions.
 
 Until a release is published and verified, label the work **merged but
 unreleased**. After publication, confirm PyPI and GitHub release metadata match

--- a/docs/runtime-and-upgrade.md
+++ b/docs/runtime-and-upgrade.md
@@ -1,0 +1,116 @@
+# Runtime versions, identity, and upgrade behavior
+
+FAVA Trails 0.6.1 fixes (governed recall isolation from #72 / #93 and MCP
+registration compatibility from #83 / #94) are **merged on `main` but not yet
+published** to PyPI or a GitHub Release. Live `pip install fava-trails` still
+resolves **0.6.0** until an authorized tag-driven release runs. Treat anything
+newer on `main` as a release candidate until publication is verified.
+
+## Report the loaded runtime
+
+MCP client configs often keep a local checkout, vendor pin, or `uv run
+--directory …` selector active after a package upgrade. Those selectors do not
+automatically follow PyPI. Ask the process that is actually running:
+
+```bash
+fava-trails version
+# or
+fava-trails doctor   # prints the same runtime block first
+```
+
+Example (values vary by install):
+
+```text
+FAVA Trails product: fava-trails
+Package version:    0.6.1
+Module version:     0.6.1
+Module path:        /…/site-packages/fava_trails/__init__.py
+Source:             installed
+MCP SDK version:    2.2.0
+Handshake product version (serverInfo.version): 0.6.1
+```
+
+| Field | Meaning |
+| --- | --- |
+| Package / module version | FAVA product version (`importlib.metadata` and `fava_trails.__version__`) |
+| Module path | Which tree the interpreter imported — use this to spot a stale checkout |
+| Source | `installed` (site-packages wheel) vs `editable` (local `src/` tree) |
+| MCP SDK version | Python `mcp` distribution version — **not** the FAVA product version |
+| Handshake product version | Value sent as MCP `serverInfo.version` on `initialize` |
+
+`fava-trails version` never prints credentials, API keys, or data-repo secrets.
+
+### Handshake vs SDK version
+
+On stdio `initialize`, FAVA advertises:
+
+- `serverInfo.name`: `fava-trails`
+- `serverInfo.version`: **FAVA product version** (for example `0.6.1`)
+
+The MCP Python SDK has its own distribution version (for example `2.2.0`). A
+client UI that shows a single "server version" may be reading either product
+metadata or its own SDK/client field. Do not assume every version string shares
+one meaning. Use `fava-trails version` for the loaded product and SDK pair.
+
+Direct stdio probes (raw JSON-RPC over the `fava-trails-server` entrypoint)
+exercise the process binary. A native client registration also loads that same
+entrypoint from the client's config; installing a wheel does not update a
+running client until the registration is restarted. Coverage for both paths
+lives in `tests/test_mcp_protocol.py` and `tests/test_packaged_mcp.py` (#83).
+
+## Identity configuration
+
+Governed read isolation is process-scoped. See
+[governed-recall.md](governed-recall.md) for the full model. Operators must:
+
+1. Set `FAVA_TRAILS_AGENT_ID` on each ordinary authoring MCP process.
+2. Keep one authenticated identity per authoring endpoint (a shared gateway
+   credential is one identity boundary).
+3. Enable `FAVA_TRAILS_OPERATOR=1` only on a separate operator-controlled process.
+4. Reject caller `agent_id` values that do not match the configured identity.
+
+Default `recall` / `get_thought` remain approved-current only. Authoring is
+explicit and owner-scoped; history is operator-only. Acceptance coverage for
+these behaviors is `tests/test_governance.py` (#72), also executed against the
+built wheel in `tests/test_packaged_mcp.py`.
+
+## Upgrade behavior and local runtime selectors
+
+| Install path | What runs after `pip install -U fava-trails` |
+| --- | --- |
+| `command: fava-trails-server` on `PATH` | New wheel **if** PATH points at the upgraded environment |
+| `uv run --directory /path/to/checkout fava-trails-server` | **Checkout tree**, not PyPI, until that directory is updated |
+| Vendor / pinned clone path in client config | **Pinned tree** until the pin is moved |
+| Long-lived MCP client session | Previous process until the client reloads the server |
+
+Checklist after an upgrade:
+
+1. `python -m pip show fava-trails` (or `uv pip show fava-trails`) in the target env.
+2. `fava-trails version` and confirm package/module versions and module path.
+3. Restart the MCP client registration (install alone does not replace a live process).
+4. For authoring endpoints, confirm `FAVA_TRAILS_AGENT_ID` is still set on the
+   process env the client actually launches.
+
+## Release candidate verification (pre-publish)
+
+Publication is tag-driven (`release.yml` on a GitHub Release). Before
+authorization:
+
+```bash
+# From an immutable reviewed commit on main / the release branch:
+uv build
+uv run pytest tests/test_packaged_mcp.py tests/test_governance.py tests/test_mcp_protocol.py tests/test_runtime_info.py -v
+```
+
+`tests/test_packaged_mcp.py` builds wheel + sdist, verifies a fresh install,
+upgrades an isolated env from published `fava-trails==0.6.0`, and re-runs the
+installed-entrypoint MCP and governed-recall suites against the wheel.
+
+Until a release is published and verified, label the work **merged but
+unreleased**. After publication, confirm PyPI and GitHub release metadata match
+the tested candidate, then install with:
+
+```bash
+pip install -U 'fava-trails>=0.6.1'
+fava-trails version
+```

--- a/docs/runtime-and-upgrade.md
+++ b/docs/runtime-and-upgrade.md
@@ -127,8 +127,13 @@ Publication is **owner-gated** via `.github/workflows/release.yml`
    recall (#72).
 5. **Only after validation succeeds**, stages a **draft** GitHub Release (wheel,
    sdist, `candidate-SHA256SUMS`), publishes **the same** `dist/` artifacts to
-   PyPI (with attestations; `skip-existing` for resume), then undrafts the
-   Release so it becomes public only after PyPI succeeds.
+   PyPI (with attestations; `skip-existing` for resume), **downloads the
+   published wheel+sdist and requires their SHA-256 to match
+   `candidate-SHA256SUMS`** (fail closed on mismatch — `skip-existing` alone is
+   not byte proof), then undrafts the Release so it becomes public only after
+   that hash proof. Candidate provenance (`CANDIDATE_*`) is exported once via
+   `$GITHUB_ENV` and inherited by later steps; it is not re-mapped through the
+   empty workflow expression `env` context.
 
 Validation therefore runs **before** any public GitHub Release or PyPI upload
 exists. The workflow no longer triggers on `release: published`.

--- a/docs/runtime-and-upgrade.md
+++ b/docs/runtime-and-upgrade.md
@@ -108,32 +108,37 @@ Checklist after an upgrade:
 ## Release candidate verification (pre-publish)
 
 Publication is **owner-gated** via `.github/workflows/release.yml`
-(`workflow_dispatch` on an **already-pushed** immutable tag). The job:
+(`workflow_dispatch` on an **already-pushed** immutable tag, job
+`environment: fava-release` with required owner approval). The job:
 
 1. Accepts `tag` only via job `env` (never raw shell interpolation). Validates
    strict `vMAJOR.MINOR.PATCH` grammar, fetches `refs/tags/<tag>` only (not a
-   same-named branch), detaches `HEAD` at the peeled tag commit, and asserts
-   `git rev-parse HEAD` equals that commit before any build. Package version must
-   match the tag. Provenance uses that verified `HEAD` SHA — not workflow
-   `GITHUB_SHA` from the dispatch ref.
+   same-named branch), fetches `refs/heads/main`, requires the peeled tag commit
+   to equal current `origin/main` (protected reviewed tip), detaches `HEAD` at
+   that commit, and asserts `git rev-parse HEAD` equals both the tag peel and
+   `origin/main` before any build. Package version must match the tag.
+   Provenance uses that verified `HEAD` SHA — not workflow `GITHUB_SHA` from the
+   dispatch ref.
 2. Refuses a **published** GitHub Release for the tag; a **draft** Release may be
-   resumed safely on rerun.
+   resumed on rerun only after canonical title/notes/target are regenerated and
+   verified against the candidate (not `isDraft` alone).
 3. **Builds once**, records SHA-256 hashes plus `CANDIDATE_COMMIT` /
-   `CANDIDATE_TAG` for the wheel and sdist.
+   `CANDIDATE_TAG` / `CANDIDATE_MAIN` for the wheel and sdist.
 4. Sets `FAVA_CANDIDATE_WHEEL` / `FAVA_CANDIDATE_SDIST` to those exact files and
    runs `tests/test_packaged_mcp.py` — fresh wheel install, fresh sdist install,
    real `0.6.0` → candidate upgrade, installed-entrypoint MCP (direct stdio **and**
    native Inspector registration), two-process identity isolation, and governed
    recall (#72).
-5. **Only after validation succeeds**, stages a **draft** GitHub Release (wheel,
-   sdist, `candidate-SHA256SUMS`), publishes **the same** `dist/` artifacts to
-   PyPI (with attestations; `skip-existing` for resume), **downloads the
-   published wheel+sdist and requires their SHA-256 to match
-   `candidate-SHA256SUMS`** (fail closed on mismatch — `skip-existing` alone is
-   not byte proof), then undrafts the Release so it becomes public only after
-   that hash proof. Candidate provenance (`CANDIDATE_*`) is exported once via
-   `$GITHUB_ENV` and inherited by later steps; it is not re-mapped through the
-   empty workflow expression `env` context.
+5. **Only after validation succeeds**, stages or normalizes a **draft** GitHub
+   Release (wheel, sdist, `candidate-SHA256SUMS`; target/title/notes bound to the
+   verified candidate), publishes **the same** `dist/` artifacts to PyPI (with
+   attestations; `skip-existing` for resume), **downloads the published
+   wheel+sdist and requires their SHA-256 to match `candidate-SHA256SUMS`**
+   (fail closed on mismatch — `skip-existing` alone is not byte proof), then
+   undrafts the Release so it becomes public only after that hash proof.
+   Candidate provenance (`CANDIDATE_*`) is exported once via `$GITHUB_ENV` and
+   inherited by later steps; it is not re-mapped through the empty workflow
+   expression `env` context.
 
 Validation therefore runs **before** any public GitHub Release or PyPI upload
 exists. The workflow no longer triggers on `release: published`.

--- a/docs/runtime-and-upgrade.md
+++ b/docs/runtime-and-upgrade.md
@@ -59,11 +59,12 @@ These are two different evidence paths and must not be conflated:
 | Path | What it proves | Automated coverage |
 | --- | --- | --- |
 | **Direct stdio probe** | The installed `fava-trails-server` binary speaks MCP over stdio when launched by absolute path | `tests/test_mcp_protocol.py::test_installed_stdio_initialize_list_and_call` |
-| **Native client registration** | A Claude-style `mcpServers` config is **loaded**, the registration's `command`/`env` are resolved, and that entrypoint completes `initialize` + a tool call | `tests/test_mcp_protocol.py::test_native_client_registration_loads_and_initializes` |
+| **Native client registration** | A real native client (`npx @modelcontextprotocol/inspector` CLI) loads a Claude-shaped `mcpServers` config, resolves `command`/`env`, spawns the server, and completes `initialize` + `tools/list` + `tools/call`. Pytest does not parse or launch the registration. | `tests/test_mcp_protocol.py::test_native_client_registration_loads_and_initializes` |
 
 Installing a wheel does not update a running client until the registration is
 restarted. `tests/test_packaged_mcp.py` re-runs the MCP suite against the built
-wheel so both paths are checked on the installed artifact (#83 / #99).
+wheel (or `FAVA_CANDIDATE_WHEEL` / `FAVA_CANDIDATE_SDIST` when set) so both paths
+are checked on the installed artifact (#83 / #99).
 
 ## Identity configuration
 
@@ -106,11 +107,23 @@ Checklist after an upgrade:
 
 ## Release candidate verification (pre-publish)
 
-Publication is tag-driven (`.github/workflows/release.yml` on a GitHub Release).
-The release job **builds once**, records SHA-256 hashes for the wheel and sdist,
-runs packaged gates against **those exact files**, attaches the hash manifest to
-the GitHub Release, and only then publishes **the same** `dist/` artifacts to
-PyPI (with attestations). It does not rebuild between test and publish.
+Publication is **owner-gated** via `.github/workflows/release.yml`
+(`workflow_dispatch` on an **already-pushed** immutable tag). The job:
+
+1. Checks out the tag and refuses to proceed if a public GitHub Release for that
+   tag already exists (avoids split state).
+2. **Builds once**, records SHA-256 hashes for the wheel and sdist.
+3. Sets `FAVA_CANDIDATE_WHEEL` / `FAVA_CANDIDATE_SDIST` to those exact files and
+   runs `tests/test_packaged_mcp.py` — fresh wheel install, fresh sdist install,
+   real `0.6.0` → candidate upgrade, installed-entrypoint MCP (direct stdio **and**
+   native Inspector registration), two-process identity isolation, and governed
+   recall (#72).
+4. **Only after validation succeeds**, creates the GitHub Release (with wheel,
+   sdist, and `candidate-SHA256SUMS`) and publishes **the same** `dist/` artifacts
+   to PyPI (with attestations).
+
+Validation therefore runs **before** any public GitHub Release or PyPI upload
+exists. The workflow no longer triggers on `release: published`.
 
 Local pre-authorization check (binds what you test to files you could tag):
 
@@ -118,6 +131,8 @@ Local pre-authorization check (binds what you test to files you could tag):
 # From an immutable reviewed commit on main / the release branch:
 uv build
 sha256sum dist/*.whl dist/*.tar.gz | tee candidate-SHA256SUMS
+export FAVA_CANDIDATE_WHEEL=$(ls dist/*.whl)
+export FAVA_CANDIDATE_SDIST=$(ls dist/*.tar.gz)
 uv run pytest \
   tests/test_packaged_mcp.py \
   tests/test_governance.py \
@@ -127,10 +142,10 @@ uv run pytest \
 sha256sum -c candidate-SHA256SUMS
 ```
 
-`tests/test_packaged_mcp.py` builds wheel + sdist, verifies a fresh install,
-upgrades an isolated env from published `fava-trails==0.6.0`, and re-runs the
-installed-entrypoint MCP (direct stdio **and** native registration), two-process
-identity isolation, and governed-recall suites against the wheel.
+`tests/test_packaged_mcp.py` uses the env-bound candidates when set; otherwise it
+builds wheel + sdist itself. Either way it verifies fresh wheel install, sdist
+install, upgrade from published `fava-trails==0.6.0`, and re-runs the installed
+MCP + governance suites against the wheel.
 
 Post-publication proof: download the published wheel/sdist (or use the Release
 asset `candidate-SHA256SUMS`) and confirm SHA-256 matches the tested candidate

--- a/src/fava_trails/__init__.py
+++ b/src/fava_trails/__init__.py
@@ -1,3 +1,13 @@
 """FAVA Trails — Federated Agents Versioned Audit Trail."""
 
-__version__ = "0.6.1"
+from __future__ import annotations
+
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:  # pragma: no cover
+    from importlib_metadata import PackageNotFoundError, version  # type: ignore
+
+try:
+    __version__ = version("fava-trails")
+except PackageNotFoundError:  # pragma: no cover - source tree without install metadata
+    __version__ = "0.6.1"

--- a/src/fava_trails/cli.py
+++ b/src/fava_trails/cli.py
@@ -30,6 +30,7 @@ from .jj_install import (
     select_or_install,
 )
 from .models import HookEntry, ThoughtRecord
+from .runtime_info import format_runtime_report, product_version
 
 # Historical alias: installers resolve GitHub latest unless --version / JJ_VERSION is set.
 JJ_DEFAULT_VERSION = JJ_MIN_VERSION
@@ -519,9 +520,18 @@ def cmd_scope_list(args: argparse.Namespace) -> int:
 # ─── Doctor ───────────────────────────────────────────────────────────────────
 
 
+def cmd_version(_args: argparse.Namespace) -> int:
+    """Report the loaded FAVA product runtime and MCP SDK version without secrets."""
+    print(format_runtime_report(), end="")
+    return 0
+
+
 def cmd_doctor(args: argparse.Namespace) -> int:
     """Health check: JJ, data repo, OpenRouter key, scope. Exits 0 if all pass, 1 if any fail."""
     any_failed = False
+
+    # Always show which binary/module is loaded so local checkout selectors are visible.
+    print(format_runtime_report(), end="")
 
     # Check 1: JJ installed?
     jj_bin = shutil.which("jj")
@@ -1575,12 +1585,7 @@ def _add_rich_view_trails_dir_arg(parser: argparse.ArgumentParser) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    try:
-        from importlib.metadata import version
-
-        _version = version("fava-trails")
-    except Exception:
-        _version = "unknown"
+    _version = product_version()
 
     parser = argparse.ArgumentParser(
         prog="fava-trails",
@@ -1589,6 +1594,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--version", action="version", version=f"%(prog)s {_version}")
 
     subparsers = parser.add_subparsers(dest="command", metavar="<command>")
+
+    # version (loaded runtime provenance; distinct from --version short form)
+    p_version = subparsers.add_parser(
+        "version",
+        help="Report the loaded FAVA product runtime, module path, and MCP SDK version",
+    )
+    p_version.set_defaults(func=cmd_version)
 
     # init
     p_init = subparsers.add_parser("init", help="Initialize a project directory for FAVA Trails")

--- a/src/fava_trails/runtime_info.py
+++ b/src/fava_trails/runtime_info.py
@@ -1,0 +1,78 @@
+"""Loaded runtime identity: product version, provenance, and MCP SDK version."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from pathlib import Path
+from typing import Any
+
+
+def product_version() -> str:
+    """Return the installed FAVA Trails product version."""
+    try:
+        return importlib.metadata.version("fava-trails")
+    except importlib.metadata.PackageNotFoundError:
+        from fava_trails import __version__
+
+        return __version__
+
+
+def mcp_sdk_version() -> str:
+    """Return the installed MCP Python SDK distribution version.
+
+    This is independent of the FAVA product version advertised in handshake
+    ``serverInfo.version``. Clients that surface a single "server version" may
+    be showing either value depending on which metadata field they read.
+    """
+    try:
+        return importlib.metadata.version("mcp")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def _module_path() -> Path:
+    import fava_trails
+
+    return Path(fava_trails.__file__).resolve()
+
+
+def _source_kind(module_path: Path) -> str:
+    parts = module_path.parts
+    if "site-packages" in parts:
+        return "installed"
+    if "src" in parts:
+        # Local checkout, worktree, or editable install resolved into the tree.
+        return "editable"
+    return "unknown"
+
+
+def runtime_report() -> dict[str, Any]:
+    """Describe the actually loaded runtime without credentials or secrets."""
+    from fava_trails import __version__ as module_version
+
+    module_path = _module_path()
+    package_version = product_version()
+    return {
+        "product_name": "fava-trails",
+        "package_version": package_version,
+        "module_version": module_version,
+        "module_path": str(module_path),
+        "source_kind": _source_kind(module_path),
+        "mcp_sdk_version": mcp_sdk_version(),
+        "handshake_product_version": package_version,
+    }
+
+
+def format_runtime_report(report: dict[str, Any] | None = None) -> str:
+    """Human-readable multi-line report for CLI / doctor output."""
+    data = report or runtime_report()
+    lines = [
+        f"FAVA Trails product: {data['product_name']}",
+        f"Package version:    {data['package_version']}",
+        f"Module version:     {data['module_version']}",
+        f"Module path:        {data['module_path']}",
+        f"Source:             {data['source_kind']}",
+        f"MCP SDK version:    {data['mcp_sdk_version']}",
+        f"Handshake product version (serverInfo.version): {data['handshake_product_version']}",
+    ]
+    return "\n".join(lines) + "\n"

--- a/src/fava_trails/runtime_info.py
+++ b/src/fava_trails/runtime_info.py
@@ -6,15 +6,15 @@ import importlib.metadata
 from pathlib import Path
 from typing import Any
 
+import fava_trails
+
 
 def product_version() -> str:
     """Return the installed FAVA Trails product version."""
     try:
         return importlib.metadata.version("fava-trails")
     except importlib.metadata.PackageNotFoundError:
-        from fava_trails import __version__
-
-        return __version__
+        return fava_trails.__version__
 
 
 def mcp_sdk_version() -> str:
@@ -31,8 +31,6 @@ def mcp_sdk_version() -> str:
 
 
 def _module_path() -> Path:
-    import fava_trails
-
     return Path(fava_trails.__file__).resolve()
 
 
@@ -48,14 +46,12 @@ def _source_kind(module_path: Path) -> str:
 
 def runtime_report() -> dict[str, Any]:
     """Describe the actually loaded runtime without credentials or secrets."""
-    from fava_trails import __version__ as module_version
-
     module_path = _module_path()
     package_version = product_version()
     return {
         "product_name": "fava-trails",
         "package_version": package_version,
-        "module_version": module_version,
+        "module_version": fava_trails.__version__,
         "module_path": str(module_path),
         "source_kind": _source_kind(module_path),
         "mcp_sdk_version": mcp_sdk_version(),

--- a/src/fava_trails/server.py
+++ b/src/fava_trails/server.py
@@ -42,6 +42,7 @@ from .config import (
 from .governance import Principal, Visibility, runtime_principal
 from .hook_manifest import HookRegistry
 from .models import ValidationStatus
+from .runtime_info import product_version
 from .trail import TrailManager
 from .trust_gate import TrustGatePromptCache
 from .vcs.jj_backend import JjBackend
@@ -1126,6 +1127,7 @@ async def _call_tool(ctx: ServerRequestContext, params: CallToolRequestParams) -
 
 server = Server(
     "fava-trails",
+    version=product_version(),
     instructions=_build_server_instructions(),
     on_list_tools=_list_tools,
     on_call_tool=_call_tool,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,7 @@ from fava_trails.cli import (
     cmd_scope_set,
     cmd_secom_setup,
     cmd_secom_warmup,
+    cmd_version,
 )
 from fava_trails.config import ConfigStore
 from fava_trails.models import GlobalConfig
@@ -485,6 +486,28 @@ def test_cli_version():
     assert "fava-trails" in result.stdout or "unknown" in result.stdout
 
 
+def test_cli_version_subcommand_reports_loaded_runtime(capsys):
+    """fava-trails version reports product, module path, and MCP SDK without secrets."""
+    rc = cmd_version(_make_args())
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Package version:" in out
+    assert "Module version:" in out
+    assert "Module path:" in out
+    assert "MCP SDK version:" in out
+    assert "OPENROUTER" not in out
+    assert "sk-" not in out
+
+    result = subprocess.run(
+        [sys.executable, "-m", "fava_trails.cli", "version"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "Package version:" in result.stdout
+    assert "MCP SDK version:" in result.stdout
+
+
 def test_cli_help():
     """fava-trails --help exits 0."""
     result = subprocess.run(
@@ -496,6 +519,7 @@ def test_cli_help():
     assert "init" in result.stdout
     assert "bootstrap" in result.stdout
     assert "scope" in result.stdout
+    assert "version" in result.stdout
 
 
 # ─── cmd_doctor ───────────────────────────────────────────────────────────────
@@ -534,6 +558,8 @@ def test_doctor_all_green(tmp_path, monkeypatch, capsys):
 
     assert rc == 0
     out = capsys.readouterr().out
+    assert "Package version:" in out
+    assert "MCP SDK version:" in out
     assert "JJ:" in out
     assert "Data repo:" in out
     assert "Trust Gate:" in out

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -81,6 +81,14 @@ async def test_installed_stdio_initialize_list_and_call(stdio_rpc, tmp_fava_home
     assert initialized["protocolVersion"] == "2025-11-25"
     assert "tools" in initialized["capabilities"]
     assert "Governed Visibility" in initialized["instructions"]
+    # Handshake serverInfo.version is the FAVA product version, not the MCP SDK.
+    server_info = initialized["serverInfo"]
+    assert server_info["name"] == "fava-trails"
+    assert server_info["version"] == server.server.version
+    assert server_info["version"] == __import__("fava_trails").__version__
+    import importlib.metadata as _md
+
+    assert server_info["version"] != _md.version("mcp")
     await stdio_rpc("notifications/initialized", notification=True)
     listed = await stdio_rpc("tools/list")
     by_name = {tool["name"]: tool for tool in listed["tools"]}

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import shutil
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -17,67 +18,128 @@ from mcp import Client
 from fava_trails import server
 
 
-@pytest_asyncio.fixture
-async def stdio_rpc(tmp_fava_home, tmp_path):
-    """Run the installed console script against synthetic data with bounded I/O."""
+def _server_executable() -> Path:
     executable = Path(sys.executable).parent / "fava-trails-server"
     assert executable.is_file(), "The installed package must provide its console entrypoint"
     if os.environ.get("FAVA_EXPECT_WHEEL") == "1":
         assert "site-packages" in Path(server.__file__).parts
+    return executable
+
+
+def _base_server_env(tmp_fava_home: Path, tmp_path: Path, agent_id: str) -> dict[str, str]:
     env = {key: value for key, value in os.environ.items() if not key.startswith("FAVA_TRAILS_")}
-    env.update({
-        "FAVA_TRAILS_DATA_REPO": str(tmp_fava_home),
-        "FAVA_TRAILS_DIR": str(tmp_fava_home / "trails"),
-        "FAVA_TRAILS_LOG_DIR": str(tmp_path / "logs"),
-        "FAVA_TRAILS_AGENT_ID": "synthetic-wire-agent",
-        "XDG_CONFIG_HOME": str(tmp_path / "xdg-config"),
-    })
-    with (tmp_path / "server-stderr.log").open("wb") as stderr:
+    env.update(
+        {
+            "FAVA_TRAILS_DATA_REPO": str(tmp_fava_home),
+            "FAVA_TRAILS_DIR": str(tmp_fava_home / "trails"),
+            "FAVA_TRAILS_LOG_DIR": str(tmp_path / "logs" / agent_id),
+            "FAVA_TRAILS_AGENT_ID": agent_id,
+            "XDG_CONFIG_HOME": str(tmp_path / "xdg-config"),
+            # Ensure registration command resolution finds the installed entrypoint.
+            "PATH": f"{Path(sys.executable).parent}{os.pathsep}{os.environ.get('PATH', '')}",
+        }
+    )
+    return env
+
+
+class _StdioRpc:
+    """JSON-RPC helper over a live stdio MCP process."""
+
+    def __init__(self, process: asyncio.subprocess.Process, stderr_path: Path):
+        self.process = process
+        self.stderr_path = stderr_path
+        self._next_id = 0
+
+    async def rpc(self, method, params=None, *, notification=False):
+        self._next_id += 1
+        message = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            message["params"] = params
+        if not notification:
+            message["id"] = self._next_id
+        self.process.stdin.write((json.dumps(message) + "\n").encode())
+        await self.process.stdin.drain()
+        if notification:
+            return None
+        async with asyncio.timeout(30):
+            while True:
+                line = await self.process.stdout.readline()
+                assert line, self.stderr_path.read_text()
+                response = json.loads(line)
+                if response.get("id") == self._next_id:
+                    assert "result" in response, response
+                    return response["result"]
+
+    async def call_tool(self, name: str, arguments: dict):
+        return await self.rpc("tools/call", {"name": name, "arguments": arguments})
+
+    async def close(self):
+        if self.process.returncode is None:
+            self.process.terminate()
+            try:
+                await asyncio.wait_for(self.process.wait(), 5)
+            except TimeoutError:
+                self.process.kill()
+                await asyncio.wait_for(self.process.wait(), 5)
+
+
+async def _spawn_stdio_rpc(
+    *,
+    command: str,
+    args: list[str] | None = None,
+    env: dict[str, str],
+    cwd: Path,
+    stderr_path: Path,
+) -> _StdioRpc:
+    """Start an MCP server process the same way a native client would."""
+    resolved = shutil.which(command, path=env.get("PATH"))
+    assert resolved, f"native registration command not found on PATH: {command}"
+    argv = [resolved, *(args or [])]
+    stderr_path.parent.mkdir(parents=True, exist_ok=True)
+    with stderr_path.open("wb") as stderr:
         process = await asyncio.create_subprocess_exec(
-            str(executable), cwd=tmp_path, env=env,
-            stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE, stderr=stderr,
+            *argv,
+            cwd=cwd,
+            env=env,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=stderr,
         )
-        next_id = 0
+    return _StdioRpc(process, stderr_path)
 
-        async def rpc(method, params=None, *, notification=False):
-            nonlocal next_id
-            next_id += 1
-            message = {"jsonrpc": "2.0", "method": method}
-            if params is not None:
-                message["params"] = params
-            if not notification:
-                message["id"] = next_id
-            process.stdin.write((json.dumps(message) + "\n").encode())
-            await process.stdin.drain()
-            if notification:
-                return None
-            async with asyncio.timeout(30):
-                while True:
-                    line = await process.stdout.readline()
-                    assert line, (tmp_path / "server-stderr.log").read_text()
-                    response = json.loads(line)
-                    if response.get("id") == next_id:
-                        assert "result" in response, response
-                        return response["result"]
 
-        try:
-            yield rpc
-        finally:
-            if process.returncode is None:
-                process.terminate()
-                try:
-                    await asyncio.wait_for(process.wait(), 5)
-                except TimeoutError:
-                    process.kill()
-                    await asyncio.wait_for(process.wait(), 5)
+@pytest_asyncio.fixture
+async def stdio_rpc(tmp_fava_home, tmp_path):
+    """Direct stdio probe: launch the installed console script by absolute path.
+
+    This is intentionally *not* a native-client registration load. Prefer
+    ``test_native_client_registration_loads_and_initializes`` for the
+    config-driven path issue #99 distinguishes from this probe.
+    """
+    executable = _server_executable()
+    env = _base_server_env(tmp_fava_home, tmp_path, "synthetic-wire-agent")
+    rpc = await _spawn_stdio_rpc(
+        command=str(executable),
+        env=env,
+        cwd=tmp_path,
+        stderr_path=tmp_path / "server-stderr.log",
+    )
+    try:
+        yield rpc.rpc
+    finally:
+        await rpc.close()
 
 
 @pytest.mark.asyncio
 async def test_installed_stdio_initialize_list_and_call(stdio_rpc, tmp_fava_home):
-    initialized = await stdio_rpc("initialize", {
-        "protocolVersion": "2025-11-25", "capabilities": {},
-        "clientInfo": {"name": "synthetic-legacy-client", "version": "1"},
-    })
+    initialized = await stdio_rpc(
+        "initialize",
+        {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "synthetic-legacy-client", "version": "1"},
+        },
+    )
     assert initialized["protocolVersion"] == "2025-11-25"
     assert "tools" in initialized["capabilities"]
     assert "Governed Visibility" in initialized["instructions"]
@@ -132,6 +194,158 @@ async def test_installed_stdio_initialize_list_and_call(stdio_rpc, tmp_fava_home
     missing = await call("recall", {"trail_name": "synthetic/missing"})
     assert not missing.get("isError", False)
     assert missing["structuredContent"]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_native_client_registration_loads_and_initializes(tmp_fava_home, tmp_path):
+    """Issue #99: a real native-client config is loaded, then the registration is launched.
+
+    Distinct from ``test_installed_stdio_initialize_list_and_call``, which probes the
+    entrypoint binary directly. Here the client config is the source of truth for
+    command/env, matching Claude Code / Claude Desktop ``mcpServers`` shape.
+    """
+    _server_executable()  # assert entrypoint exists (and wheel layout when requested)
+    env = _base_server_env(tmp_fava_home, tmp_path, "native-registration-agent")
+    # Claude-style registration: command name only (resolved via PATH), plus process env.
+    registration = {
+        "mcpServers": {
+            "fava-trails": {
+                "type": "stdio",
+                "command": "fava-trails-server",
+                "args": [],
+                "env": {
+                    "FAVA_TRAILS_DATA_REPO": env["FAVA_TRAILS_DATA_REPO"],
+                    "FAVA_TRAILS_DIR": env["FAVA_TRAILS_DIR"],
+                    "FAVA_TRAILS_LOG_DIR": env["FAVA_TRAILS_LOG_DIR"],
+                    "FAVA_TRAILS_AGENT_ID": env["FAVA_TRAILS_AGENT_ID"],
+                },
+            }
+        }
+    }
+    config_path = tmp_path / "claude_desktop_config.json"
+    config_path.write_text(json.dumps(registration, indent=2) + "\n")
+
+    # Native client load step: read the registration file and resolve the server entry.
+    loaded = json.loads(config_path.read_text())
+    entry = loaded["mcpServers"]["fava-trails"]
+    assert entry["command"] == "fava-trails-server"
+    assert entry.get("type", "stdio") == "stdio"
+    launch_env = dict(env)
+    launch_env.update({str(k): str(v) for k, v in entry.get("env", {}).items()})
+
+    rpc = await _spawn_stdio_rpc(
+        command=entry["command"],
+        args=list(entry.get("args") or []),
+        env=launch_env,
+        cwd=tmp_path,
+        stderr_path=tmp_path / "native-registration-stderr.log",
+    )
+    try:
+        initialized = await rpc.rpc(
+            "initialize",
+            {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "synthetic-claude-desktop", "version": "1"},
+            },
+        )
+        assert initialized["serverInfo"]["name"] == "fava-trails"
+        assert initialized["serverInfo"]["version"] == __import__("fava_trails").__version__
+        await rpc.rpc("notifications/initialized", notification=True)
+        listed = await rpc.rpc("tools/list")
+        assert len(listed["tools"]) == 17
+        saved = await rpc.call_tool(
+            "save_thought",
+            {"trail_name": "synthetic/native-reg", "content": "Loaded via native registration"},
+        )
+        assert not saved.get("isError", False)
+        assert saved["structuredContent"]["status"] == "ok"
+        assert saved["structuredContent"]["thought"]["agent_id"] == "native-registration-agent"
+    finally:
+        await rpc.close()
+
+
+@pytest.mark.asyncio
+async def test_two_ordinary_server_processes_isolate_authoring(tmp_fava_home, tmp_path):
+    """Issue #99 / #72: two process-scoped ordinary identities on one data repo.
+
+    Unlike in-process monkeypatch swaps of ``FAVA_TRAILS_AGENT_ID``, each identity
+    is a separately configured stdio server process (as real MCP registrations are).
+    """
+    _server_executable()
+    scope = "synthetic/process-isolation"
+    alice_env = _base_server_env(tmp_fava_home, tmp_path, "alice")
+    bob_env = _base_server_env(tmp_fava_home, tmp_path, "bob")
+
+    alice = await _spawn_stdio_rpc(
+        command="fava-trails-server",
+        env=alice_env,
+        cwd=tmp_path,
+        stderr_path=tmp_path / "alice-stderr.log",
+    )
+    bob = await _spawn_stdio_rpc(
+        command="fava-trails-server",
+        env=bob_env,
+        cwd=tmp_path,
+        stderr_path=tmp_path / "bob-stderr.log",
+    )
+    try:
+        for rpc, name in ((alice, "alice-client"), (bob, "bob-client")):
+            await rpc.rpc(
+                "initialize",
+                {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": name, "version": "1"},
+                },
+            )
+            await rpc.rpc("notifications/initialized", notification=True)
+
+        saved = await alice.call_tool(
+            "save_thought",
+            {"trail_name": scope, "content": "Alice private draft across process boundary"},
+        )
+        assert not saved.get("isError", False)
+        assert saved["structuredContent"]["thought"]["agent_id"] == "alice"
+        thought_id = saved["structuredContent"]["thought"]["thought_id"]
+
+        alice_own = await alice.call_tool("recall", {"trail_name": scope, "mode": "authoring"})
+        assert alice_own["structuredContent"]["count"] == 1
+        assert alice_own["structuredContent"]["thoughts"][0]["thought_id"] == thought_id
+
+        # Bob's separate process must not see Alice's draft authoring records.
+        bob_authoring = await bob.call_tool("recall", {"trail_name": scope, "mode": "authoring"})
+        assert bob_authoring["structuredContent"]["count"] == 0
+        assert bob_authoring["structuredContent"]["thoughts"] == []
+
+        # Default governed recall hides unapproved drafts for both processes.
+        for rpc in (alice, bob):
+            governed = await rpc.call_tool("recall", {"trail_name": scope})
+            assert governed["structuredContent"]["count"] == 0
+
+        # Caller identity spoofing is rejected at Bob's process boundary.
+        spoof = await bob.call_tool(
+            "save_thought",
+            {"trail_name": scope, "content": "spoof as alice", "agent_id": "alice"},
+        )
+        assert not spoof.get("isError", False)
+        assert spoof["structuredContent"]["status"] == "error"
+        spoof_blob = json.dumps(spoof)
+        assert "Alice private draft" not in spoof_blob
+        assert "does not match" in spoof["structuredContent"]["message"].lower() or "agent_id" in spoof[
+            "structuredContent"
+        ]["message"]
+
+        bob_get = await bob.call_tool(
+            "get_thought",
+            {"trail_name": scope, "thought_id": thought_id, "mode": "authoring"},
+        )
+        assert not bob_get.get("isError", False)
+        assert bob_get["structuredContent"]["status"] == "error"
+        assert "Alice private draft" not in json.dumps(bob_get)
+    finally:
+        await alice.close()
+        await bob.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -17,6 +18,10 @@ from mcp import Client
 
 from fava_trails import server
 
+# Pin the native MCP client used for registration-load evidence (issue #99).
+# This is a real client binary that loads mcpServers config — not a pytest JSON parse.
+_NATIVE_MCP_CLIENT_PACKAGE = "@modelcontextprotocol/inspector@2.6.0"
+
 
 def _server_executable() -> Path:
     executable = Path(sys.executable).parent / "fava-trails-server"
@@ -26,8 +31,24 @@ def _server_executable() -> Path:
     return executable
 
 
+def _jj_bin() -> str:
+    jj = shutil.which("jj")
+    if jj:
+        return jj
+    fallback = Path.home() / ".local" / "bin" / "jj"
+    assert fallback.is_file(), "jj binary not found — install via: fava-trails install-jj"
+    return str(fallback)
+
+
 def _base_server_env(tmp_fava_home: Path, tmp_path: Path, agent_id: str) -> dict[str, str]:
     env = {key: value for key, value in os.environ.items() if not key.startswith("FAVA_TRAILS_")}
+    path_prefix = os.pathsep.join(
+        [
+            str(Path(sys.executable).parent),
+            str(Path(_jj_bin()).parent),
+            os.environ.get("PATH", ""),
+        ]
+    )
     env.update(
         {
             "FAVA_TRAILS_DATA_REPO": str(tmp_fava_home),
@@ -35,8 +56,8 @@ def _base_server_env(tmp_fava_home: Path, tmp_path: Path, agent_id: str) -> dict
             "FAVA_TRAILS_LOG_DIR": str(tmp_path / "logs" / agent_id),
             "FAVA_TRAILS_AGENT_ID": agent_id,
             "XDG_CONFIG_HOME": str(tmp_path / "xdg-config"),
-            # Ensure registration command resolution finds the installed entrypoint.
-            "PATH": f"{Path(sys.executable).parent}{os.pathsep}{os.environ.get('PATH', '')}",
+            # Ensure registration command resolution finds the installed entrypoint + jj.
+            "PATH": path_prefix,
         }
     )
     return env
@@ -106,6 +127,59 @@ async def _spawn_stdio_rpc(
             stderr=stderr,
         )
     return _StdioRpc(process, stderr_path)
+
+
+def _require_native_mcp_client() -> str:
+    """Return npx path; skip if the native client toolchain is unavailable."""
+    npx = shutil.which("npx")
+    node = shutil.which("node")
+    if not npx or not node:
+        pytest.skip("npx/node not available — native MCP client registration test requires Node/npx")
+    assert npx is not None
+    return npx
+
+
+def _inspector_cli(
+    *,
+    npx: str,
+    config_path: Path,
+    method: str,
+    env: dict[str, str],
+    cwd: Path,
+    extra: list[str] | None = None,
+    timeout: float = 180,
+) -> dict:
+    """Invoke MCP Inspector CLI so *its* config loader resolves mcpServers."""
+    cmd = [
+        npx,
+        "--yes",
+        _NATIVE_MCP_CLIENT_PACKAGE,
+        "--cli",
+        "--config",
+        str(config_path),
+        "--server",
+        "fava-trails",
+        "--method",
+        method,
+        "--format",
+        "json",
+        *(extra or []),
+    ]
+    completed = subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    assert completed.returncode == 0, (
+        f"native client ({_NATIVE_MCP_CLIENT_PACKAGE}) failed method={method}\n"
+        f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    )
+    payload = json.loads(completed.stdout)
+    assert "result" in payload, payload
+    return payload["result"]
 
 
 @pytest_asyncio.fixture
@@ -196,17 +270,26 @@ async def test_installed_stdio_initialize_list_and_call(stdio_rpc, tmp_fava_home
     assert missing["structuredContent"]["status"] == "error"
 
 
-@pytest.mark.asyncio
-async def test_native_client_registration_loads_and_initializes(tmp_fava_home, tmp_path):
-    """Issue #99: a real native-client config is loaded, then the registration is launched.
+def test_native_client_registration_loads_and_initializes(tmp_fava_home, tmp_path):
+    """Issue #99: a real native MCP client loads the registration and talks MCP.
 
     Distinct from ``test_installed_stdio_initialize_list_and_call``, which probes the
-    entrypoint binary directly. Here the client config is the source of truth for
-    command/env, matching Claude Code / Claude Desktop ``mcpServers`` shape.
+    entrypoint binary directly via raw JSON-RPC. Here the official MCP Inspector CLI
+    (``@modelcontextprotocol/inspector``) is the client: it reads a Claude-shaped
+    ``mcpServers`` config file, resolves command/env, spawns the server, and performs
+    initialize / tools/list / tools/call. Pytest does not parse or launch the registration.
     """
+    npx = _require_native_mcp_client()
     _server_executable()  # assert entrypoint exists (and wheel layout when requested)
-    env = _base_server_env(tmp_fava_home, tmp_path, "native-registration-agent")
-    # Claude-style registration: command name only (resolved via PATH), plus process env.
+    agent_id = "native-registration-agent"
+    base_env = _base_server_env(tmp_fava_home, tmp_path, agent_id)
+
+    # Isolated HOME so the native client never touches the operator's real config/secrets.
+    client_home = tmp_path / "native-client-home"
+    client_home.mkdir()
+    npm_cache = tmp_path / "npm-cache"
+    npm_cache.mkdir()
+
     registration = {
         "mcpServers": {
             "fava-trails": {
@@ -214,10 +297,13 @@ async def test_native_client_registration_loads_and_initializes(tmp_fava_home, t
                 "command": "fava-trails-server",
                 "args": [],
                 "env": {
-                    "FAVA_TRAILS_DATA_REPO": env["FAVA_TRAILS_DATA_REPO"],
-                    "FAVA_TRAILS_DIR": env["FAVA_TRAILS_DIR"],
-                    "FAVA_TRAILS_LOG_DIR": env["FAVA_TRAILS_LOG_DIR"],
-                    "FAVA_TRAILS_AGENT_ID": env["FAVA_TRAILS_AGENT_ID"],
+                    "FAVA_TRAILS_DATA_REPO": base_env["FAVA_TRAILS_DATA_REPO"],
+                    "FAVA_TRAILS_DIR": base_env["FAVA_TRAILS_DIR"],
+                    "FAVA_TRAILS_LOG_DIR": base_env["FAVA_TRAILS_LOG_DIR"],
+                    "FAVA_TRAILS_AGENT_ID": base_env["FAVA_TRAILS_AGENT_ID"],
+                    "PATH": base_env["PATH"],
+                    "HOME": str(client_home),
+                    "XDG_CONFIG_HOME": base_env["XDG_CONFIG_HOME"],
                 },
             }
         }
@@ -225,44 +311,56 @@ async def test_native_client_registration_loads_and_initializes(tmp_fava_home, t
     config_path = tmp_path / "claude_desktop_config.json"
     config_path.write_text(json.dumps(registration, indent=2) + "\n")
 
-    # Native client load step: read the registration file and resolve the server entry.
-    loaded = json.loads(config_path.read_text())
-    entry = loaded["mcpServers"]["fava-trails"]
-    assert entry["command"] == "fava-trails-server"
-    assert entry.get("type", "stdio") == "stdio"
-    launch_env = dict(env)
-    launch_env.update({str(k): str(v) for k, v in entry.get("env", {}).items()})
+    # Client process env: inspector runs here; it alone loads config_path.
+    client_env = {
+        **base_env,
+        "HOME": str(client_home),
+        "npm_config_cache": str(npm_cache),
+        "MCP_INSPECTOR_SECRET_STORE": "memory",
+        "NO_UPDATE_NOTIFIER": "1",
+    }
 
-    rpc = await _spawn_stdio_rpc(
-        command=entry["command"],
-        args=list(entry.get("args") or []),
-        env=launch_env,
+    initialized = _inspector_cli(
+        npx=npx,
+        config_path=config_path,
+        method="initialize",
+        env=client_env,
         cwd=tmp_path,
-        stderr_path=tmp_path / "native-registration-stderr.log",
     )
-    try:
-        initialized = await rpc.rpc(
-            "initialize",
-            {
-                "protocolVersion": "2025-11-25",
-                "capabilities": {},
-                "clientInfo": {"name": "synthetic-claude-desktop", "version": "1"},
-            },
-        )
-        assert initialized["serverInfo"]["name"] == "fava-trails"
-        assert initialized["serverInfo"]["version"] == __import__("fava_trails").__version__
-        await rpc.rpc("notifications/initialized", notification=True)
-        listed = await rpc.rpc("tools/list")
-        assert len(listed["tools"]) == 17
-        saved = await rpc.call_tool(
+    assert initialized["serverInfo"]["name"] == "fava-trails"
+    assert initialized["serverInfo"]["version"] == __import__("fava_trails").__version__
+
+    listed = _inspector_cli(
+        npx=npx,
+        config_path=config_path,
+        method="tools/list",
+        env=client_env,
+        cwd=tmp_path,
+    )
+    assert len(listed["tools"]) == 17
+
+    saved = _inspector_cli(
+        npx=npx,
+        config_path=config_path,
+        method="tools/call",
+        env=client_env,
+        cwd=tmp_path,
+        extra=[
+            "--tool-name",
             "save_thought",
-            {"trail_name": "synthetic/native-reg", "content": "Loaded via native registration"},
-        )
-        assert not saved.get("isError", False)
-        assert saved["structuredContent"]["status"] == "ok"
-        assert saved["structuredContent"]["thought"]["agent_id"] == "native-registration-agent"
-    finally:
-        await rpc.close()
+            "--tool-args-json",
+            json.dumps(
+                {
+                    "trail_name": "synthetic/native-reg",
+                    "content": "Loaded via native MCP Inspector registration",
+                }
+            ),
+        ],
+    )
+    assert saved.get("isError") is False
+    structured = saved["structuredContent"]
+    assert structured["status"] == "ok"
+    assert structured["thought"]["agent_id"] == agent_id
 
 
 @pytest.mark.asyncio

--- a/tests/test_packaged_mcp.py
+++ b/tests/test_packaged_mcp.py
@@ -100,18 +100,14 @@ def test_candidate_artifacts_support_fresh_install_and_upgrade_from_0_6_0(tmp_pa
     assert uv
 
     def _probe(python: Path) -> str:
-        return subprocess.check_output(
-            [
-                str(python),
-                "-c",
-                "import fava_trails, importlib.metadata as m; "
-                "from fava_trails.runtime_info import runtime_report; "
-                "r=runtime_report(); "
-                "assert r['package_version']==r['module_version']==m.version('fava-trails'); "
-                "print(r['package_version'], r['mcp_sdk_version'], r['source_kind'])",
-            ],
-            text=True,
-        ).strip()
+        probe = (
+            "import importlib.metadata as m\n"
+            "from fava_trails.runtime_info import runtime_report\n"
+            "r = runtime_report()\n"
+            "assert r['package_version'] == r['module_version'] == m.version('fava-trails')\n"
+            "print(r['package_version'], r['mcp_sdk_version'], r['source_kind'])\n"
+        )
+        return subprocess.check_output([str(python), "-c", probe], text=True).strip()
 
     fresh = tmp_path / "fresh"
     fresh.mkdir()

--- a/tests/test_packaged_mcp.py
+++ b/tests/test_packaged_mcp.py
@@ -9,24 +9,172 @@ import sys
 from pathlib import Path
 
 
-def test_built_wheel_starts_and_serves_mcp(tmp_path):
-    root = Path(__file__).resolve().parent.parent
+def _build_artifacts(root: Path, out_dir: Path) -> tuple[Path, Path]:
     uv = shutil.which("uv")
     assert uv, "Run the package verification with the project's uv toolchain"
     build = subprocess.run(
-        [uv, "build", "--wheel", "--out-dir", str(tmp_path / "dist")],
-        cwd=root, capture_output=True, text=True, timeout=120,
+        [uv, "build", "--out-dir", str(out_dir)],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=180,
     )
     assert build.returncode == 0, build.stdout + build.stderr
-    wheels = list((tmp_path / "dist").glob("*.whl"))
-    assert len(wheels) == 1
+    wheels = list(out_dir.glob("*.whl"))
+    sdists = list(out_dir.glob("*.tar.gz"))
+    assert len(wheels) == 1, wheels
+    assert len(sdists) == 1, sdists
+    return wheels[0], sdists[0]
+
+
+def test_built_wheel_starts_and_serves_mcp(tmp_path):
+    root = Path(__file__).resolve().parent.parent
+    wheel, _sdist = _build_artifacts(root, tmp_path / "dist")
     env = {**os.environ, "FAVA_EXPECT_WHEEL": "1"}
     verified = subprocess.run(
         [
-            uv, "run", "--isolated", "--no-project", "--python", sys.executable,
-            "--with", str(wheels[0]), "--with", "pytest>=9,<10", "--with", "pytest-asyncio>=1.3,<2",
-            "pytest", str(root / "tests" / "test_mcp_protocol.py"), "-v",
+            "uv",
+            "run",
+            "--isolated",
+            "--no-project",
+            "--python",
+            sys.executable,
+            "--with",
+            str(wheel),
+            "--with",
+            "pytest>=9,<10",
+            "--with",
+            "pytest-asyncio>=1.3,<2",
+            "pytest",
+            str(root / "tests" / "test_mcp_protocol.py"),
+            "-v",
         ],
-        cwd=tmp_path, env=env, capture_output=True, text=True, timeout=180,
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
     )
     assert verified.returncode == 0, verified.stdout + verified.stderr
+
+
+def test_built_wheel_preserves_governed_recall_isolation(tmp_path):
+    """Issue #99 / #72: installed artifact keeps approved-only and identity isolation."""
+    root = Path(__file__).resolve().parent.parent
+    wheel, _sdist = _build_artifacts(root, tmp_path / "dist")
+    env = {**os.environ, "FAVA_EXPECT_WHEEL": "1"}
+    # Link existing #72 coverage rather than rebuilding those cases here.
+    verified = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--isolated",
+            "--no-project",
+            "--python",
+            sys.executable,
+            "--with",
+            str(wheel),
+            "--with",
+            "pytest>=9,<10",
+            "--with",
+            "pytest-asyncio>=1.3,<2",
+            "pytest",
+            str(root / "tests" / "test_governance.py"),
+            str(root / "tests" / "test_runtime_info.py"),
+            "-v",
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert verified.returncode == 0, verified.stdout + verified.stderr
+
+
+def test_candidate_artifacts_support_fresh_install_and_upgrade_from_0_6_0(tmp_path):
+    """Build wheel+sdist once; verify fresh install and upgrade from published 0.6.0."""
+    root = Path(__file__).resolve().parent.parent
+    wheel, sdist = _build_artifacts(root, tmp_path / "dist")
+    uv = shutil.which("uv")
+    assert uv
+
+    def _probe(python: Path) -> str:
+        return subprocess.check_output(
+            [
+                str(python),
+                "-c",
+                "import fava_trails, importlib.metadata as m; "
+                "from fava_trails.runtime_info import runtime_report; "
+                "r=runtime_report(); "
+                "assert r['package_version']==r['module_version']==m.version('fava-trails'); "
+                "print(r['package_version'], r['mcp_sdk_version'], r['source_kind'])",
+            ],
+            text=True,
+        ).strip()
+
+    fresh = tmp_path / "fresh"
+    fresh.mkdir()
+    subprocess.run([uv, "venv", str(fresh / ".venv")], check=True, capture_output=True, text=True)
+    fresh_py = fresh / ".venv" / "bin" / "python"
+    install_fresh = subprocess.run(
+        [uv, "pip", "install", "--python", str(fresh_py), str(wheel)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert install_fresh.returncode == 0, install_fresh.stdout + install_fresh.stderr
+    fresh_probe = _probe(fresh_py)
+    assert fresh_probe.split()[0] == "0.6.1"
+    version_cmd = subprocess.run(
+        [str(fresh / ".venv" / "bin" / "fava-trails"), "version"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert version_cmd.returncode == 0, version_cmd.stdout + version_cmd.stderr
+    assert "Package version:" in version_cmd.stdout
+    assert "0.6.1" in version_cmd.stdout
+    assert "MCP SDK version:" in version_cmd.stdout
+    assert "Source:             installed" in version_cmd.stdout
+
+    upgrade = tmp_path / "upgrade"
+    upgrade.mkdir()
+    subprocess.run([uv, "venv", str(upgrade / ".venv")], check=True, capture_output=True, text=True)
+    upgrade_py = upgrade / ".venv" / "bin" / "python"
+    baseline = subprocess.run(
+        [uv, "pip", "install", "--python", str(upgrade_py), "fava-trails==0.6.0"],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert baseline.returncode == 0, baseline.stdout + baseline.stderr
+    before = subprocess.check_output(
+        [str(upgrade_py), "-c", "import importlib.metadata as m; print(m.version('fava-trails'))"],
+        text=True,
+    ).strip()
+    assert before == "0.6.0"
+    upgraded = subprocess.run(
+        [uv, "pip", "install", "--python", str(upgrade_py), "--upgrade", str(wheel)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert upgraded.returncode == 0, upgraded.stdout + upgraded.stderr
+    after = _probe(upgrade_py)
+    assert after.split()[0] == "0.6.1"
+
+    # sdist must also be installable in isolation (release candidate gate).
+    sdist_env = tmp_path / "sdist"
+    sdist_env.mkdir()
+    subprocess.run([uv, "venv", str(sdist_env / ".venv")], check=True, capture_output=True, text=True)
+    sdist_py = sdist_env / ".venv" / "bin" / "python"
+    sdist_install = subprocess.run(
+        [uv, "pip", "install", "--python", str(sdist_py), str(sdist)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert sdist_install.returncode == 0, sdist_install.stdout + sdist_install.stderr
+    sdist_probe = _probe(sdist_py)
+    assert sdist_probe.split()[0] == "0.6.1"

--- a/tests/test_packaged_mcp.py
+++ b/tests/test_packaged_mcp.py
@@ -1,4 +1,16 @@
-"""The regular CI suite must exercise the installed wheel's real MCP entrypoint."""
+"""The regular CI suite must exercise the installed wheel's real MCP entrypoint.
+
+Candidate binding (issue #99 / release gate)
+-------------------------------------------
+By default each test builds wheel+sdist into a temp dir. When the release
+workflow (or an operator) already built immutable candidates, set both:
+
+  FAVA_CANDIDATE_WHEEL=/path/to/fava_trails-…-py3-none-any.whl
+  FAVA_CANDIDATE_SDIST=/path/to/fava_trails-….tar.gz
+
+Those exact files are installed/tested — never rebuilt — so release.yml can
+bind publish bytes to verification bytes.
+"""
 
 from __future__ import annotations
 
@@ -27,9 +39,48 @@ def _build_artifacts(root: Path, out_dir: Path) -> tuple[Path, Path]:
     return wheels[0], sdists[0]
 
 
+def _candidate_artifacts(root: Path, out_dir: Path) -> tuple[Path, Path]:
+    """Prefer pre-built release candidates when both env paths are set."""
+    wheel_env = os.environ.get("FAVA_CANDIDATE_WHEEL")
+    sdist_env = os.environ.get("FAVA_CANDIDATE_SDIST")
+    if wheel_env or sdist_env:
+        assert wheel_env and sdist_env, (
+            "Set both FAVA_CANDIDATE_WHEEL and FAVA_CANDIDATE_SDIST to bind verification "
+            "to already-built artifacts (or set neither to build locally)."
+        )
+        wheel = Path(wheel_env)
+        sdist = Path(sdist_env)
+        assert wheel.is_file(), f"FAVA_CANDIDATE_WHEEL missing: {wheel}"
+        assert sdist.is_file(), f"FAVA_CANDIDATE_SDIST missing: {sdist}"
+        assert wheel.suffix == ".whl", wheel
+        assert sdist.name.endswith(".tar.gz"), sdist
+        return wheel.resolve(), sdist.resolve()
+    return _build_artifacts(root, out_dir)
+
+
+def _probe_runtime(python: Path) -> str:
+    probe = (
+        "import importlib.metadata as m\n"
+        "from fava_trails.runtime_info import runtime_report\n"
+        "r = runtime_report()\n"
+        "assert r['package_version'] == r['module_version'] == m.version('fava-trails')\n"
+        "print(r['package_version'], r['mcp_sdk_version'], r['source_kind'])\n"
+    )
+    return subprocess.check_output([str(python), "-c", probe], text=True).strip()
+
+
+def _install_into_venv(uv: str, python: Path, artifact: Path, *, upgrade: bool = False) -> None:
+    cmd = [uv, "pip", "install", "--python", str(python)]
+    if upgrade:
+        cmd.append("--upgrade")
+    cmd.append(str(artifact))
+    installed = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    assert installed.returncode == 0, installed.stdout + installed.stderr
+
+
 def test_built_wheel_starts_and_serves_mcp(tmp_path):
     root = Path(__file__).resolve().parent.parent
-    wheel, _sdist = _build_artifacts(root, tmp_path / "dist")
+    wheel, _sdist = _candidate_artifacts(root, tmp_path / "dist")
     env = {**os.environ, "FAVA_EXPECT_WHEEL": "1"}
     verified = subprocess.run(
         [
@@ -53,7 +104,7 @@ def test_built_wheel_starts_and_serves_mcp(tmp_path):
         env=env,
         capture_output=True,
         text=True,
-        timeout=180,
+        timeout=300,
     )
     assert verified.returncode == 0, verified.stdout + verified.stderr
 
@@ -61,7 +112,7 @@ def test_built_wheel_starts_and_serves_mcp(tmp_path):
 def test_built_wheel_preserves_governed_recall_isolation(tmp_path):
     """Issue #99 / #72: installed artifact keeps approved-only and identity isolation."""
     root = Path(__file__).resolve().parent.parent
-    wheel, _sdist = _build_artifacts(root, tmp_path / "dist")
+    wheel, _sdist = _candidate_artifacts(root, tmp_path / "dist")
     env = {**os.environ, "FAVA_EXPECT_WHEEL": "1"}
     # Link existing #72 coverage rather than rebuilding those cases here.
     verified = subprocess.run(
@@ -93,34 +144,23 @@ def test_built_wheel_preserves_governed_recall_isolation(tmp_path):
 
 
 def test_candidate_artifacts_support_fresh_install_and_upgrade_from_0_6_0(tmp_path):
-    """Build wheel+sdist once; verify fresh install and upgrade from published 0.6.0."""
+    """Verify fresh wheel install, sdist install, and upgrade from published 0.6.0.
+
+    Uses FAVA_CANDIDATE_WHEEL / FAVA_CANDIDATE_SDIST when set so the release job
+    exercises the exact bytes it will publish.
+    """
     root = Path(__file__).resolve().parent.parent
-    wheel, sdist = _build_artifacts(root, tmp_path / "dist")
+    wheel, sdist = _candidate_artifacts(root, tmp_path / "dist")
     uv = shutil.which("uv")
     assert uv
 
-    def _probe(python: Path) -> str:
-        probe = (
-            "import importlib.metadata as m\n"
-            "from fava_trails.runtime_info import runtime_report\n"
-            "r = runtime_report()\n"
-            "assert r['package_version'] == r['module_version'] == m.version('fava-trails')\n"
-            "print(r['package_version'], r['mcp_sdk_version'], r['source_kind'])\n"
-        )
-        return subprocess.check_output([str(python), "-c", probe], text=True).strip()
-
-    fresh = tmp_path / "fresh"
+    # Fresh wheel install
+    fresh = tmp_path / "fresh-wheel"
     fresh.mkdir()
     subprocess.run([uv, "venv", str(fresh / ".venv")], check=True, capture_output=True, text=True)
     fresh_py = fresh / ".venv" / "bin" / "python"
-    install_fresh = subprocess.run(
-        [uv, "pip", "install", "--python", str(fresh_py), str(wheel)],
-        capture_output=True,
-        text=True,
-        timeout=180,
-    )
-    assert install_fresh.returncode == 0, install_fresh.stdout + install_fresh.stderr
-    fresh_probe = _probe(fresh_py)
+    _install_into_venv(uv, fresh_py, wheel)
+    fresh_probe = _probe_runtime(fresh_py)
     assert fresh_probe.split()[0] == "0.6.1"
     version_cmd = subprocess.run(
         [str(fresh / ".venv" / "bin" / "fava-trails"), "version"],
@@ -134,6 +174,7 @@ def test_candidate_artifacts_support_fresh_install_and_upgrade_from_0_6_0(tmp_pa
     assert "MCP SDK version:" in version_cmd.stdout
     assert "Source:             installed" in version_cmd.stdout
 
+    # 0.6.0 → candidate wheel upgrade (exact candidate file, not a rebuild)
     upgrade = tmp_path / "upgrade"
     upgrade.mkdir()
     subprocess.run([uv, "venv", str(upgrade / ".venv")], check=True, capture_output=True, text=True)
@@ -150,27 +191,15 @@ def test_candidate_artifacts_support_fresh_install_and_upgrade_from_0_6_0(tmp_pa
         text=True,
     ).strip()
     assert before == "0.6.0"
-    upgraded = subprocess.run(
-        [uv, "pip", "install", "--python", str(upgrade_py), "--upgrade", str(wheel)],
-        capture_output=True,
-        text=True,
-        timeout=180,
-    )
-    assert upgraded.returncode == 0, upgraded.stdout + upgraded.stderr
-    after = _probe(upgrade_py)
+    _install_into_venv(uv, upgrade_py, wheel, upgrade=True)
+    after = _probe_runtime(upgrade_py)
     assert after.split()[0] == "0.6.1"
 
-    # sdist must also be installable in isolation (release candidate gate).
-    sdist_env = tmp_path / "sdist"
+    # Fresh sdist install of the same candidate sdist bytes
+    sdist_env = tmp_path / "fresh-sdist"
     sdist_env.mkdir()
     subprocess.run([uv, "venv", str(sdist_env / ".venv")], check=True, capture_output=True, text=True)
     sdist_py = sdist_env / ".venv" / "bin" / "python"
-    sdist_install = subprocess.run(
-        [uv, "pip", "install", "--python", str(sdist_py), str(sdist)],
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
-    assert sdist_install.returncode == 0, sdist_install.stdout + sdist_install.stderr
-    sdist_probe = _probe(sdist_py)
+    _install_into_venv(uv, sdist_py, sdist)
+    sdist_probe = _probe_runtime(sdist_py)
     assert sdist_probe.split()[0] == "0.6.1"

--- a/tests/test_runtime_info.py
+++ b/tests/test_runtime_info.py
@@ -1,0 +1,41 @@
+"""Runtime version and provenance reporting (issue #99)."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from pathlib import Path
+
+from fava_trails import __version__ as module_version
+from fava_trails.runtime_info import format_runtime_report, runtime_report
+
+
+def test_runtime_report_separates_product_and_mcp_sdk_versions():
+    report = runtime_report()
+    package_version = importlib.metadata.version("fava-trails")
+    mcp_version = importlib.metadata.version("mcp")
+
+    assert report["product_name"] == "fava-trails"
+    assert report["package_version"] == package_version
+    assert report["module_version"] == module_version
+    assert report["package_version"] == report["module_version"]
+    assert report["mcp_sdk_version"] == mcp_version
+    assert report["mcp_sdk_version"] != report["package_version"]
+    assert Path(report["module_path"]).name == "__init__.py"
+    assert "fava_trails" in report["module_path"]
+    assert report["source_kind"] in {"editable", "installed", "unknown"}
+    # Never leak credentials or data-repo secrets in the report payload.
+    blob = format_runtime_report(report)
+    assert "OPENROUTER" not in blob
+    assert "api_key" not in blob.lower()
+    assert "sk-" not in blob
+
+
+def test_format_runtime_report_is_stable_and_human_readable():
+    text = format_runtime_report(runtime_report())
+    assert "FAVA Trails product:" in text
+    assert "Package version:" in text
+    assert "Module version:" in text
+    assert "Module path:" in text
+    assert "Source:" in text
+    assert "MCP SDK version:" in text
+    assert "serverInfo.version" in text or "Handshake product version" in text


### PR DESCRIPTION
## Summary

Prepares issue #99 release-candidate verification for governed recall isolation and MCP registration fixes that are **merged on main as 0.6.1 but still unreleased** on PyPI/GitHub (latest published remains 0.6.0).

- `fava-trails version` (+ doctor preamble) reports package/module version, module path/source kind, and MCP SDK version separately, without credentials
- MCP `initialize` `serverInfo.version` carries the FAVA **product** version (not the MCP SDK)
- Docs: `docs/runtime-and-upgrade.md`, README/CONTRIBUTING/CHANGELOG/governed-recall notes for identity config, local runtime selectors, and merged-but-unreleased status
- Packaging gates: build wheel+sdist, fresh install, upgrade from published `fava-trails==0.6.0`, re-run #72 governance and #83 MCP protocol against the installed wheel

**Not in this PR:** authorized PyPI/GitHub publication (completion contract is local-only; publish remains operator-gated via tag + `release.yml`).

## Test plan

- [x] `uv run pytest tests/test_runtime_info.py tests/test_cli.py::test_cli_version_subcommand_reports_loaded_runtime tests/test_mcp_protocol.py -v`
- [x] `uv run pytest tests/test_governance.py tests/test_packaged_mcp.py -v` (wheel MCP + #72 isolation + fresh/upgrade/sdist)
- [x] Full suite: `uv run pytest -q` → **905 passed**
- [ ] CI green on this PR
- [ ] After authorized publication (follow-up): verify PyPI/GitHub metadata match candidate and update install instructions

Closes #99