### PR TITLE
docs: keep FAVA scope out of application env files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,11 +34,11 @@ Every tool call requires `trail_name` — a slash-separated scope path (e.g. `mw
 
 | Priority | Source | Set where |
 |----------|--------|-----------|
-| 1 | `FAVA_TRAILS_SCOPE` env var | `.env` (gitignored) — per-worktree override |
+| 1 | `FAVA_TRAILS_SCOPE` env var | Process environment (optional) — per-worktree override |
 | 2 | `.fava-trails.yaml` `scope` | Project root (committed) — default for all clones |
 | 3 | `FAVA_TRAILS_SCOPE_HINT` | MCP server `env` block — broad fallback |
 
-**If `FAVA_TRAILS_SCOPE` is not set** but `.fava-trails.yaml` exists, read the `scope` field and write it to `.env` as `FAVA_TRAILS_SCOPE=<scope>`. If neither exists, use the scope hint from tool descriptions and prompt the user to create a `.fava-trails.yaml`.
+**If `FAVA_TRAILS_SCOPE` is not set** but `.fava-trails.yaml` exists, read its `scope` field and use that value as `trail_name`. Agents must not silently create or edit application-owned `.env` files. Operators may export `FAVA_TRAILS_SCOPE` as an optional process override. If neither source exists, use the scope hint from tool descriptions and prompt the user to create a `.fava-trails.yaml`.
 
 See [AGENTS_USAGE_INSTRUCTIONS.md](AGENTS_USAGE_INSTRUCTIONS.md) for full scope discovery protocol with examples.
 


### PR DESCRIPTION
Issue #103 changes initialization so agents no longer write application-owned `.env` files by default, but the repository's root `AGENTS.md` still told agents to do exactly that. Hermes cannot modify the instruction file from its worker sandbox, so this narrow prerequisite aligns the authoritative guidance with the new process-environment and `.fava-trails.yaml` behavior.

Verification: `git diff --check` passed, and targeted searches found no remaining root-guidance instruction to write `.env`.

Supports #103 and PR #113.
